### PR TITLE
calcule et affiche le nombre de dangers mal identifiés

### DIFF
--- a/app/models/evenement_securite_decorator.rb
+++ b/app/models/evenement_securite_decorator.rb
@@ -19,10 +19,12 @@ class EvenementSecuriteDecorator < SimpleDelegator
     donnees['reponse'] == BONNE_QUALIFICATION
   end
 
-  def est_un_danger_identifie?
-    nom == EVENEMENT[:IDENTIFICATION_DANGER] &&
-      donnees['reponse'] == IDENTIFICATION_POSITIVE &&
-      donnees['danger'].present?
+  def est_un_danger_bien_identifie?
+    est_un_danger_identifie?(bonne_reponse: true)
+  end
+
+  def est_un_danger_mal_identifie?
+    est_un_danger_identifie?(bonne_reponse: false)
   end
 
   def ouverture_zone_sans_danger?
@@ -43,5 +45,14 @@ class EvenementSecuriteDecorator < SimpleDelegator
 
   def danger_visuo_spatial?
     donnees['danger'] == DANGER_VISUO_SPATIAL
+  end
+
+  private
+
+  def est_un_danger_identifie?(bonne_reponse:)
+    comparateur = bonne_reponse ? :== : :!=
+    nom == EVENEMENT[:IDENTIFICATION_DANGER] &&
+      donnees['reponse'].send(comparateur, IDENTIFICATION_POSITIVE) &&
+      donnees['danger'].present?
   end
 end

--- a/app/models/restitution/securite.rb
+++ b/app/models/restitution/securite.rb
@@ -20,8 +20,8 @@ module Restitution
     def persiste
       metriques = %i[
         nombre_reouverture_zone_sans_danger nombre_bien_qualifies
-        nombre_dangers_identifies nombre_retours_deja_qualifies
-        nombre_dangers_identifies_avant_aide_1 attention_visuo_spatiale
+        nombre_dangers_bien_identifies nombre_retours_deja_qualifies
+        nombre_dangers_bien_identifies_avant_aide_1 attention_visuo_spatiale
         temps_ouvertures_zones_dangers temps_moyen_ouvertures_zones_dangers
         temps_entrainement temps_total nombre_rejoue_consigne nombre_danger_mal_identifies
       ].each_with_object({}) do |methode, memo|
@@ -36,8 +36,8 @@ module Restitution
       end.count(&:bonne_reponse?)
     end
 
-    def nombre_dangers_identifies
-      dangers_identifies.count
+    def nombre_dangers_bien_identifies
+      dangers_bien_identifies.count
     end
 
     def nombre_danger_mal_identifies
@@ -50,17 +50,17 @@ module Restitution
       end
     end
 
-    def nombre_dangers_identifies_avant_aide_1
-      return nombre_dangers_identifies if activation_aide1.blank?
+    def nombre_dangers_bien_identifies_avant_aide_1
+      return nombre_dangers_bien_identifies if activation_aide1.blank?
 
-      dangers_identifies_tries = dangers_identifies.partition do |danger|
+      dangers_bien_identifies_tries = dangers_bien_identifies.partition do |danger|
         danger.date < activation_aide1.date
       end
-      dangers_identifies_tries.first.length
+      dangers_bien_identifies_tries.first.length
     end
 
     def attention_visuo_spatiale
-      identification = dangers_identifies.find(&:danger_visuo_spatial?)
+      identification = dangers_bien_identifies.find(&:danger_visuo_spatial?)
       return ::Competence::NIVEAU_INDETERMINE if identification.blank?
 
       if activation_aide1.present? && activation_aide1.date < identification.date
@@ -100,12 +100,12 @@ module Restitution
       evenements_situation.select(&:qualification_danger?).group_by { |e| e.donnees['danger'] }
     end
 
-    def dangers_identifies
-      @dangers_identifies || evenements_situation.select(&:est_un_danger_bien_identifie?)
+    def dangers_bien_identifies
+      @dangers_bien_identifies ||= evenements_situation.select(&:est_un_danger_bien_identifie?)
     end
 
     def dangers_mal_identifies
-      evenements_situation.select(&:est_un_danger_mal_identifie?)
+      @dangers_mal_identifies ||= evenements_situation.select(&:est_un_danger_mal_identifie?)
     end
 
     def activation_aide1

--- a/app/models/restitution/securite.rb
+++ b/app/models/restitution/securite.rb
@@ -23,7 +23,7 @@ module Restitution
         nombre_dangers_identifies nombre_retours_deja_qualifies
         nombre_dangers_identifies_avant_aide_1 attention_visuo_spatiale
         temps_ouvertures_zones_dangers temps_moyen_ouvertures_zones_dangers
-        temps_entrainement temps_total nombre_rejoue_consigne
+        temps_entrainement temps_total nombre_rejoue_consigne nombre_danger_mal_identifies
       ].each_with_object({}) do |methode, memo|
         memo[methode] = public_send(methode)
       end
@@ -38,6 +38,10 @@ module Restitution
 
     def nombre_dangers_identifies
       dangers_identifies.count
+    end
+
+    def nombre_danger_mal_identifies
+      dangers_mal_identifies.count
     end
 
     def nombre_retours_deja_qualifies
@@ -97,7 +101,11 @@ module Restitution
     end
 
     def dangers_identifies
-      @dangers_identifies || evenements_situation.select(&:est_un_danger_identifie?)
+      @dangers_identifies || evenements_situation.select(&:est_un_danger_bien_identifie?)
+    end
+
+    def dangers_mal_identifies
+      evenements_situation.select(&:est_un_danger_mal_identifie?)
     end
 
     def activation_aide1

--- a/app/views/admin/restitutions/_restitution_securite.html.arb
+++ b/app/views/admin/restitutions/_restitution_securite.html.arb
@@ -13,14 +13,14 @@ panel t('.restitution_securite') do
     row t('.temps_entrainement') do |(_, r)|
       Time.at(r.temps_entrainement).strftime('%M:%S') if r.temps_entrainement.present?
     end
-    row t('.dangers_identifies') do |(_, r)|
-      r.nombre_dangers_identifies
+    row t('.dangers_bien_identifies') do |(_, r)|
+      r.nombre_dangers_bien_identifies
     end
     row t('.dangers_mal_identifies') do |(_, r)|
       r.nombre_danger_mal_identifies
     end
-    row t('.dangers_identifies_avant_aide_1') do |(_, r)|
-      r.nombre_dangers_identifies_avant_aide_1
+    row t('.dangers_bien_identifies_avant_aide_1') do |(_, r)|
+      r.nombre_dangers_bien_identifies_avant_aide_1
     end
     row t('.dangers_bien_qualifies') do |(_, r)|
       r.nombre_bien_qualifies

--- a/app/views/admin/restitutions/_restitution_securite.html.arb
+++ b/app/views/admin/restitutions/_restitution_securite.html.arb
@@ -16,6 +16,9 @@ panel t('.restitution_securite') do
     row t('.dangers_identifies') do |(_, r)|
       r.nombre_dangers_identifies
     end
+    row t('.dangers_mal_identifies') do |(_, r)|
+      r.nombre_danger_mal_identifies
+    end
     row t('.dangers_identifies_avant_aide_1') do |(_, r)|
       r.nombre_dangers_identifies_avant_aide_1
     end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -110,11 +110,11 @@ fr:
         restitution_securite: Restitution de la situation sécurité
         temps_entrainement: Temps passé dans l'entrainement
         dangers_bien_qualifies: Dangers bien qualifiés
-        dangers_identifies: Dangers identifiés
+        dangers_bien_identifies: Dangers bien identifiés
         retours_dangers_deja_qualifies: Retours sur les situations déjà qualifiées
         retours_zones_sans_danger: Retours sur les zones sans danger
-        dangers_mal_identifies: Nombre de dangers mal identifiés
-        dangers_identifies_avant_aide_1: Dangers identifiés avant activation de l'aide N°1
+        dangers_mal_identifies: Dangers mal identifiés
+        dangers_bien_identifies_avant_aide_1: Dangers bien identifiés avant activation de l'aide N°1
         temps_ouvertures_zones_dangers: Temps d'ouvertures de zones de danger
         temps_moyen_ouvertures_zones_dangers: Temps moyen d'ouverture de zone de danger
         attention_visuo_spatiale: Attention visuo-spatiale

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -113,6 +113,7 @@ fr:
         dangers_identifies: Dangers identifiés
         retours_dangers_deja_qualifies: Retours sur les situations déjà qualifiées
         retours_zones_sans_danger: Retours sur les zones sans danger
+        dangers_mal_identifies: Nombre de dangers mal identifiés
         dangers_identifies_avant_aide_1: Dangers identifiés avant activation de l'aide N°1
         temps_ouvertures_zones_dangers: Temps d'ouvertures de zones de danger
         temps_moyen_ouvertures_zones_dangers: Temps moyen d'ouverture de zone de danger

--- a/spec/models/restitution/securite_spec.rb
+++ b/spec/models/restitution/securite_spec.rb
@@ -108,10 +108,10 @@ describe Restitution::Securite do
     end
   end
 
-  describe '#nombre_dangers_identifies' do
+  describe '#nombre_dangers_bien_identifies' do
     context 'sans évenement' do
       let(:evenements) { [] }
-      it { expect(restitution.nombre_dangers_identifies).to eq 0 }
+      it { expect(restitution.nombre_dangers_bien_identifies).to eq 0 }
     end
 
     context 'avec bonne identification' do
@@ -119,7 +119,7 @@ describe Restitution::Securite do
         [build(:evenement_demarrage),
          build(:evenement_identification_danger, donnees: { reponse: 'oui', danger: 'danger' })]
       end
-      it { expect(restitution.nombre_dangers_identifies).to eq 1 }
+      it { expect(restitution.nombre_dangers_bien_identifies).to eq 1 }
     end
 
     context 'ignore les réponses négatives' do
@@ -127,7 +127,7 @@ describe Restitution::Securite do
         [build(:evenement_demarrage),
          build(:evenement_identification_danger, donnees: { reponse: 'non' })]
       end
-      it { expect(restitution.nombre_dangers_identifies).to eq 0 }
+      it { expect(restitution.nombre_dangers_bien_identifies).to eq 0 }
     end
 
     context 'ignore les identifications de zone sans danger' do
@@ -135,7 +135,7 @@ describe Restitution::Securite do
         [build(:evenement_demarrage),
          build(:evenement_identification_danger, donnees: { reponse: 'oui' })]
       end
-      it { expect(restitution.nombre_dangers_identifies).to eq 0 }
+      it { expect(restitution.nombre_dangers_bien_identifies).to eq 0 }
     end
   end
 
@@ -157,10 +157,10 @@ describe Restitution::Securite do
     end
   end
 
-  describe '#nombre_dangers_identifies_avant_aide_1' do
+  describe '#nombre_dangers_bien_identifies_avant_aide_1' do
     context 'sans évenement' do
       let(:evenements) { [] }
-      it { expect(restitution.nombre_dangers_identifies_avant_aide_1).to eq 0 }
+      it { expect(restitution.nombre_dangers_bien_identifies_avant_aide_1).to eq 0 }
     end
 
     context "avec des dangers identifiés en ayant activé l'aide" do
@@ -177,7 +177,7 @@ describe Restitution::Securite do
                donnees: { reponse: 'oui', danger: 'danger' },
                date: 2.minutes.from_now)]
       end
-      it { expect(restitution.nombre_dangers_identifies_avant_aide_1).to eq 2 }
+      it { expect(restitution.nombre_dangers_bien_identifies_avant_aide_1).to eq 2 }
     end
 
     context "avec des dangers identifiés aprés avoir activé l'aide" do
@@ -188,7 +188,7 @@ describe Restitution::Securite do
                donnees: { reponse: 'oui', danger: 'danger' },
                date: 2.minutes.from_now)]
       end
-      it { expect(restitution.nombre_dangers_identifies_avant_aide_1).to eq 0 }
+      it { expect(restitution.nombre_dangers_bien_identifies_avant_aide_1).to eq 0 }
     end
 
     context "avec un danger identifié sans avoir activé l'aide" do
@@ -198,7 +198,7 @@ describe Restitution::Securite do
                donnees: { reponse: 'oui', danger: 'danger' },
                date: 2.minutes.from_now)]
       end
-      it { expect(restitution.nombre_dangers_identifies_avant_aide_1).to eq 1 }
+      it { expect(restitution.nombre_dangers_bien_identifies_avant_aide_1).to eq 1 }
     end
   end
 
@@ -356,9 +356,9 @@ describe Restitution::Securite do
       it do
         expect(restitution).to receive(:nombre_reouverture_zone_sans_danger).and_return 1
         expect(restitution).to receive(:nombre_bien_qualifies).and_return 2
-        expect(restitution).to receive(:nombre_dangers_identifies).and_return 3
+        expect(restitution).to receive(:nombre_dangers_bien_identifies).and_return 3
         expect(restitution).to receive(:nombre_retours_deja_qualifies).and_return 4
-        expect(restitution).to receive(:nombre_dangers_identifies_avant_aide_1).and_return 5
+        expect(restitution).to receive(:nombre_dangers_bien_identifies_avant_aide_1).and_return 5
         expect(restitution).to receive(:attention_visuo_spatiale).and_return Competence::APTE
         expect(restitution).to receive(:temps_ouvertures_zones_dangers).and_return [1, 2]
         expect(restitution).to receive(:temps_moyen_ouvertures_zones_dangers).and_return 7
@@ -370,9 +370,9 @@ describe Restitution::Securite do
         partie.reload
         expect(partie.metriques['nombre_reouverture_zone_sans_danger']).to eq 1
         expect(partie.metriques['nombre_bien_qualifies']).to eq 2
-        expect(partie.metriques['nombre_dangers_identifies']).to eq 3
+        expect(partie.metriques['nombre_dangers_bien_identifies']).to eq 3
         expect(partie.metriques['nombre_retours_deja_qualifies']).to eq 4
-        expect(partie.metriques['nombre_dangers_identifies_avant_aide_1']).to eql 5
+        expect(partie.metriques['nombre_dangers_bien_identifies_avant_aide_1']).to eql 5
         expect(partie.metriques['attention_visuo_spatiale']).to eql 'apte'
         expect(partie.metriques['temps_ouvertures_zones_dangers']).to eql [1, 2]
         expect(partie.metriques['temps_moyen_ouvertures_zones_dangers']).to eql 7

--- a/spec/models/restitution/securite_spec.rb
+++ b/spec/models/restitution/securite_spec.rb
@@ -51,6 +51,29 @@ describe Restitution::Securite do
     end
   end
 
+  describe '#nombre_danger_mal_identifies' do
+    context 'sans évenement' do
+      let(:evenements) { [] }
+      it { expect(restitution.nombre_danger_mal_identifies).to eq 0 }
+    end
+
+    context 'avec une bonne identification' do
+      let(:evenements) do
+        [build(:evenement_demarrage),
+         build(:evenement_identification_danger, donnees: { reponse: 'oui', danger: 'danger' })]
+      end
+      it { expect(restitution.nombre_danger_mal_identifies).to eq 0 }
+    end
+
+    context 'avec une mauvaise identification' do
+      let(:evenements) do
+        [build(:evenement_demarrage),
+         build(:evenement_identification_danger, donnees: { reponse: 'non', danger: 'danger' })]
+      end
+      it { expect(restitution.nombre_danger_mal_identifies).to eq 1 }
+    end
+  end
+
   describe '#nombre_bien_qualifies' do
     context 'sans évenement' do
       let(:evenements) { [] }
@@ -342,6 +365,7 @@ describe Restitution::Securite do
         expect(restitution).to receive(:temps_entrainement).and_return 8
         expect(restitution).to receive(:temps_total).and_return 9
         expect(restitution).to receive(:nombre_rejoue_consigne).and_return 10
+        expect(restitution).to receive(:nombre_danger_mal_identifies).and_return 1
         restitution.persiste
         partie.reload
         expect(partie.metriques['nombre_reouverture_zone_sans_danger']).to eq 1
@@ -355,6 +379,7 @@ describe Restitution::Securite do
         expect(partie.metriques['temps_entrainement']).to eql 8
         expect(partie.metriques['temps_total']).to eql 9
         expect(partie.metriques['nombre_rejoue_consigne']).to eql 10
+        expect(partie.metriques['nombre_danger_mal_identifies']).to eql 1
       end
     end
   end


### PR DESCRIPTION
Contribue à https://github.com/betagouv/eva/issues/681

En rajoutant la métrique suivante:

` NombreErreurs : nombre de zones dangereuse identifiés comme non dangers`