### PR TITLE
Déplace les stats de campagne dans le périmètre de campagne

### DIFF
--- a/app/admin/campagne_stats.rb
+++ b/app/admin/campagne_stats.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Evaluation, as: 'Campagne Stats' do
-  menu false
+  belongs_to :campagne
   config.batch_actions = false
   config.sort_order = 'created_at_desc'
-  includes :campagne
 
   filter :nom
   filter :created_at
@@ -71,6 +70,10 @@ ActiveAdmin.register Evaluation, as: 'Campagne Stats' do
       restitution_globale(evaluation).restitutions.find do |restitution|
         restitution.situation.nom_technique == nom_situation
       end
+    end
+
+    def scoped_collection
+      Evaluation.where(campagne: params[:campagne_id])
     end
   end
 end

--- a/app/views/admin/campagnes/_show.html.arb
+++ b/app/views/admin/campagnes/_show.html.arb
@@ -22,7 +22,7 @@ panel 'Consulter' do
   ul do
     li link_to "les #{resource.nombre_evaluations} évaluations",
                admin_campagne_evaluations_path(resource)
-    li link_to 'les stats', admin_campagne_stats_path(q: { campagne_id_eq: resource.id })
+    li link_to 'les stats', admin_campagne_campagne_stats_path(resource)
     li link_to 'les événements', admin_campagne_evenements_path(resource)
   end
 end

--- a/spec/features/campagne_stats_spec.rb
+++ b/spec/features/campagne_stats_spec.rb
@@ -59,7 +59,7 @@ describe 'Admin - Campagne Stats', type: :feature do
       expect(restitution_globale).to receive(:efficience).and_return(1)
       expect(FabriqueRestitution).to receive(:restitution_globale).and_return(restitution_globale)
       connecte compte_organisation
-      visit admin_campagne_stats_path
+      visit admin_campagne_campagne_stats_path(campagne)
     end
 
     it do


### PR DESCRIPTION
ce qui harmonise avec les autres consultation de campagne et permet de revenir à la campagne grâce au fil d'ariane

![Capture d’écran 2020-01-03 à 15 52 24](https://user-images.githubusercontent.com/28393/71729863-16e3c800-2e41-11ea-9d36-3dea2410d197.png)
