### PR TITLE
Corrige un warning de rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
     - 'test/**/*'
     - 'vendor/**/*'
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
 
 Metrics/BlockLength:


### PR DESCRIPTION
```
.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
```