### PR TITLE
Ajoute propriété pour éviter les sauts de page au milieu d'une div.row

### DIFF
--- a/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
+++ b/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
@@ -41,6 +41,7 @@
   .row {
     display: -webkit-box;
     width: 1000px;
+    page-break-inside: avoid;
     .col-4, .col-6, .competences-identifiees {
       height: 100%;
       vertical-align: top;


### PR DESCRIPTION
Fix: #283

**Avant:**

<img width="718" alt="Capture d’écran 2019-12-27 à 12 55 52" src="https://user-images.githubusercontent.com/20596535/71516278-49714c00-28a8-11ea-8def-5f65c1e885cc.png">

----

**Aprés:**

<img width="704" alt="Capture d’écran 2019-12-27 à 12 55 27" src="https://user-images.githubusercontent.com/20596535/71516296-5beb8580-28a8-11ea-8b07-f558686033be.png">
