### PR TITLE
Permet de configurer une campagne sans compétences fortes

### DIFF
--- a/app/admin/campagnes.rb
+++ b/app/admin/campagnes.rb
@@ -2,7 +2,8 @@
 
 ActiveAdmin.register Campagne do
   config.batch_actions = false
-  permit_params :libelle, :code, :questionnaire_id, :compte, :compte_id,
+  permit_params :libelle, :code, :questionnaire_id, :compte,
+                :compte_id, :affiche_competences_fortes,
                 situations_configurations_attributes: %i[id situation_id _destroy]
 
   filter :compte, if: proc { can? :manage, Compte }
@@ -30,6 +31,7 @@ ActiveAdmin.register Campagne do
       f.input :compte if can?(:manage, Compte)
       f.input :libelle
       f.input :code
+      f.input :affiche_competences_fortes
       f.input :questionnaire
       f.has_many :situations_configurations, allow_destroy: true do |c|
         c.input :id, as: :hidden

--- a/app/controllers/api/evaluations_controller.rb
+++ b/app/controllers/api/evaluations_controller.rb
@@ -32,9 +32,12 @@ module Api
       evaluation = Evaluation.find(params[:id])
       situations = evaluation.campagne.situations
       questions = evaluation.campagne.questionnaire&.questions || []
-      competences = map_descriptions(FabriqueRestitution
-        .restitution_globale(evaluation)
-        .competences)
+      competences = []
+      if evaluation.campagne.affiche_competences_fortes
+        competences = map_descriptions(FabriqueRestitution
+                                        .restitution_globale(evaluation)
+                                        .competences)
+      end
       render json: { questions: questions, situations: situations, competences_fortes: competences }
     end
   end

--- a/app/views/admin/campagnes/_show.html.arb
+++ b/app/views/admin/campagnes/_show.html.arb
@@ -5,6 +5,7 @@ panel 'Détails de la campagne' do
     row :id
     row :libelle
     row :code
+    row :affiche_competences_fortes
     row :questionnaire
     row :compte if can?(:manage, Compte)
     row :created_at

--- a/config/locales/models/campagne.yml
+++ b/config/locales/models/campagne.yml
@@ -5,6 +5,7 @@ fr:
         created_at: Créée le
         updated_at: Mise à jour le
         libelle: Libellé
+        affiche_competences_fortes: Afficher les compétences fortes ?
         nombre_evaluations: Nombre d'évaluations
   formtastic:
     actions:

--- a/db/migrate/20191223102653_ajoute_colonne_affiche_competences_fortes_a_campagne.rb
+++ b/db/migrate/20191223102653_ajoute_colonne_affiche_competences_fortes_a_campagne.rb
@@ -1,0 +1,5 @@
+class AjouteColonneAfficheCompetencesFortesACampagne < ActiveRecord::Migration[6.0]
+  def change
+    add_column :campagnes, :affiche_competences_fortes, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_04_115816) do
+ActiveRecord::Schema.define(version: 2019_12_23_102653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 2019_12_04_115816) do
     t.uuid "questionnaire_id"
     t.uuid "compte_id"
     t.integer "nombre_evaluations", default: 0
+    t.boolean "affiche_competences_fortes", default: true
     t.index ["compte_id"], name: "index_campagnes_on_compte_id"
     t.index ["questionnaire_id"], name: "index_campagnes_on_questionnaire_id"
   end

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -85,27 +85,38 @@ describe 'Evaluation API', type: :request do
                           evenements: [saisie]
         end
 
-        before { get "/api/evaluations/#{evaluation.id}" }
+        context 'avec une campagne configurée sans compétences fortes' do
+          before do
+            campagne.update(affiche_competences_fortes: false)
+            get "/api/evaluations/#{evaluation.id}"
+          end
 
-        it 'retourne les compétences triées par ordre de force décroissante' do
-          attendues = [Competence::RAPIDITE, Competence::VIGILANCE_CONTROLE,
-                       Competence::ORGANISATION_METHODE].map(&:to_s)
-          expect(JSON.parse(response.body)['competences_fortes'].pluck('id'))
-            .to eql(attendues)
+          it { expect(JSON.parse(response.body)['competences_fortes']).to be_empty }
         end
 
-        it 'envoie aussi le nom et la description des compétences' do
-          premiere_competence = JSON.parse(response.body)['competences_fortes'][0]
-          expect(premiere_competence['nom']).to eql("Vitesse d'exécution")
-          expect(premiere_competence['description'])
-            .to eql(I18n.t("#{Competence::RAPIDITE}.description",
-                           scope: 'admin.evaluations.restitution_competence'))
-        end
+        context 'avec une campagne configurée avec compétences fortes' do
+          before { get "/api/evaluations/#{evaluation.id}" }
 
-        it "envoie aussi l'URL du picto des compétences" do
-          premiere_competence = JSON.parse(response.body)['competences_fortes'][0]
-          expect(premiere_competence['picto'])
-            .to start_with('http://asset_host:port/assets/rapidite')
+          it 'retourne les compétences triées par ordre de force décroissante' do
+            attendues = [Competence::RAPIDITE, Competence::VIGILANCE_CONTROLE,
+                         Competence::ORGANISATION_METHODE].map(&:to_s)
+            expect(JSON.parse(response.body)['competences_fortes'].pluck('id'))
+              .to eql(attendues)
+          end
+
+          it 'envoie aussi le nom et la description des compétences' do
+            premiere_competence = JSON.parse(response.body)['competences_fortes'][0]
+            expect(premiere_competence['nom']).to eql("Vitesse d'exécution")
+            expect(premiere_competence['description'])
+              .to eql(I18n.t("#{Competence::RAPIDITE}.description",
+                             scope: 'admin.evaluations.restitution_competence'))
+          end
+
+          it "envoie aussi l'URL du picto des compétences" do
+            premiere_competence = JSON.parse(response.body)['competences_fortes'][0]
+            expect(premiere_competence['picto'])
+              .to start_with('http://asset_host:port/assets/rapidite')
+          end
         end
       end
 


### PR DESCRIPTION
Fix la betagouv/eva#658

Pour les campagnes mTurk qui doivent s'arrêter sur l'écran de félicitation contenant l'id de l'utilisateur.

Par défaut la colonne `affiche_competences_fortes` est à `true`.