### PR TITLE
Restitution maintenance/affiche le nombre d'erreurs

### DIFF
--- a/app/models/restitution/maintenance.rb
+++ b/app/models/restitution/maintenance.rb
@@ -2,5 +2,10 @@
 
 module Restitution
   class Maintenance < AvecEntrainement
+    def nombre_erreurs
+      Metriques::MAINTENANCE['nombre_erreurs']
+        .new(evenements_situation)
+        .calcule
+    end
   end
 end

--- a/app/models/restitution/maintenance/nombre_erreurs.rb
+++ b/app/models/restitution/maintenance/nombre_erreurs.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Restitution
+  class Maintenance
+    class NombreErreurs
+      attr_reader :evenements_situation
+
+      EVENEMENT = {
+        NOM_MOT: 'non-mot',
+        REPONSE_NON_FRANCAIS: 'pasfrancais',
+        REPONSE_FRANCAIS: 'francais'
+      }.freeze
+
+      def initialize(evenements_situation)
+        @evenements_situation = evenements_situation
+      end
+
+      def calcule
+        evenements_situation.keep_if do |e|
+          mauvaises_reponses(e)
+        end.count
+      end
+
+      private
+
+      def mauvaises_reponses(evt)
+        mot_pas_francais_reponse_francais?(evt) ||
+          mot_francais_reponse_non_francais?(evt)
+      end
+
+      def mot_pas_francais_reponse_francais?(evt)
+        (evt.donnees['type'] == EVENEMENT[:NOM_MOT]) &&
+          (evt.donnees['reponse'] == EVENEMENT[:REPONSE_FRANCAIS])
+      end
+
+      def mot_francais_reponse_non_francais?(evt)
+        (evt.donnees['type'] != EVENEMENT[:NOM_MOT]) &&
+          (evt.donnees['reponse'] == EVENEMENT[:REPONSE_NON_FRANCAIS])
+      end
+    end
+  end
+end

--- a/app/models/restitution/metriques.rb
+++ b/app/models/restitution/metriques.rb
@@ -19,5 +19,9 @@ module Restitution
       'nombre_rejoue_consigne' => Securite,
       'nombre_danger_mal_identifies' => Securite
     }.freeze
+
+    MAINTENANCE = {
+      'nombre_erreurs' => Maintenance::NombreErreurs
+    }.freeze
   end
 end

--- a/app/views/admin/restitutions/_restitution_maintenance.html.arb
+++ b/app/views/admin/restitutions/_restitution_maintenance.html.arb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+panel t('.restitution_maintenance') do
+  attributes_table_for restitution do
+    row t('.nombre_erreurs'), &:nombre_erreurs
+  end
+end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -121,3 +121,6 @@ fr:
         delai_ouvertures_zones_dangers: Délai avant ouverture de zone de danger
         delai_moyen_ouvertures_zones_dangers: Délai moyen avant ouverture de zone de danger
         attention_visuo_spatiale: Attention visuo-spatiale
+      restitution_maintenance:
+        restitution_maintenance: Restitution de la situation maintenance
+        nombre_erreurs: "Nombre d'erreurs"

--- a/spec/factories/evenement.rb
+++ b/spec/factories/evenement.rb
@@ -87,5 +87,21 @@ FactoryBot.define do
     factory :evenement_ouverture_zone do
       nom { 'ouvertureZone' }
     end
+
+    factory :evenement_identification_mot do
+      nom { 'identificationMot' }
+
+      trait :bon do
+        donnees { { type: 'non-mot', reponse: 'pasfrancais' } }
+      end
+
+      trait :mauvais do
+        donnees { { type: 'non-mot', reponse: 'francais' } }
+      end
+
+      trait :non_reponse do
+        donnees { { type: 'non-mot' } }
+      end
+    end
   end
 end

--- a/spec/models/restitution/maintenance/nombre_erreurs_spec.rb
+++ b/spec/models/restitution/maintenance/nombre_erreurs_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Restitution::Maintenance::NombreErreurs do
+  let(:campagne) { Campagne.new }
+  let(:restitution) { Restitution::Maintenance.new campagne, evenements }
+
+  describe '#nombre_erreurs' do
+    context "aucun événement d'identification" do
+      let(:evenements) do
+        [
+          build(:evenement_demarrage)
+        ]
+      end
+      it { expect(restitution.nombre_erreurs).to eq 0 }
+    end
+
+    context 'avec une bonne réponse' do
+      let(:evenements) do
+        [
+          build(:evenement_demarrage),
+          build(:evenement_identification_mot, :bon)
+        ]
+      end
+      it { expect(restitution.nombre_erreurs).to eq 0 }
+    end
+
+    context 'avec une non réponse' do
+      let(:evenements) do
+        [
+          build(:evenement_demarrage),
+          build(:evenement_identification_mot, :non_reponse)
+        ]
+      end
+      it { expect(restitution.nombre_erreurs).to eq 0 }
+    end
+
+    context 'avec une mauvaise réponse' do
+      let(:evenements) do
+        [
+          build(:evenement_demarrage),
+          build(:evenement_identification_mot, :mauvais)
+        ]
+      end
+      it { expect(restitution.nombre_erreurs).to eq 1 }
+    end
+  end
+end


### PR DESCRIPTION
Ajoute la métrique `nombre d'erreurs` dans la restitution de la situation Maintenance.

Contribue à https://github.com/betagouv/eva/issues/740