### PR TITLE
Empêche le filtre par campagne dans stat

### DIFF
--- a/app/admin/campagne_stats.rb
+++ b/app/admin/campagne_stats.rb
@@ -5,6 +5,9 @@ ActiveAdmin.register Evaluation, as: 'Campagne Stats' do
   config.sort_order = 'created_at_desc'
   includes :campagne
 
+  filter :nom
+  filter :created_at
+
   column_stats = proc do |situation, nom|
     proc do
       column "#{situation}_#{nom}".to_sym do |evaluation|

--- a/app/admin/campagne_stats.rb
+++ b/app/admin/campagne_stats.rb
@@ -2,6 +2,7 @@
 
 ActiveAdmin.register Evaluation, as: 'Campagne Stats' do
   menu false
+  config.batch_actions = false
   config.sort_order = 'created_at_desc'
   includes :campagne
 


### PR DESCRIPTION
Permet d'éviter de voir les campagnes qui ne m'appartiennent pas