### PR TITLE
Fix le calcul de la cote Z

### DIFF
--- a/app/models/partie.rb
+++ b/app/models/partie.rb
@@ -39,15 +39,21 @@ class Partie < ApplicationRecord
 
   def cote_z_metriques
     collect_metriques do |metrique|
-      unless metriques[metrique].nil?
-        (
-          (metriques[metrique] - moyenne_metriques[metrique]) / ecart_type_metriques[metrique]
-        ).round(2)
+      if ecart_type_metriques[metrique].zero?
+        0
+      elsif metriques[metrique].present?
+        cote_z_metrique(metrique)
       end
     end
   end
 
   private
+
+  def cote_z_metrique(metrique)
+    (
+      (metriques[metrique] - moyenne_metriques[metrique]) / ecart_type_metriques[metrique]
+    ).round(2)
+  end
 
   def aggrege_metrique(fonction, metrique)
     Partie

--- a/app/models/partie.rb
+++ b/app/models/partie.rb
@@ -39,9 +39,11 @@ class Partie < ApplicationRecord
 
   def cote_z_metriques
     collect_metriques do |metrique|
-      (
-        (metriques[metrique] - moyenne_metriques[metrique]) / ecart_type_metriques[metrique]
-      ).round(2)
+      unless metriques[metrique].nil?
+        (
+          (metriques[metrique] - moyenne_metriques[metrique]) / ecart_type_metriques[metrique]
+        ).round(2)
+      end
     end
   end
 

--- a/spec/integrations/partie_spec.rb
+++ b/spec/integrations/partie_spec.rb
@@ -101,6 +101,17 @@ describe Partie do
       end
     end
 
+    context "lorsque la partie courante n'est pas terminée" do
+      before { [partie1, partie2, partie3] }
+
+      it do
+        partie1.update(metriques: {})
+        expect(partie1.cote_z_metriques).to eql('test_chaine' => nil,
+                                                'test_metrique' => nil,
+                                                'test_metrique_tableau' => nil)
+      end
+    end
+
     it "lorsqu'il n'y a aucune partie enregistré" do
       partie1.update(metriques: {})
       expect(partie1.cote_z_metriques).to be_nil

--- a/spec/integrations/partie_spec.rb
+++ b/spec/integrations/partie_spec.rb
@@ -112,6 +112,14 @@ describe Partie do
       end
     end
 
+    context "lorsque l'écart type est nul" do
+      it do
+        expect(partie1.cote_z_metriques).to eql('test_chaine' => nil,
+                                                'test_metrique' => 0,
+                                                'test_metrique_tableau' => nil)
+      end
+    end
+
     it "lorsqu'il n'y a aucune partie enregistré" do
       partie1.update(metriques: {})
       expect(partie1.cote_z_metriques).to be_nil


### PR DESCRIPTION
- lorsque la situation n'est pas terminé / enregistré
- lorsque l'écart type est nul