### PR TITLE
retire le filtre des événements discontinus

### DIFF
--- a/app/models/restitution/securite.rb
+++ b/app/models/restitution/securite.rb
@@ -112,19 +112,8 @@ module Restitution
       les_temps
     end
 
-    def evenements_discontinus
-      dernier_evenement_retenu = nil
-      evenements_situation.select do |e|
-        next if dernier_evenement_retenu&.nom == e.nom
-
-        next unless yield(e)
-
-        dernier_evenement_retenu = e
-      end
-    end
-
-    def temps_entre_evenements(&block)
-      evenements = evenements_discontinus(&block)
+    def temps_entre_evenements
+      evenements = evenements_situation.select { |e| yield e }
       temps_entre_couples evenements
     end
   end

--- a/spec/models/restitution/securite_spec.rb
+++ b/spec/models/restitution/securite_spec.rb
@@ -252,19 +252,6 @@ describe Restitution::Securite do
       end
       it { expect(restitution.temps_ouvertures_zones_dangers).to eq [60] }
     end
-
-    context 'ignore les requalifications' do
-      let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_ouverture_zone,
-               donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1)),
-         build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2)),
-         build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 3)),
-         build(:evenement_ouverture_zone,
-               donnees: { danger: 'd2' }, date: Time.local(2019, 10, 9, 10, 5))]
-      end
-      it { expect(restitution.temps_ouvertures_zones_dangers).to eq [60, 180] }
-    end
   end
 
   describe '#temps_bonnes_qualifications_dangers' do
@@ -310,23 +297,6 @@ describe Restitution::Securite do
          build(:evenement_ouverture_zone, date: Time.local(2019, 10, 9, 10, 1))]
       end
       it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [] }
-    end
-
-    context 'ignore les requalifications' do
-      let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_ouverture_zone,
-               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 1)),
-         build(:evenement_qualification_danger,
-               donnees: { reponse: 'bonne', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 2)),
-         build(:evenement_qualification_danger,
-               donnees: { reponse: 'bonne', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 3)),
-         build(:evenement_ouverture_zone,
-               donnees: { danger: 'd2' }, date: Time.local(2019, 10, 9, 10, 4)),
-         build(:evenement_qualification_danger,
-               donnees: { reponse: 'bonne', danger: 'd2' }, date: Time.local(2019, 10, 9, 10, 7))]
-      end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [60, 180] }
     end
 
     context 'ignore les zones non dangers ouverts' do


### PR DESCRIPTION
car il ne représente pas un cas qui je produit dans la réalité
Co-authored-by: François de Metz <francois.de_metz@beta.gouv.fr>