### PR TITLE
Restitution maintenance/affiche les non réponses

### DIFF
--- a/app/models/evenement_maintenance_decorator.rb
+++ b/app/models/evenement_maintenance_decorator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class EvenementMaintenanceDecorator < SimpleDelegator
+  EVENEMENT = {
+    NON_MOT: 'non-mot',
+    REPONSE_NON_FRANCAIS: 'pasfrancais',
+    REPONSE_FRANCAIS: 'francais',
+    IDENTIFICATION: 'identificationMot'
+  }.freeze
+
+  def type_non_mot
+    donnees['type'] == EVENEMENT[:NON_MOT]
+  end
+
+  def type_mot_francais
+    donnees['type'] != EVENEMENT[:NON_MOT]
+  end
+
+  def reponse_francais
+    donnees['reponse'] == EVENEMENT[:REPONSE_FRANCAIS]
+  end
+
+  def reponse_non_francais
+    donnees['reponse'] == EVENEMENT[:REPONSE_NON_FRANCAIS]
+  end
+
+  def identification_mot
+    nom == EVENEMENT[:IDENTIFICATION]
+  end
+end

--- a/app/models/restitution/maintenance.rb
+++ b/app/models/restitution/maintenance.rb
@@ -2,8 +2,13 @@
 
 module Restitution
   class Maintenance < AvecEntrainement
-    def nombre_erreurs
-      Metriques::MAINTENANCE['nombre_erreurs']
+    def initialize(campagne, evenements)
+      evenements = evenements.map { |e| EvenementMaintenanceDecorator.new e }
+      super(campagne, evenements)
+    end
+
+    def metrique(nom)
+      Metriques::MAINTENANCE[nom]
         .new(evenements_situation)
         .calcule
     end

--- a/app/models/restitution/maintenance/nombre_erreurs.rb
+++ b/app/models/restitution/maintenance/nombre_erreurs.rb
@@ -5,18 +5,12 @@ module Restitution
     class NombreErreurs
       attr_reader :evenements_situation
 
-      EVENEMENT = {
-        NOM_MOT: 'non-mot',
-        REPONSE_NON_FRANCAIS: 'pasfrancais',
-        REPONSE_FRANCAIS: 'francais'
-      }.freeze
-
       def initialize(evenements_situation)
         @evenements_situation = evenements_situation
       end
 
       def calcule
-        evenements_situation.keep_if do |e|
+        evenements_situation.select do |e|
           mauvaises_reponses(e)
         end.count
       end
@@ -29,13 +23,13 @@ module Restitution
       end
 
       def mot_pas_francais_reponse_francais?(evt)
-        (evt.donnees['type'] == EVENEMENT[:NOM_MOT]) &&
-          (evt.donnees['reponse'] == EVENEMENT[:REPONSE_FRANCAIS])
+        evt.type_non_mot &&
+          evt.reponse_francais
       end
 
       def mot_francais_reponse_non_francais?(evt)
-        (evt.donnees['type'] != EVENEMENT[:NOM_MOT]) &&
-          (evt.donnees['reponse'] == EVENEMENT[:REPONSE_NON_FRANCAIS])
+        evt.type_mot_francais &&
+          evt.reponse_non_francais
       end
     end
   end

--- a/app/models/restitution/maintenance/nombre_non_reponses.rb
+++ b/app/models/restitution/maintenance/nombre_non_reponses.rb
@@ -5,16 +5,12 @@ module Restitution
     class NombreNonReponses
       attr_reader :evenements_situation
 
-      EVENEMENT = {
-        IDENTIFICATION: 'identificationMot'
-      }.freeze
-
       def initialize(evenements_situation)
         @evenements_situation = evenements_situation
       end
 
       def calcule
-        evenements_situation.keep_if do |e|
+        evenements_situation.select do |e|
           non_reponse?(e)
         end.count
       end
@@ -23,7 +19,7 @@ module Restitution
 
       def non_reponse?(evt)
         evt.donnees['reponse'].nil? &&
-          evt['nom'] == EVENEMENT[:IDENTIFICATION]
+          evt.identification_mot
       end
     end
   end

--- a/app/models/restitution/maintenance/nombre_non_reponses.rb
+++ b/app/models/restitution/maintenance/nombre_non_reponses.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Restitution
+  class Maintenance
+    class NombreNonReponses
+      attr_reader :evenements_situation
+
+      EVENEMENT = {
+        IDENTIFICATION: 'identificationMot'
+      }.freeze
+
+      def initialize(evenements_situation)
+        @evenements_situation = evenements_situation
+      end
+
+      def calcule
+        evenements_situation.keep_if do |e|
+          non_reponse?(e)
+        end.count
+      end
+
+      private
+
+      def non_reponse?(evt)
+        evt.donnees['reponse'].nil? &&
+          evt['nom'] == EVENEMENT[:IDENTIFICATION]
+      end
+    end
+  end
+end

--- a/app/models/restitution/metriques.rb
+++ b/app/models/restitution/metriques.rb
@@ -21,7 +21,8 @@ module Restitution
     }.freeze
 
     MAINTENANCE = {
-      'nombre_erreurs' => Maintenance::NombreErreurs
+      'nombre_erreurs' => Maintenance::NombreErreurs,
+      'nombre_non_reponses' => Maintenance::NombreNonReponses
     }.freeze
   end
 end

--- a/app/views/admin/restitutions/_restitution_maintenance.html.arb
+++ b/app/views/admin/restitutions/_restitution_maintenance.html.arb
@@ -2,6 +2,10 @@
 
 panel t('.restitution_maintenance') do
   attributes_table_for restitution do
-    row t('.nombre_erreurs'), &:nombre_erreurs
+    Restitution::Metriques::MAINTENANCE.keys.each do |metrique|
+      row t(".#{metrique}") do |r|
+        r.metrique(metrique.to_s)
+      end
+    end
   end
 end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -124,3 +124,4 @@ fr:
       restitution_maintenance:
         restitution_maintenance: Restitution de la situation maintenance
         nombre_erreurs: "Nombre d'erreurs"
+        nombre_non_reponses: "Nombre de non réponses"

--- a/spec/models/restitution/maintenance/nombre_erreurs_spec.rb
+++ b/spec/models/restitution/maintenance/nombre_erreurs_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 
 describe Restitution::Maintenance::NombreErreurs do
   let(:campagne) { Campagne.new }
-  let(:restitution) { Restitution::Maintenance.new campagne, evenements }
+  let(:metrique_nombre_erreurs) do
+    described_class.new(evenements_decores(evenements)).calcule
+  end
 
   describe '#metrique nombre_erreurs' do
     context "aucun événement d'identification" do
@@ -13,7 +15,7 @@ describe Restitution::Maintenance::NombreErreurs do
           build(:evenement_demarrage)
         ]
       end
-      it { expect(restitution.metrique('nombre_erreurs')).to eq 0 }
+      it { expect(metrique_nombre_erreurs).to eq 0 }
     end
 
     context 'avec une bonne réponse' do
@@ -23,7 +25,7 @@ describe Restitution::Maintenance::NombreErreurs do
           build(:evenement_identification_mot, :bon)
         ]
       end
-      it { expect(restitution.metrique('nombre_erreurs')).to eq 0 }
+      it { expect(metrique_nombre_erreurs).to eq 0 }
     end
 
     context 'avec une non réponse' do
@@ -33,7 +35,7 @@ describe Restitution::Maintenance::NombreErreurs do
           build(:evenement_identification_mot, :non_reponse)
         ]
       end
-      it { expect(restitution.metrique('nombre_erreurs')).to eq 0 }
+      it { expect(metrique_nombre_erreurs).to eq 0 }
     end
 
     context 'avec une mauvaise réponse' do
@@ -43,7 +45,7 @@ describe Restitution::Maintenance::NombreErreurs do
           build(:evenement_identification_mot, :mauvais)
         ]
       end
-      it { expect(restitution.metrique('nombre_erreurs')).to eq 1 }
+      it { expect(metrique_nombre_erreurs).to eq 1 }
     end
   end
 end

--- a/spec/models/restitution/maintenance/nombre_erreurs_spec.rb
+++ b/spec/models/restitution/maintenance/nombre_erreurs_spec.rb
@@ -6,14 +6,14 @@ describe Restitution::Maintenance::NombreErreurs do
   let(:campagne) { Campagne.new }
   let(:restitution) { Restitution::Maintenance.new campagne, evenements }
 
-  describe '#nombre_erreurs' do
+  describe '#metrique nombre_erreurs' do
     context "aucun événement d'identification" do
       let(:evenements) do
         [
           build(:evenement_demarrage)
         ]
       end
-      it { expect(restitution.nombre_erreurs).to eq 0 }
+      it { expect(restitution.metrique('nombre_erreurs')).to eq 0 }
     end
 
     context 'avec une bonne réponse' do
@@ -23,7 +23,7 @@ describe Restitution::Maintenance::NombreErreurs do
           build(:evenement_identification_mot, :bon)
         ]
       end
-      it { expect(restitution.nombre_erreurs).to eq 0 }
+      it { expect(restitution.metrique('nombre_erreurs')).to eq 0 }
     end
 
     context 'avec une non réponse' do
@@ -33,7 +33,7 @@ describe Restitution::Maintenance::NombreErreurs do
           build(:evenement_identification_mot, :non_reponse)
         ]
       end
-      it { expect(restitution.nombre_erreurs).to eq 0 }
+      it { expect(restitution.metrique('nombre_erreurs')).to eq 0 }
     end
 
     context 'avec une mauvaise réponse' do
@@ -43,7 +43,7 @@ describe Restitution::Maintenance::NombreErreurs do
           build(:evenement_identification_mot, :mauvais)
         ]
       end
-      it { expect(restitution.nombre_erreurs).to eq 1 }
+      it { expect(restitution.metrique('nombre_erreurs')).to eq 1 }
     end
   end
 end

--- a/spec/models/restitution/maintenance/nombre_non_reponse_spec.rb
+++ b/spec/models/restitution/maintenance/nombre_non_reponse_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Restitution::Maintenance::NombreNonReponses do
+  let(:campagne) { Campagne.new }
+  let(:restitution) { Restitution::Maintenance.new campagne, evenements }
+
+  describe '#metrique nombre_non_reponses' do
+    context "aucun événement d'identification" do
+      let(:evenements) do
+        [
+          build(:evenement_demarrage)
+        ]
+      end
+      it { expect(restitution.metrique('nombre_non_reponses')).to eq 0 }
+    end
+
+    context 'avec une non réponse' do
+      let(:evenements) do
+        [
+          build(:evenement_demarrage),
+          build(:evenement_identification_mot, :non_reponse)
+        ]
+      end
+      it { expect(restitution.metrique('nombre_non_reponses')).to eq 1 }
+    end
+
+    context 'avec une réponse' do
+      let(:evenements) do
+        [
+          build(:evenement_demarrage),
+          build(:evenement_identification_mot, :bon)
+        ]
+      end
+      it { expect(restitution.metrique('nombre_non_reponses')).to eq 0 }
+    end
+  end
+end

--- a/spec/models/restitution/maintenance/nombre_non_reponse_spec.rb
+++ b/spec/models/restitution/maintenance/nombre_non_reponse_spec.rb
@@ -4,7 +4,10 @@ require 'rails_helper'
 
 describe Restitution::Maintenance::NombreNonReponses do
   let(:campagne) { Campagne.new }
-  let(:restitution) { Restitution::Maintenance.new campagne, evenements }
+  let(:campagne) { Campagne.new }
+  let(:metrique_nombre_erreurs) do
+    described_class.new(evenements_decores(evenements)).calcule
+  end
 
   describe '#metrique nombre_non_reponses' do
     context "aucun événement d'identification" do
@@ -13,7 +16,7 @@ describe Restitution::Maintenance::NombreNonReponses do
           build(:evenement_demarrage)
         ]
       end
-      it { expect(restitution.metrique('nombre_non_reponses')).to eq 0 }
+      it { expect(metrique_nombre_erreurs).to eq 0 }
     end
 
     context 'avec une non réponse' do
@@ -23,7 +26,7 @@ describe Restitution::Maintenance::NombreNonReponses do
           build(:evenement_identification_mot, :non_reponse)
         ]
       end
-      it { expect(restitution.metrique('nombre_non_reponses')).to eq 1 }
+      it { expect(metrique_nombre_erreurs).to eq 1 }
     end
 
     context 'avec une réponse' do
@@ -33,7 +36,7 @@ describe Restitution::Maintenance::NombreNonReponses do
           build(:evenement_identification_mot, :bon)
         ]
       end
-      it { expect(restitution.metrique('nombre_non_reponses')).to eq 0 }
+      it { expect(metrique_nombre_erreurs).to eq 0 }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,4 +48,8 @@ RSpec.configure do |config|
     click_on 'Se connecter'
     compte
   end
+
+  def evenements_decores(evenements)
+    evenements.map { |e| EvenementMaintenanceDecorator.new e }
+  end
 end


### PR DESCRIPTION
Contribue à https://github.com/betagouv/eva/issues/740

- affiche les non réponses
- introduit un `EvenementMaintenanceDecorator`

Fait suite à une discussion avec Alexis:

` on aimerait pouvoir les distinguer dans un premier temps pour savoir si les non-réponses concernent toujours les mêmes mots (et peut-être revoir la tâche). En gros on voudrait un compteur différent pour les non-réponses et les erreurs`