### PR TITLE
Renomme les métriques Sécurité pour plus de précisions

### DIFF
--- a/app/models/restitution/metriques.rb
+++ b/app/models/restitution/metriques.rb
@@ -6,7 +6,7 @@ module Restitution
       nombre_reouverture_zone_sans_danger nombre_bien_qualifies
       nombre_dangers_bien_identifies nombre_retours_deja_qualifies
       nombre_dangers_bien_identifies_avant_aide_1 attention_visuo_spatiale
-      temps_ouvertures_zones_dangers temps_moyen_ouvertures_zones_dangers
+      temps_recherche_zones_dangers temps_moyen_ouvertures_zones_dangers
       temps_entrainement temps_total nombre_rejoue_consigne nombre_danger_mal_identifies
     ].freeze
   end

--- a/app/models/restitution/securite.rb
+++ b/app/models/restitution/securite.rb
@@ -71,7 +71,7 @@ module Restitution
                           end
     end
 
-    def temps_ouvertures_zones_dangers
+    def temps_recherche_zones_dangers
       temps_entre_evenements do |e|
         e.demarrage? || e.qualification_danger? || e.ouverture_zone_danger?
       end
@@ -82,9 +82,9 @@ module Restitution
     end
 
     def temps_moyen_ouvertures_zones_dangers
-      return nil if temps_ouvertures_zones_dangers.empty?
+      return nil if temps_recherche_zones_dangers.empty?
 
-      temps_ouvertures_zones_dangers.sum / temps_ouvertures_zones_dangers.size
+      temps_recherche_zones_dangers.sum / temps_recherche_zones_dangers.size
     end
 
     private

--- a/app/views/admin/restitutions/_restitution_securite.html.arb
+++ b/app/views/admin/restitutions/_restitution_securite.html.arb
@@ -28,8 +28,8 @@ panel t('.restitution_securite') do
     row t('.retours_dangers_deja_qualifies') do |(_, r)|
       r.nombre_retours_deja_qualifies
     end
-    row t('.temps_ouvertures_zones_dangers') do |_, r|
-      r.temps_ouvertures_zones_dangers&.collect do |temps|
+    row t('.temps_recherche_zones_dangers') do |_, r|
+      r.temps_recherche_zones_dangers&.collect do |temps|
         Time.at(temps).strftime('%M:%S')
       end&.join(', ')
     end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -113,9 +113,9 @@ fr:
         dangers_bien_identifies: Dangers bien identifiés
         retours_dangers_deja_qualifies: Retours sur les situations déjà qualifiées
         retours_zones_sans_danger: Retours sur les zones sans danger
-        temps_bonnes_qualifications_dangers: Temps entre chaque bonne qualification de danger
+        temps_bonnes_qualifications_dangers: Temps dernière ouverture pour les bonnes qualifications
         dangers_mal_identifies: Dangers mal identifiés
         dangers_bien_identifies_avant_aide_1: Dangers bien identifiés avant activation de l'aide N°1
-        temps_ouvertures_zones_dangers: Temps d'ouvertures de zones de danger
+        temps_recherche_zones_dangers: Temps de recherche de zones de danger
         temps_moyen_ouvertures_zones_dangers: Temps moyen d'ouverture de zone de danger
         attention_visuo_spatiale: Attention visuo-spatiale

--- a/spec/models/restitution/securite_spec.rb
+++ b/spec/models/restitution/securite_spec.rb
@@ -202,10 +202,10 @@ describe Restitution::Securite do
     end
   end
 
-  describe '#temps_ouvertures_zones_dangers et #temps_moyen_ouvertures_zones_dangers' do
+  describe '#temps_recherche_zones_dangers et #temps_moyen_ouvertures_zones_dangers' do
     context 'sans zone danger ouverte' do
       let(:evenements) { [] }
-      it { expect(restitution.temps_ouvertures_zones_dangers).to eq [] }
+      it { expect(restitution.temps_recherche_zones_dangers).to eq [] }
       it { expect(restitution.temps_moyen_ouvertures_zones_dangers).to eq nil }
     end
 
@@ -215,7 +215,7 @@ describe Restitution::Securite do
          build(:evenement_ouverture_zone,
                donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1))]
       end
-      it { expect(restitution.temps_ouvertures_zones_dangers).to eq [60] }
+      it { expect(restitution.temps_recherche_zones_dangers).to eq [60] }
       it { expect(restitution.temps_moyen_ouvertures_zones_dangers).to eq 60 }
     end
 
@@ -228,7 +228,7 @@ describe Restitution::Securite do
          build(:evenement_ouverture_zone,
                donnees: { danger: 'd2' }, date: Time.local(2019, 10, 9, 10, 4))]
       end
-      it { expect(restitution.temps_ouvertures_zones_dangers).to eq [60, 120] }
+      it { expect(restitution.temps_recherche_zones_dangers).to eq [60, 120] }
       it { expect(restitution.temps_moyen_ouvertures_zones_dangers).to eq 90 }
     end
 
@@ -240,7 +240,7 @@ describe Restitution::Securite do
          build(:evenement_ouverture_zone,
                donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 3))]
       end
-      it { expect(restitution.temps_ouvertures_zones_dangers).to eq [180] }
+      it { expect(restitution.temps_recherche_zones_dangers).to eq [180] }
     end
 
     context 'quand on ne finit pas par une identification' do
@@ -250,7 +250,7 @@ describe Restitution::Securite do
                donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1)),
          build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2))]
       end
-      it { expect(restitution.temps_ouvertures_zones_dangers).to eq [60] }
+      it { expect(restitution.temps_recherche_zones_dangers).to eq [60] }
     end
   end
 
@@ -406,7 +406,7 @@ describe Restitution::Securite do
         expect(restitution).to receive(:nombre_retours_deja_qualifies).and_return 4
         expect(restitution).to receive(:nombre_dangers_bien_identifies_avant_aide_1).and_return 5
         expect(restitution).to receive(:attention_visuo_spatiale).and_return Competence::APTE
-        expect(restitution).to receive(:temps_ouvertures_zones_dangers).and_return [1, 2]
+        expect(restitution).to receive(:temps_recherche_zones_dangers).and_return [1, 2]
         expect(restitution).to receive(:temps_moyen_ouvertures_zones_dangers).and_return 7
         expect(restitution).to receive(:temps_entrainement).and_return 8
         expect(restitution).to receive(:temps_total).and_return 9
@@ -420,7 +420,7 @@ describe Restitution::Securite do
         expect(partie.metriques['nombre_retours_deja_qualifies']).to eq 4
         expect(partie.metriques['nombre_dangers_bien_identifies_avant_aide_1']).to eql 5
         expect(partie.metriques['attention_visuo_spatiale']).to eql 'apte'
-        expect(partie.metriques['temps_ouvertures_zones_dangers']).to eql [1, 2]
+        expect(partie.metriques['temps_recherche_zones_dangers']).to eql [1, 2]
         expect(partie.metriques['temps_moyen_ouvertures_zones_dangers']).to eql 7
         expect(partie.metriques['temps_entrainement']).to eql 8
         expect(partie.metriques['temps_total']).to eql 9


### PR DESCRIPTION
`temps_ouvertures_zones_dangers` devient `temps_recherche_zones_dangers`

`Temps entre chaque bonne qualification de danger` devient `Temps dernière ouverture pour les bonnes qualifications`