### PR TITLE
Supprime les compteurs d'évaluations dans le dashboard pour mettre les dernières évaluations.

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -10,18 +10,11 @@ ActiveAdmin.register_page 'Dashboard' do
                   Campagne.where(compte: current_compte)
                 end
 
-    evaluations = Evaluation.where(campagne: campagnes)
-    debut_aujourdhui = Date.current.beginning_of_day
-    interval_hier = Date.yesterday.beginning_of_day..debut_aujourdhui
-    nombre_evaluations_total = evaluations.count
-    nombre_evaluations_hier = evaluations.where('created_at' => interval_hier).count
-    nombre_evaluations_aujourdhui = evaluations.where('created_at > ?', debut_aujourdhui).count
+    evaluations = Evaluation.where(campagne: campagnes).order(created_at: :desc).limit(10)
 
     render partial: 'dashboard',
            locals: {
-             total: nombre_evaluations_total,
-             hier: nombre_evaluations_hier,
-             aujourdhui: nombre_evaluations_aujourdhui
+             evaluations: evaluations
            }
   end
 end

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -36,17 +36,3 @@
     background-color: gray;
   }
 }
-
-.compteurs {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  .compteur {
-    display: flex;
-    flex:1;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
-  }
-}

--- a/app/views/admin/dashboard/_dashboard.html.arb
+++ b/app/views/admin/dashboard/_dashboard.html.arb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-panel t('.nombre_evaluations.titre') do
-  div class: 'compteurs' do
-    { hier: hier, aujourdhui: aujourdhui, total: total }.each do |clef, valeur|
-      div class: 'compteur' do
-        h1 valeur
-        span t(".nombre_evaluations.#{clef}")
+panel t('.dernieres_evaluations.titre') do
+  ul do
+    evaluations.each do |evaluation|
+      li do
+        text_node link_to evaluation.nom,
+                          admin_campagne_evaluation_path(evaluation.campagne, evaluation)
+        text_node ' il y a '
+        text_node time_ago_in_words(evaluation.created_at)
       end
     end
   end

--- a/config/locales/views/dashboard.yml
+++ b/config/locales/views/dashboard.yml
@@ -2,6 +2,5 @@ fr:
   admin:
     dashboard:
       dashboard:
-        nombre_evaluations:
-          titre: Nombre d'évaluations
-          total: Total
+        dernieres_evaluations:
+          titre: Dernières évaluations


### PR DESCRIPTION
Maintenant que nous avons metabase pour afficher des stats, nous pouvons supprimer les compteurs du tableau de bord de l'admin pour tenter de rendre celui ci plus pratique.

Dans un premier temps, je propose de lister les 10 dernières évaluations réalisé dans les campagnes de la personne connectée.

![Screenshot_2020-02-04 Tableau de bord eva](https://user-images.githubusercontent.com/86659/73752795-db029200-4761-11ea-9ced-b991eef01ae7.png)
