### PR TITLE
Ajoute un bouton pour recalculer et repersister les métriques de situations

### DIFF
--- a/app/admin/situations.rb
+++ b/app/admin/situations.rb
@@ -13,4 +13,20 @@ ActiveAdmin.register Situation do
     end
     f.actions
   end
+
+  action_item :lien_recalcule, only: :show, priority: 0 do
+    link_to I18n.t('admin.situations.recalcul_metriques.lien'),
+            recalcule_metriques_admin_situation_path(resource),
+            method: :post
+  end
+
+  member_action :recalcule_metriques, method: :post do
+    Partie
+      .where(situation: resource)
+      .where.not(metriques: {})
+      .find_each(&:persiste_restitution)
+
+    redirect_to admin_situation_path(resource),
+                notice: I18n.t('admin.situations.recalcul_metriques.fait')
+  end
 end

--- a/config/locales/views/situations.yml
+++ b/config/locales/views/situations.yml
@@ -1,0 +1,6 @@
+fr:
+  admin:
+    situations:
+      recalcul_metriques:
+        lien: Recalcule les métriques
+        fait: Métriques recalculées

--- a/spec/features/situation_spec.rb
+++ b/spec/features/situation_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 
 describe 'Admin - Situation', type: :feature do
   before { se_connecter_comme_administrateur }
+  let!(:tri) { create :situation_tri, libelle: 'Situation Tri' }
 
   describe 'index' do
-    let!(:tri) { create :situation_tri, libelle: 'Situation Tri' }
     before { visit admin_situations_path }
     it { expect(page).to have_content 'Situation Tri' }
   end
@@ -19,5 +19,22 @@ describe 'Admin - Situation', type: :feature do
     end
 
     it { expect { click_on 'Créer' }.to(change { Situation.count }) }
+  end
+
+  describe 'recalcule_metriques' do
+    let(:evaluation) { create :evaluation }
+    let!(:partie) do
+      create :partie,
+             evaluation: evaluation,
+             situation: tri,
+             metriques: { test: 'test' }
+    end
+
+    before { visit admin_situation_path(tri) }
+
+    it {
+      expect_any_instance_of(Partie).to receive(:persiste_restitution)
+      click_on 'Recalcule les métriques'
+    }
   end
 end


### PR DESCRIPTION
![Screenshot_2020-02-10 Sécurité eva](https://user-images.githubusercontent.com/86659/74135584-d835f000-4bec-11ea-9cf1-c4c641c74320.png)

Fix https://github.com/betagouv/eva/issues/739