### PR TITLE
Renvois une donnée par danger pour la métrique temps_bonnes_qualifications_dangers

### DIFF
--- a/app/models/restitution/metriques.rb
+++ b/app/models/restitution/metriques.rb
@@ -2,8 +2,6 @@
 
 module Restitution
   class Metriques
-    ZONES_DANGER_SECURITE = %w[bouche-egout casque escabeau camion signalisation].freeze
-
     REGLES_SECURITE = {
       'temps_bonnes_qualifications_dangers' => Securite::TempsBonnesQualificationsDangers
     }.freeze

--- a/app/models/restitution/metriques.rb
+++ b/app/models/restitution/metriques.rb
@@ -2,6 +2,16 @@
 
 module Restitution
   class Metriques
+    def self.temps_entre_couples(evenements)
+      les_temps = []
+      evenements.each_slice(2) do |e1, e2|
+        next if e2.blank?
+
+        les_temps << e2.date - e1.date
+      end
+      les_temps
+    end
+
     SECURITE = %i[
       nombre_reouverture_zone_sans_danger nombre_bien_qualifies
       nombre_dangers_bien_identifies nombre_retours_deja_qualifies
@@ -9,5 +19,9 @@ module Restitution
       temps_ouvertures_zones_dangers temps_moyen_ouvertures_zones_dangers
       temps_entrainement temps_total nombre_rejoue_consigne nombre_danger_mal_identifies
     ].freeze
+
+    REGLES_SECURITE = {
+      'temps_bonnes_qualifications_dangers' => Securite::TempsBonnesQualificationsDangers
+    }.freeze
   end
 end

--- a/app/models/restitution/metriques.rb
+++ b/app/models/restitution/metriques.rb
@@ -2,15 +2,11 @@
 
 module Restitution
   class Metriques
-    def self.temps_entre_couples(evenements)
-      les_temps = []
-      evenements.each_slice(2) do |e1, e2|
-        next if e2.blank?
+    ZONES_DANGER_SECURITE = %w[bouche-egout casque escabeau camion signalisation].freeze
 
-        les_temps << e2.date - e1.date
-      end
-      les_temps
-    end
+    REGLES_SECURITE = {
+      'temps_bonnes_qualifications_dangers' => Securite::TempsBonnesQualificationsDangers
+    }.freeze
 
     SECURITE = %i[
       nombre_reouverture_zone_sans_danger nombre_bien_qualifies
@@ -19,9 +15,5 @@ module Restitution
       temps_ouvertures_zones_dangers temps_moyen_ouvertures_zones_dangers
       temps_entrainement temps_total nombre_rejoue_consigne nombre_danger_mal_identifies
     ].freeze
-
-    REGLES_SECURITE = {
-      'temps_bonnes_qualifications_dangers' => Securite::TempsBonnesQualificationsDangers
-    }.freeze
   end
 end

--- a/app/models/restitution/metriques_helper.rb
+++ b/app/models/restitution/metriques_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Restitution
+  class MetriquesHelper
+    class << self
+      def temps_entre_couples(evenements)
+        les_temps = []
+        evenements.each_slice(2) do |e1, e2|
+          next if e2.blank?
+
+          les_temps << e2.date - e1.date
+        end
+        les_temps
+      end
+    end
+  end
+end

--- a/app/models/restitution/securite.rb
+++ b/app/models/restitution/securite.rb
@@ -8,8 +8,6 @@ module Restitution
       ACTIVATION_AIDE_1: 'activationAide'
     }.freeze
 
-    ZONES_DANGER = %w[bouche-egout casque escabeau camion signalisation].freeze
-
     def initialize(campagne, evenements)
       evenements = evenements.map { |e| EvenementSecuriteDecorator.new e }
       super(campagne, evenements)
@@ -80,14 +78,9 @@ module Restitution
     end
 
     def temps_bonnes_qualifications_dangers
-      resultat = []
-      ZONES_DANGER.each do |danger|
-        resultat << temps_entre_evenements do |e|
-          filtre_evenement = e.ouverture_zone_danger? || e.bonne_qualification_danger?
-          e.donnees['danger'] == danger && filtre_evenement
-        end.last
-      end
-      resultat
+      Metriques::REGLES_SECURITE['temps_bonnes_qualifications_dangers']
+        .new
+        .calcule(evenements_situation)
     end
 
     def temps_moyen_ouvertures_zones_dangers
@@ -111,19 +104,9 @@ module Restitution
                                                      EVENEMENT[:ACTIVATION_AIDE_1])
     end
 
-    def temps_entre_couples(evenements)
-      les_temps = []
-      evenements.each_slice(2) do |e1, e2|
-        next if e2.blank?
-
-        les_temps << e2.date - e1.date
-      end
-      les_temps
-    end
-
     def temps_entre_evenements
       evenements = evenements_situation.select { |e| yield e }
-      temps_entre_couples evenements
+      Metriques.temps_entre_couples evenements
     end
   end
 end

--- a/app/models/restitution/securite.rb
+++ b/app/models/restitution/securite.rb
@@ -79,8 +79,8 @@ module Restitution
 
     def temps_bonnes_qualifications_dangers
       Metriques::REGLES_SECURITE['temps_bonnes_qualifications_dangers']
-        .new
-        .calcule(evenements_situation)
+        .new(evenements_situation)
+        .calcule
     end
 
     def temps_moyen_ouvertures_zones_dangers
@@ -92,7 +92,7 @@ module Restitution
     private
 
     def qualifications_par_danger
-      evenements_situation.select(&:qualification_danger?).group_by { |e| e.donnees['danger'] }
+      SecuriteHelper.filtre_par_danger(evenements_situation, &:qualification_danger?)
     end
 
     def dangers_bien_identifies

--- a/app/models/restitution/securite.rb
+++ b/app/models/restitution/securite.rb
@@ -8,6 +8,8 @@ module Restitution
       ACTIVATION_AIDE_1: 'activationAide'
     }.freeze
 
+    ZONES_DANGER = %w[bouche-egout casque escabeau camion signalisation].freeze
+
     def initialize(campagne, evenements)
       evenements = evenements.map { |e| EvenementSecuriteDecorator.new e }
       super(campagne, evenements)
@@ -78,7 +80,14 @@ module Restitution
     end
 
     def temps_bonnes_qualifications_dangers
-      temps_entre_evenements { |e| e.ouverture_zone_danger? || e.bonne_qualification_danger? }
+      resultat = []
+      ZONES_DANGER.each do |danger|
+        resultat << temps_entre_evenements do |e|
+          filtre_evenement = e.ouverture_zone_danger? || e.bonne_qualification_danger?
+          e.donnees['danger'] == danger && filtre_evenement
+        end.last
+      end
+      resultat
     end
 
     def temps_moyen_ouvertures_zones_dangers

--- a/app/models/restitution/securite.rb
+++ b/app/models/restitution/securite.rb
@@ -106,7 +106,7 @@ module Restitution
 
     def temps_entre_evenements
       evenements = evenements_situation.select { |e| yield e }
-      Metriques.temps_entre_couples evenements
+      MetriquesHelper.temps_entre_couples evenements
     end
   end
 end

--- a/app/models/restitution/securite/securite_helper.rb
+++ b/app/models/restitution/securite/securite_helper.rb
@@ -5,7 +5,7 @@ module Restitution
     class SecuriteHelper
       class << self
         def filtre_par_danger(evenements, &block)
-          evenements.select(&block).group_by { |e| e.donnees['danger'] }
+          evenements.select(&block).group_by { |e| e.donnees['danger'] }.sort.to_h
         end
       end
     end

--- a/app/models/restitution/securite/securite_helper.rb
+++ b/app/models/restitution/securite/securite_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Restitution
+  class Securite
+    class SecuriteHelper
+      class << self
+        def filtre_par_danger(evenements, &block)
+          evenements.select(&block).group_by { |e| e.donnees['danger'] }
+        end
+      end
+    end
+  end
+end

--- a/app/models/restitution/securite/temps_bonnes_qualifications_dangers.rb
+++ b/app/models/restitution/securite/temps_bonnes_qualifications_dangers.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Restitution
+  class Securite
+    class TempsBonnesQualificationsDangers
+      ZONES_DANGER = %w[bouche-egout casque escabeau camion signalisation].freeze
+
+      def calcule(evenements_situation)
+        resultat = []
+        ZONES_DANGER.each do |danger|
+          evenements = evenements_situation.select do |e|
+            filtre_evenement = e.ouverture_zone_danger? || e.bonne_qualification_danger?
+            e.donnees['danger'] == danger && filtre_evenement
+          end
+          temps = Metriques.temps_entre_couples evenements
+          resultat << temps.last
+        end
+        resultat
+      end
+    end
+  end
+end

--- a/app/models/restitution/securite/temps_bonnes_qualifications_dangers.rb
+++ b/app/models/restitution/securite/temps_bonnes_qualifications_dangers.rb
@@ -4,16 +4,17 @@ module Restitution
   class Securite
     class TempsBonnesQualificationsDangers
       def calcule(evenements_situation)
-        resultat = []
-        Metriques::ZONES_DANGER_SECURITE.each do |danger|
-          evenements = evenements_situation.select do |e|
-            filtre_evenement = e.ouverture_zone_danger? || e.bonne_qualification_danger?
-            e.donnees['danger'] == danger && filtre_evenement
-          end
-          temps = MetriquesHelper.temps_entre_couples evenements
-          resultat << temps.last
+        evenements = evenements_situation.select do |e|
+          e.ouverture_zone_danger? || e.bonne_qualification_danger?
         end
-        resultat
+        evenements_par_danger = evenements.group_by { |e| e.donnees['danger'] }
+
+        temps_par_dangers = {}
+        evenements_par_danger.each do |danger, les_evenements|
+          temps = MetriquesHelper.temps_entre_couples les_evenements
+          temps_par_dangers[danger] = temps.last if temps.last.present?
+        end
+        temps_par_dangers
       end
     end
   end

--- a/app/models/restitution/securite/temps_bonnes_qualifications_dangers.rb
+++ b/app/models/restitution/securite/temps_bonnes_qualifications_dangers.rb
@@ -3,18 +3,27 @@
 module Restitution
   class Securite
     class TempsBonnesQualificationsDangers
-      def calcule(evenements_situation)
-        evenements = evenements_situation.select do |e|
-          e.ouverture_zone_danger? || e.bonne_qualification_danger?
-        end
-        evenements_par_danger = evenements.group_by { |e| e.donnees['danger'] }
+      attr_reader :evenements_situation
 
-        temps_par_dangers = {}
+      def initialize(evenements_situation)
+        @evenements_situation = evenements_situation
+      end
+
+      def calcule
+        temps_par_danger = {}
         evenements_par_danger.each do |danger, les_evenements|
           temps = MetriquesHelper.temps_entre_couples les_evenements
-          temps_par_dangers[danger] = temps.last if temps.last.present?
+          temps_par_danger[danger] = temps.last if temps.last.present?
         end
-        temps_par_dangers
+        temps_par_danger
+      end
+
+      private
+
+      def evenements_par_danger
+        SecuriteHelper.filtre_par_danger(evenements_situation) do |e|
+          e.ouverture_zone_danger? || e.bonne_qualification_danger?
+        end
       end
     end
   end

--- a/app/models/restitution/securite/temps_bonnes_qualifications_dangers.rb
+++ b/app/models/restitution/securite/temps_bonnes_qualifications_dangers.rb
@@ -3,16 +3,14 @@
 module Restitution
   class Securite
     class TempsBonnesQualificationsDangers
-      ZONES_DANGER = %w[bouche-egout casque escabeau camion signalisation].freeze
-
       def calcule(evenements_situation)
         resultat = []
-        ZONES_DANGER.each do |danger|
+        Metriques::ZONES_DANGER_SECURITE.each do |danger|
           evenements = evenements_situation.select do |e|
             filtre_evenement = e.ouverture_zone_danger? || e.bonne_qualification_danger?
             e.donnees['danger'] == danger && filtre_evenement
           end
-          temps = Metriques.temps_entre_couples evenements
+          temps = MetriquesHelper.temps_entre_couples evenements
           resultat << temps.last
         end
         resultat

--- a/app/views/admin/restitutions/_restitution_securite.html.arb
+++ b/app/views/admin/restitutions/_restitution_securite.html.arb
@@ -43,7 +43,11 @@ panel t('.restitution_securite') do
       r.nombre_reouverture_zone_sans_danger
     end
     row t('.temps_bonnes_qualifications_dangers') do |(_, r)|
-      formate_durees r.temps_bonnes_qualifications_dangers
+      ul do
+        r.temps_bonnes_qualifications_dangers&.each do |danger, temps|
+          li "#{danger} : #{formate_duree(temps)}"
+        end
+      end
     end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,6 +42,7 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  config.hosts << "api.eva-dev"
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true

--- a/spec/models/restitution/securite/securite_helper_spec.rb
+++ b/spec/models/restitution/securite/securite_helper_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Restitution::Securite::SecuriteHelper do
+  describe '#filtre_par_danger' do
+    let(:e1) { Evenement.new donnees: { 'danger' => 'signalisation' } }
+    let(:e2) { Evenement.new donnees: { 'danger' => 'camion' } }
+
+    it 'trie les dangers par ordre alphabetique' do
+      expect(described_class.filtre_par_danger([e1, e2], &:present?).keys)
+        .to eql(%w[camion signalisation])
+    end
+  end
+end

--- a/spec/models/restitution/securite/temps_bonnes_qualification_dangers_spec.rb
+++ b/spec/models/restitution/securite/temps_bonnes_qualification_dangers_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Restitution::Securite::TempsBonnesQualificationsDangers do
+  let(:campagne) { Campagne.new }
+  let(:restitution) { Restitution::Securite.new campagne, evenements }
+
+  describe '#temps_bonnes_qualifications_dangers' do
+    context 'sans évenement' do
+      let(:evenements) { [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0))] }
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, nil, nil, nil, nil] }
+    end
+
+    context 'avec une bonne qualification' do
+      let(:evenements) do
+        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
+         build(:evenement_qualification_danger,
+               donnees: { reponse: 'bonne', danger: 'casque' },
+               date: Time.local(2019, 10, 9, 10, 2))]
+      end
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, 60, nil, nil, nil] }
+    end
+
+    context 'ignore les mauvaises qualifications' do
+      let(:evenements) do
+        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 1)),
+         build(:evenement_qualification_danger,
+               donnees: { reponse: 'mauvais', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 2))]
+      end
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, nil, nil, nil, nil] }
+    end
+
+    context 'ouverture sans qualification' do
+      let(:evenements) do
+        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1))]
+      end
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, nil, nil, nil, nil] }
+    end
+
+    context 'ignore les événements hors ouverture et qualification' do
+      let(:evenements) do
+        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone, date: Time.local(2019, 10, 9, 10, 1))]
+      end
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, nil, nil, nil, nil] }
+    end
+
+    context 'ignore les zones non dangers ouverts' do
+      let(:evenements) do
+        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone,
+               donnees: {}, date: Time.local(2019, 10, 9, 10, 1)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 2)),
+         build(:evenement_qualification_danger,
+               donnees: { reponse: 'bonne', danger: 'casque' },
+               date: Time.local(2019, 10, 9, 10, 3))]
+      end
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, 60, nil, nil, nil] }
+    end
+  end
+end

--- a/spec/models/restitution/securite/temps_bonnes_qualification_dangers_spec.rb
+++ b/spec/models/restitution/securite/temps_bonnes_qualification_dangers_spec.rb
@@ -9,7 +9,7 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
   describe '#temps_bonnes_qualifications_dangers' do
     context 'sans évenement' do
       let(:evenements) { [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0))] }
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, nil, nil, nil, nil] }
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq({}) }
     end
 
     context 'avec une bonne qualification' do
@@ -21,7 +21,7 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
                donnees: { reponse: 'bonne', danger: 'casque' },
                date: Time.local(2019, 10, 9, 10, 2))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, 60, nil, nil, nil] }
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq('casque' => 60) }
     end
 
     context 'ignore les mauvaises qualifications' do
@@ -32,7 +32,7 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
          build(:evenement_qualification_danger,
                donnees: { reponse: 'mauvais', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 2))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, nil, nil, nil, nil] }
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq({}) }
     end
 
     context 'ouverture sans qualification' do
@@ -41,7 +41,7 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
          build(:evenement_ouverture_zone,
                donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, nil, nil, nil, nil] }
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq({}) }
     end
 
     context 'ignore les événements hors ouverture et qualification' do
@@ -49,7 +49,7 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
         [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone, date: Time.local(2019, 10, 9, 10, 1))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, nil, nil, nil, nil] }
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq({}) }
     end
 
     context 'ignore les zones non dangers ouverts' do
@@ -63,7 +63,7 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
                donnees: { reponse: 'bonne', danger: 'casque' },
                date: Time.local(2019, 10, 9, 10, 3))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, 60, nil, nil, nil] }
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq('casque' => 60) }
     end
   end
 end

--- a/spec/models/restitution/securite_spec.rb
+++ b/spec/models/restitution/securite_spec.rb
@@ -257,18 +257,19 @@ describe Restitution::Securite do
   describe '#temps_bonnes_qualifications_dangers' do
     context 'sans évenement' do
       let(:evenements) { [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0))] }
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [] }
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, nil, nil, nil, nil] }
     end
 
     context 'avec une bonne qualification' do
       let(:evenements) do
         [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 1)),
+               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
          build(:evenement_qualification_danger,
-               donnees: { reponse: 'bonne', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 2))]
+               donnees: { reponse: 'bonne', danger: 'casque' },
+               date: Time.local(2019, 10, 9, 10, 2))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [60] }
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, 60, nil, nil, nil] }
     end
 
     context 'ignore les mauvaises qualifications' do
@@ -279,7 +280,7 @@ describe Restitution::Securite do
          build(:evenement_qualification_danger,
                donnees: { reponse: 'mauvais', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 2))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [] }
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, nil, nil, nil, nil] }
     end
 
     context 'ouverture sans qualification' do
@@ -288,7 +289,7 @@ describe Restitution::Securite do
          build(:evenement_ouverture_zone,
                donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [] }
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, nil, nil, nil, nil] }
     end
 
     context 'ignore les événements hors ouverture et qualification' do
@@ -296,7 +297,7 @@ describe Restitution::Securite do
         [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone, date: Time.local(2019, 10, 9, 10, 1))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [] }
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, nil, nil, nil, nil] }
     end
 
     context 'ignore les zones non dangers ouverts' do
@@ -305,11 +306,12 @@ describe Restitution::Securite do
          build(:evenement_ouverture_zone,
                donnees: {}, date: Time.local(2019, 10, 9, 10, 1)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 2)),
+               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 2)),
          build(:evenement_qualification_danger,
-               donnees: { reponse: 'bonne', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 3))]
+               donnees: { reponse: 'bonne', danger: 'casque' },
+               date: Time.local(2019, 10, 9, 10, 3))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [60] }
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, 60, nil, nil, nil] }
     end
   end
 

--- a/spec/models/restitution/securite_spec.rb
+++ b/spec/models/restitution/securite_spec.rb
@@ -254,67 +254,6 @@ describe Restitution::Securite do
     end
   end
 
-  describe '#temps_bonnes_qualifications_dangers' do
-    context 'sans évenement' do
-      let(:evenements) { [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0))] }
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, nil, nil, nil, nil] }
-    end
-
-    context 'avec une bonne qualification' do
-      let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_ouverture_zone,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
-         build(:evenement_qualification_danger,
-               donnees: { reponse: 'bonne', danger: 'casque' },
-               date: Time.local(2019, 10, 9, 10, 2))]
-      end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, 60, nil, nil, nil] }
-    end
-
-    context 'ignore les mauvaises qualifications' do
-      let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_ouverture_zone,
-               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 1)),
-         build(:evenement_qualification_danger,
-               donnees: { reponse: 'mauvais', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 2))]
-      end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, nil, nil, nil, nil] }
-    end
-
-    context 'ouverture sans qualification' do
-      let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_ouverture_zone,
-               donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1))]
-      end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, nil, nil, nil, nil] }
-    end
-
-    context 'ignore les événements hors ouverture et qualification' do
-      let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_ouverture_zone, date: Time.local(2019, 10, 9, 10, 1))]
-      end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, nil, nil, nil, nil] }
-    end
-
-    context 'ignore les zones non dangers ouverts' do
-      let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_ouverture_zone,
-               donnees: {}, date: Time.local(2019, 10, 9, 10, 1)),
-         build(:evenement_ouverture_zone,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 2)),
-         build(:evenement_qualification_danger,
-               donnees: { reponse: 'bonne', danger: 'casque' },
-               date: Time.local(2019, 10, 9, 10, 3))]
-      end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq [nil, 60, nil, nil, nil] }
-    end
-  end
-
   describe '#attention_visuo_spatiale' do
     let(:danger_visuo_spatial) { EvenementSecuriteDecorator::DANGER_VISUO_SPATIAL }
     context 'sans évenement: indéterminé' do


### PR DESCRIPTION
La liste de temps de la métrique `temps_bonne_qualifications_dangers` est une liste de 5 éléments qui donne les temps que l'évalué·e à mis pour la dernière qualification réussie pour les dangers dans l'ordre suivante : `bouche-egout casque escabeau camion signalisation`