### PR TITLE
modifie le nom du fichier généré à l'export

### DIFF
--- a/app/admin/stats.rb
+++ b/app/admin/stats.rb
@@ -75,5 +75,9 @@ ActiveAdmin.register Evaluation, as: 'Stats' do
     def scoped_collection
       Evaluation.where(campagne: params[:campagne_id])
     end
+
+    def csv_filename
+      "#{Time.current.to_formatted_s(:number)}-stats-#{@campagne.code}.csv"
+    end
   end
 end


### PR DESCRIPTION
Contribue à betagouv#299

Du coup on a le format suivant:

`20200106104613-stats-pole-emploi-rouen.csv`