### PR TITLE
[Securite] temps_de_bonne_qualifications_danger: retourne le premier 

### DIFF
--- a/app/models/restitution/securite/temps_bonnes_qualifications_dangers.rb
+++ b/app/models/restitution/securite/temps_bonnes_qualifications_dangers.rb
@@ -13,7 +13,7 @@ module Restitution
         temps_par_danger = {}
         evenements_par_danger.each do |danger, les_evenements|
           temps = MetriquesHelper.temps_entre_couples les_evenements
-          temps_par_danger[danger] = temps.last if temps.last.present?
+          temps_par_danger[danger] = temps.first if temps.first.present?
         end
         temps_par_danger
       end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -113,7 +113,7 @@ fr:
         dangers_bien_identifies: Dangers bien identifiés
         retours_dangers_deja_qualifies: Retours sur les situations déjà qualifiées
         retours_zones_sans_danger: Retours sur les zones sans danger
-        temps_bonnes_qualifications_dangers: Temps dernière ouverture pour les bonnes qualifications
+        temps_bonnes_qualifications_dangers: Temps ouverture de la première bonne qualification
         temps_recherche_zones_dangers: Temps de recherche des zones de dangers
         dangers_mal_identifies: Dangers mal identifiés
         dangers_bien_identifies_avant_aide_1: Dangers bien identifiés avant activation de l'aide N°1

--- a/spec/models/restitution/securite/temps_bonnes_qualification_dangers_spec.rb
+++ b/spec/models/restitution/securite/temps_bonnes_qualification_dangers_spec.rb
@@ -24,7 +24,7 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
       it { expect(restitution.temps_bonnes_qualifications_dangers).to eq('casque' => 60) }
     end
 
-    context 'avec deux bonnes qualifications pour des danges différents' do
+    context 'avec deux bonnes qualifications pour des dangers différents' do
       let(:evenements) do
         [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
@@ -75,6 +75,36 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
       it { expect(restitution.temps_bonnes_qualifications_dangers).to eq({}) }
     end
 
+    context 'ignore les mauvaises qualifications précédant une bonne qualification' do
+      let(:evenements) do
+        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 1)),
+         build(:evenement_qualification_danger,
+               donnees: { reponse: 'mauvais', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 2)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 3)),
+         build(:evenement_qualification_danger,
+               donnees: { reponse: 'bonne', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 5))]
+      end
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq('d1' => 120) }
+    end
+
+    context 'ignore les mauvaises qualifications même suivant une bonne qualification' do
+      let(:evenements) do
+        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 1)),
+         build(:evenement_qualification_danger,
+               donnees: { reponse: 'bonne', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 2)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 3)),
+         build(:evenement_qualification_danger,
+               donnees: { reponse: 'mauvais', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 5))]
+      end
+      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq('d1' => 60) }
+    end
+
     context 'ouverture sans qualification' do
       let(:evenements) do
         [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
@@ -92,7 +122,7 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
       it { expect(restitution.temps_bonnes_qualifications_dangers).to eq({}) }
     end
 
-    context 'ignore les zones non dangers ouverts' do
+    context 'ignore les zones non dangers ouvertes' do
       let(:evenements) do
         [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,

--- a/spec/models/restitution/securite/temps_bonnes_qualification_dangers_spec.rb
+++ b/spec/models/restitution/securite/temps_bonnes_qualification_dangers_spec.rb
@@ -24,6 +24,46 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
       it { expect(restitution.temps_bonnes_qualifications_dangers).to eq('casque' => 60) }
     end
 
+    context 'avec deux bonnes qualifications pour des danges différents' do
+      let(:evenements) do
+        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
+         build(:evenement_qualification_danger,
+               donnees: { reponse: 'bonne', danger: 'casque' },
+               date: Time.local(2019, 10, 9, 10, 2)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'camion' }, date: Time.local(2019, 10, 9, 10, 3)),
+         build(:evenement_qualification_danger,
+               donnees: { reponse: 'bonne', danger: 'camion' },
+               date: Time.local(2019, 10, 9, 10, 5))]
+      end
+      it do
+        temps = restitution.temps_bonnes_qualifications_dangers
+        expect(temps).to eq('casque' => 60, 'camion' => 120)
+      end
+    end
+
+    context 'avec deux bonnes qualifications pour le même danger, on prend la première' do
+      let(:evenements) do
+        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
+         build(:evenement_qualification_danger,
+               donnees: { reponse: 'bonne', danger: 'casque' },
+               date: Time.local(2019, 10, 9, 10, 2)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 3)),
+         build(:evenement_qualification_danger,
+               donnees: { reponse: 'bonne', danger: 'casque' },
+               date: Time.local(2019, 10, 9, 10, 5))]
+      end
+      it do
+        temps = restitution.temps_bonnes_qualifications_dangers
+        expect(temps).to eq('casque' => 60)
+      end
+    end
+
     context 'ignore les mauvaises qualifications' do
       let(:evenements) do
         [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),


### PR DESCRIPTION
En cas de plusieurs bonne qualification d'un même danger, on retourne la
première tentative et non la dernière

Cette PR ajoute aussi deux spécifications pour préciser le comportement en cas de mauvaise qualification.