### PR TITLE
Maintenance: persiste les restitutions et affiche la moyenne et l'écart type glissant et la cote Z

### DIFF
--- a/app/models/restitution/maintenance.rb
+++ b/app/models/restitution/maintenance.rb
@@ -7,10 +7,19 @@ module Restitution
       super(campagne, evenements)
     end
 
-    def metrique(nom)
-      Metriques::MAINTENANCE[nom]
-        .new(evenements_situation)
-        .calcule
+    Restitution::Metriques::MAINTENANCE.keys.each do |metrique|
+      define_method metrique do
+        Metriques::MAINTENANCE[metrique]
+          .new(evenements_situation)
+          .calcule
+      end
+    end
+
+    def persiste
+      metriques = Metriques::MAINTENANCE.keys.each_with_object({}) do |nom_metrique, memo|
+        memo[nom_metrique] = public_send(nom_metrique)
+      end
+      partie.update(metriques: metriques)
     end
   end
 end

--- a/app/views/admin/restitutions/_restitution_maintenance.html.arb
+++ b/app/views/admin/restitutions/_restitution_maintenance.html.arb
@@ -1,10 +1,18 @@
 # frozen_string_literal: true
 
 panel t('.restitution_maintenance') do
-  attributes_table_for restitution do
+  attributes_table_for [
+    [t('admin.restitutions.restitution_colonnes.valeur_utilisateur'), restitution],
+    [t('admin.restitutions.restitution_colonnes.moyenne_glissante'), moyenne_glissante],
+    [t('admin.restitutions.restitution_colonnes.ecart_type_glissant'), ecart_type_glissant],
+    [t('admin.restitutions.restitution_colonnes.cote_z'), cote_z]
+  ] do
+    row do |(titre, _)|
+      strong titre
+    end
     Restitution::Metriques::MAINTENANCE.keys.each do |metrique|
-      row t(".#{metrique}") do |r|
-        r.metrique(metrique.to_s)
+      row t(".#{metrique}") do |(_, r)|
+        r.public_send(metrique)
       end
     end
   end

--- a/app/views/admin/restitutions/_restitution_securite.html.arb
+++ b/app/views/admin/restitutions/_restitution_securite.html.arb
@@ -2,10 +2,10 @@
 
 panel t('.restitution_securite') do
   attributes_table_for [
-    [t('.valeur_utilisateur'), restitution],
-    [t('.moyenne_glissante'), moyenne_glissante],
-    [t('.ecart_type_glissant'), ecart_type_glissant],
-    [t('.cote_z'), cote_z]
+    [t('admin.restitutions.restitution_colonnes.valeur_utilisateur'), restitution],
+    [t('admin.restitutions.restitution_colonnes.moyenne_glissante'), moyenne_glissante],
+    [t('admin.restitutions.restitution_colonnes.ecart_type_glissant'), ecart_type_glissant],
+    [t('admin.restitutions.restitution_colonnes.cote_z'), cote_z]
   ] do
     row do |(titre, _)|
       strong titre

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -103,10 +103,6 @@ fr:
         question: Question
         reponse: Réponse
       restitution_securite:
-        cote_z: Cote Z
-        valeur_utilisateur: Valeur de l'évalué·e
-        moyenne_glissante: Moyenne glissante
-        ecart_type_glissant: Écart type glissant
         restitution_securite: Restitution de la situation sécurité
         temps_entrainement: Temps passé dans l'entrainement
         dangers_bien_qualifies: Dangers bien qualifiés
@@ -126,3 +122,8 @@ fr:
         nombre_erreurs: "Nombre d'erreurs"
         nombre_non_reponses: "Nombre de non réponses"
         temps_moyen_non_mots: "Temps moyen de réponse correcte non-mots (en secondes)"
+      restitution_colonnes:
+        cote_z: Cote Z
+        valeur_utilisateur: Valeur de l'évalué·e
+        moyenne_glissante: Moyenne glissante
+        ecart_type_glissant: Écart type glissant

--- a/spec/factories/situation.rb
+++ b/spec/factories/situation.rb
@@ -21,5 +21,10 @@ FactoryBot.define do
       libelle { 'Sécurite' }
       nom_technique { 'securite' }
     end
+
+    factory :situation_maintenance do
+      libelle { 'Maintenance' }
+      nom_technique { 'maintenance' }
+    end
   end
 end

--- a/spec/models/restitution/maintenance_spec.rb
+++ b/spec/models/restitution/maintenance_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Restitution::Maintenance do
+  describe '#persiste' do
+    context "persiste l'ensemble des données de sécurité" do
+      let(:campagne) { Campagne.new }
+      let(:restitution) { described_class.new campagne, evenements }
+
+      let(:situation) { create :situation_maintenance }
+      let(:evaluation) { create :evaluation, campagne: campagne }
+      let!(:partie) { create :partie, situation: situation, evaluation: evaluation }
+      let(:evenements) do
+        [build(:evenement_demarrage)]
+      end
+
+      it do
+        expect(restitution).to receive(:nombre_erreurs).and_return 1
+        expect(restitution).to receive(:nombre_non_reponses).and_return 2
+        restitution.persiste
+        partie.reload
+        expect(partie.metriques['nombre_erreurs']).to eq 1
+        expect(partie.metriques['nombre_non_reponses']).to eq 2
+      end
+    end
+  end
+end

--- a/spec/models/restitution/securite_spec.rb
+++ b/spec/models/restitution/securite_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe Restitution::Securite do
   let(:campagne) { Campagne.new }
-  let(:restitution) { Restitution::Securite.new campagne, evenements }
+  let(:restitution) { described_class.new campagne, evenements }
 
   describe '#termine?' do
     context 'aucun danger qualifié' do
@@ -140,7 +140,7 @@ describe Restitution::Securite do
 
   describe '#persiste' do
     context "persiste l'ensemble des données de sécurité" do
-      let(:situation) { create :situation_inventaire }
+      let(:situation) { create :situation_securite }
       let(:evaluation) { create :evaluation, campagne: campagne }
       let!(:partie) { create :partie, situation: situation, evaluation: evaluation }
       let(:evenements) do


### PR DESCRIPTION
![Screenshot_2020-02-12 Roger - Maintenance eva(1)](https://user-images.githubusercontent.com/86659/74328184-c3449280-4d8d-11ea-978b-8d018baa0de8.png)

Contribue à https://github.com/betagouv/eva/issues/740
