### PR TITLE
[Securite] ajout de la métrique "temps recherche zone dangers par zone"

### DIFF
--- a/app/models/restitution/metriques.rb
+++ b/app/models/restitution/metriques.rb
@@ -3,7 +3,8 @@
 module Restitution
   class Metriques
     REGLES_SECURITE = {
-      'temps_bonnes_qualifications_dangers' => Securite::TempsBonnesQualificationsDangers
+      'temps_bonnes_qualifications_dangers' => Securite::TempsBonnesQualificationsDangers,
+      'temps_recherche_zones_dangers' => Securite::TempsRechercheZonesDangers
     }.freeze
 
     SECURITE = %i[

--- a/app/models/restitution/securite.rb
+++ b/app/models/restitution/securite.rb
@@ -77,6 +77,26 @@ module Restitution
       end
     end
 
+    ZONES_DANGER = %w[bouche-egout casque escabeau camion signalisation].freeze
+
+    def temps_recherche_zones_dangers
+      temps = []
+      ZONES_DANGER.each do |danger|
+        date_evenement_precedent = nil
+        temp = nil
+        evenements_situation.each do |e|
+          if e.demarrage? || e.qualification_danger?
+            date_evenement_precedent = e.date
+          elsif e.donnees['danger'] == danger && e.ouverture_zone_danger?
+            temp = (e.date - date_evenement_precedent)
+            break
+          end
+        end
+        temps << temp
+      end
+      temps
+    end
+
     def temps_bonnes_qualifications_dangers
       Metriques::REGLES_SECURITE['temps_bonnes_qualifications_dangers']
         .new(evenements_situation)

--- a/app/models/restitution/securite.rb
+++ b/app/models/restitution/securite.rb
@@ -77,24 +77,10 @@ module Restitution
       end
     end
 
-    ZONES_DANGER = %w[bouche-egout casque escabeau camion signalisation].freeze
-
     def temps_recherche_zones_dangers
-      temps = []
-      ZONES_DANGER.each do |danger|
-        date_evenement_precedent = nil
-        temp = nil
-        evenements_situation.each do |e|
-          if e.demarrage? || e.qualification_danger?
-            date_evenement_precedent = e.date
-          elsif e.donnees['danger'] == danger && e.ouverture_zone_danger?
-            temp = (e.date - date_evenement_precedent)
-            break
-          end
-        end
-        temps << temp
-      end
-      temps
+      Metriques::REGLES_SECURITE['temps_recherche_zones_dangers']
+        .new(evenements_situation)
+        .calcule
     end
 
     def temps_bonnes_qualifications_dangers

--- a/app/models/restitution/securite/temps_recherche_zones_dangers.rb
+++ b/app/models/restitution/securite/temps_recherche_zones_dangers.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Restitution
+  class Securite
+    class TempsRechercheZonesDangers
+      attr_reader :evenements_situation
+
+      ZONES_DANGER = %w[bouche-egout casque escabeau camion signalisation].freeze
+
+      def initialize(evenements_situation)
+        @evenements_situation = evenements_situation
+      end
+
+      def calcule
+        durees = []
+        ZONES_DANGER.each do |danger|
+          durees << duree_recherche(danger)
+        end
+        durees
+      end
+
+      private
+
+      def duree_recherche(danger)
+        date_evenement_precedent = nil
+        evenements_situation.each do |e|
+          if e.demarrage? || e.qualification_danger?
+            date_evenement_precedent = e.date
+          elsif e.donnees['danger'] == danger && e.ouverture_zone_danger?
+            return e.date - date_evenement_precedent
+          end
+        end
+        nil
+      end
+    end
+  end
+end

--- a/app/models/restitution/securite/temps_recherche_zones_dangers.rb
+++ b/app/models/restitution/securite/temps_recherche_zones_dangers.rb
@@ -5,16 +5,17 @@ module Restitution
     class TempsRechercheZonesDangers
       attr_reader :evenements_situation
 
-      ZONES_DANGER = %w[bouche-egout casque escabeau camion signalisation].freeze
+      ZONES_DANGER = %w[bouche-egout camion casque escabeau signalisation].freeze
 
       def initialize(evenements_situation)
         @evenements_situation = evenements_situation
       end
 
       def calcule
-        durees = []
+        durees = {}
         ZONES_DANGER.each do |danger|
-          durees << duree_recherche(danger)
+          duree = duree_recherche(danger)
+          durees[danger] = duree if duree.present?
         end
         durees
       end

--- a/app/views/admin/restitutions/_restitution_securite.html.arb
+++ b/app/views/admin/restitutions/_restitution_securite.html.arb
@@ -49,5 +49,12 @@ panel t('.restitution_securite') do
         end
       end
     end
+    row t('.temps_recherche_zones_dangers') do |(_, r)|
+      ul do
+        r.temps_recherche_zones_dangers&.each do |danger, temps|
+          li "#{danger} : #{formate_duree(temps)}"
+        end
+      end
+    end
   end
 end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -114,6 +114,7 @@ fr:
         retours_dangers_deja_qualifies: Retours sur les situations déjà qualifiées
         retours_zones_sans_danger: Retours sur les zones sans danger
         temps_bonnes_qualifications_dangers: Temps dernière ouverture pour les bonnes qualifications
+        temps_recherche_zones_dangers: Temps de recherche des zones de dangers
         dangers_mal_identifies: Dangers mal identifiés
         dangers_bien_identifies_avant_aide_1: Dangers bien identifiés avant activation de l'aide N°1
         temps_ouvertures_zones_dangers: Délai avant ouverture de zone de danger

--- a/spec/models/restitution/securite/temps_recherche_zones_dangers_spec.rb
+++ b/spec/models/restitution/securite/temps_recherche_zones_dangers_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Restitution::Securite::TempsRechercheZonesDangers do
+  let(:campagne) { Campagne.new }
+  let(:restitution) { Restitution::Securite.new campagne, evenements }
+
+  describe '#temps_recherche_zones_dangers' do
+    context 'sans zone danger ouverte' do
+      let(:evenements) { [] }
+      it { expect(restitution.temps_recherche_zones_dangers).to eq [nil, nil, nil, nil, nil] }
+    end
+
+    context 'une zone danger ouverte' do
+      let(:evenements) do
+        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1))]
+      end
+      it { expect(restitution.temps_recherche_zones_dangers).to eq [nil, 60, nil, nil, nil] }
+    end
+
+    context 'deux zones danger ouverts' do
+      let(:evenements) do
+        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
+         build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'camion' }, date: Time.local(2019, 10, 9, 10, 4))]
+      end
+      it { expect(restitution.temps_recherche_zones_dangers).to eq [nil, 60, nil, 120, nil] }
+    end
+
+    context 'quand on ne finit pas par une identification' do
+      let(:evenements) do
+        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
+         build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2))]
+      end
+
+      it { expect(restitution.temps_recherche_zones_dangers).to eq [nil, 60, nil, nil, nil] }
+    end
+  end
+end

--- a/spec/models/restitution/securite/temps_recherche_zones_dangers_spec.rb
+++ b/spec/models/restitution/securite/temps_recherche_zones_dangers_spec.rb
@@ -9,7 +9,7 @@ describe Restitution::Securite::TempsRechercheZonesDangers do
   describe '#temps_recherche_zones_dangers' do
     context 'sans zone danger ouverte' do
       let(:evenements) { [] }
-      it { expect(restitution.temps_recherche_zones_dangers).to eq [nil, nil, nil, nil, nil] }
+      it { expect(restitution.temps_recherche_zones_dangers).to eq({}) }
     end
 
     context 'une zone danger ouverte' do
@@ -18,7 +18,7 @@ describe Restitution::Securite::TempsRechercheZonesDangers do
          build(:evenement_ouverture_zone,
                donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1))]
       end
-      it { expect(restitution.temps_recherche_zones_dangers).to eq [nil, 60, nil, nil, nil] }
+      it { expect(restitution.temps_recherche_zones_dangers).to eq('casque' => 60) }
     end
 
     context 'deux zones danger ouverts' do
@@ -30,7 +30,14 @@ describe Restitution::Securite::TempsRechercheZonesDangers do
          build(:evenement_ouverture_zone,
                donnees: { danger: 'camion' }, date: Time.local(2019, 10, 9, 10, 4))]
       end
-      it { expect(restitution.temps_recherche_zones_dangers).to eq [nil, 60, nil, 120, nil] }
+      it 'calcule les temps de recherhce' do
+        temps = restitution.temps_recherche_zones_dangers
+        expect(temps).to eq('casque' => 60, 'camion' => 120)
+      end
+      it 'retournes les zones par ordre alphabétique' do
+        temps = restitution.temps_recherche_zones_dangers
+        expect(temps.keys).to eq(%w[camion casque])
+      end
     end
 
     context 'quand on ne finit pas par une identification' do
@@ -41,7 +48,7 @@ describe Restitution::Securite::TempsRechercheZonesDangers do
          build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2))]
       end
 
-      it { expect(restitution.temps_recherche_zones_dangers).to eq [nil, 60, nil, nil, nil] }
+      it { expect(restitution.temps_recherche_zones_dangers).to eq('casque' => 60) }
     end
   end
 end

--- a/spec/models/restitution/securite_spec.rb
+++ b/spec/models/restitution/securite_spec.rb
@@ -219,7 +219,7 @@ describe Restitution::Securite do
       it { expect(restitution.temps_moyen_ouvertures_zones_dangers).to eq 60 }
     end
 
-    context 'deux zone danger ouverts' do
+    context 'deux zones danger ouverts' do
       let(:evenements) do
         [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
@@ -251,6 +251,45 @@ describe Restitution::Securite do
          build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2))]
       end
       it { expect(restitution.temps_ouvertures_zones_dangers).to eq [60] }
+    end
+  end
+
+  describe '#temps_recherche_zones_dangers' do
+    context 'sans zone danger ouverte' do
+      let(:evenements) { [] }
+      it { expect(restitution.temps_recherche_zones_dangers).to eq [nil, nil, nil, nil, nil] }
+    end
+
+    context 'une zone danger ouverte' do
+      let(:evenements) do
+        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1))]
+      end
+      it { expect(restitution.temps_recherche_zones_dangers).to eq [nil, 60, nil, nil, nil] }
+    end
+
+    context 'deux zones danger ouverts' do
+      let(:evenements) do
+        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
+         build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'camion' }, date: Time.local(2019, 10, 9, 10, 4))]
+      end
+      it { expect(restitution.temps_recherche_zones_dangers).to eq [nil, 60, nil, 120, nil] }
+    end
+
+    context 'quand on ne finit pas par une identification' do
+      let(:evenements) do
+        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
+         build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2))]
+      end
+
+      it { expect(restitution.temps_recherche_zones_dangers).to eq [nil, 60, nil, nil, nil] }
     end
   end
 

--- a/spec/models/restitution/securite_spec.rb
+++ b/spec/models/restitution/securite_spec.rb
@@ -254,45 +254,6 @@ describe Restitution::Securite do
     end
   end
 
-  describe '#temps_recherche_zones_dangers' do
-    context 'sans zone danger ouverte' do
-      let(:evenements) { [] }
-      it { expect(restitution.temps_recherche_zones_dangers).to eq [nil, nil, nil, nil, nil] }
-    end
-
-    context 'une zone danger ouverte' do
-      let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_ouverture_zone,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1))]
-      end
-      it { expect(restitution.temps_recherche_zones_dangers).to eq [nil, 60, nil, nil, nil] }
-    end
-
-    context 'deux zones danger ouverts' do
-      let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_ouverture_zone,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
-         build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2)),
-         build(:evenement_ouverture_zone,
-               donnees: { danger: 'camion' }, date: Time.local(2019, 10, 9, 10, 4))]
-      end
-      it { expect(restitution.temps_recherche_zones_dangers).to eq [nil, 60, nil, 120, nil] }
-    end
-
-    context 'quand on ne finit pas par une identification' do
-      let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_ouverture_zone,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
-         build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2))]
-      end
-
-      it { expect(restitution.temps_recherche_zones_dangers).to eq [nil, 60, nil, nil, nil] }
-    end
-  end
-
   describe '#attention_visuo_spatiale' do
     let(:danger_visuo_spatial) { EvenementSecuriteDecorator::DANGER_VISUO_SPATIAL }
     context 'sans évenement: indéterminé' do


### PR DESCRIPTION
<img width="571" alt="Capture d’écran 2020-01-20 à 11 08 57" src="https://user-images.githubusercontent.com/298214/72717958-4c90ec80-3b75-11ea-8d38-18d681a1f7e2.png">
