### PR TITLE
Ajoute l'API pour récupérer un questionnaire

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ L'api est accessible au point `/api`
 }
 ```
 
+### Récupére des informations sur un questionnaire
+
+**Requête**
+
+`GET /api/questionnaires/:id`
+
+**Réponse**
+
+```
+[
+  {
+    id: 1,
+    type: 'qcm',
+    intitule: 'Ma question',
+    description: 'Ma description',
+    choix: []
+  }
+]
+```
+
 ### Crée un événement
 
 `POST /api/evenements`

--- a/app/controllers/api/questionnaires_controller.rb
+++ b/app/controllers/api/questionnaires_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  class QuestionnairesController < ActionController::API
+    rescue_from ActiveRecord::RecordNotFound do
+      render status: :not_found
+    end
+
+    def show
+      questionnaire = Questionnaire.find(params[:id])
+      render json: questionnaire.questions
+    end
+  end
+end

--- a/app/models/situation.rb
+++ b/app/models/situation.rb
@@ -10,6 +10,6 @@ class Situation < ApplicationRecord
   end
 
   def as_json(_options = nil)
-    slice(:id, :libelle, :nom_technique)
+    slice(:id, :libelle, :nom_technique, :questionnaire_id)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :evaluations, only: [:create, :show]
+    resources :questionnaires, only: [:show]
     resources :evenements
   end
 end

--- a/spec/requests/questionnaires_spec.rb
+++ b/spec/requests/questionnaires_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Questionnaires API', type: :request do
+  describe 'GET /questionnaires/:id' do
+    let(:question) { create :question_qcm, intitule: 'Ma question' }
+    let(:questionnaire) { create :questionnaire, questions: [question] }
+
+    it 'retourne les questions' do
+      get "/api/questionnaires/#{questionnaire.id}"
+
+      expect(response).to be_ok
+      expect(JSON.parse(response.body).size).to eql(1)
+    end
+
+    it "retourne une 404 lorsque le questionnaire n'existe pas" do
+      get '/api/questionnaires/404'
+
+      expect(response).to have_http_status(404)
+    end
+  end
+end


### PR DESCRIPTION
Dans l'évaluation, on sérialise désormais un éventuel id de questionnaire. De cette façon, on va pouvoir récupérer les questions associés coté client

Dépendant de https://github.com/betagouv/eva-serveur/pull/329

Contribue à https://github.com/betagouv/eva/issues/745