### PR TITLE
remplace des références Compétences pro vers eva

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,1 +1,1 @@
-competences-pro-serveur
+eva-serveur

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,7 @@ require "rails/test_unit/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module CompetencesProServeur
+module EvaServeur
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -7,4 +7,4 @@ test:
 production:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: competences_pro_serveur_production
+  channel_prefix: eva_serveur_production

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,15 +15,15 @@ default: &default
 
 development:
   <<: *default
-  database: competences-pro_development
+  database: eva_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: competences-pro_test
+  database: eva_test
 
 production:
   <<: *default
-  database: competences-pro_production
+  database: eva_production

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "competences_pro_serveur_production"
+  # config.active_job.queue_name_prefix = "eva_serveur_production"
 
 
   config.action_mailer.perform_caching = false


### PR DESCRIPTION
pour betagouv/eva#653

Attention en faisant ça on change les noms des bases de données. Il faut donc les renommer en local, par exemple avec `psql`
```
ALTER DATABASE "competences-pro_development" RENAME TO "eva_development";
ALTER DATABASE "competences-pro_test" RENAME TO "eva_test";
```