### PR TITLE
Securite: Extrait la métrique `nombre_reouverture_zones_sans_danger"

### DIFF
--- a/app/admin/stats.rb
+++ b/app/admin/stats.rb
@@ -39,7 +39,7 @@ ActiveAdmin.register Evaluation, as: 'Stats' do
     instance_exec('securite', :nombre_retours_deja_qualifies, &column_stats)
     instance_exec('securite', :delai_moyen_ouvertures_zones_dangers, &column_stats)
     instance_exec('securite', :attention_visuo_spatiale, &column_stats)
-    instance_exec('securite', :nombre_reouverture_zone_sans_danger, &column_stats)
+    instance_exec('securite', :nombre_reouverture_zones_sans_danger, &column_stats)
     instance_exec(:temps_bonnes_qualifications_dangers, &colonnes_stats_securite_par_danger)
     instance_exec(:temps_recherche_zones_dangers, &colonnes_stats_securite_par_danger)
     instance_exec(:temps_total_ouverture_zones_dangers, &colonnes_stats_securite_par_danger)

--- a/app/models/evenement.rb
+++ b/app/models/evenement.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class Evenement < ApplicationRecord
+  DECORATORS = {
+    maintenance: EvenementMaintenanceDecorator,
+    securite: EvenementSecuriteDecorator
+  }.freeze
+
   validates :nom, :date, presence: true
   belongs_to :partie, foreign_key: :session_id, primary_key: :session_id
   delegate :situation, :evaluation, to: :partie

--- a/app/models/restitution/metriques.rb
+++ b/app/models/restitution/metriques.rb
@@ -13,7 +13,7 @@ module Restitution
       'temps_bonnes_qualifications_dangers' => Securite::TempsBonnesQualificationsDangers,
       'temps_recherche_zones_dangers' => Securite::TempsRechercheZonesDangers,
       'temps_total_ouverture_zones_dangers' => Securite::TempsTotalOuvertureZonesDangers,
-      'nombre_reouverture_zone_sans_danger' => Securite,
+      'nombre_reouverture_zones_sans_danger' => Securite::NombreReouvertureZonesSansDanger,
       'nombre_bien_qualifies' => Securite::NombreDangersBienQualifies,
       'nombre_retours_deja_qualifies' => Securite::NombreRetoursDejaQualifies,
       'delai_ouvertures_zones_dangers' => Securite,

--- a/app/models/restitution/securite.rb
+++ b/app/models/restitution/securite.rb
@@ -47,12 +47,8 @@ module Restitution
       Metriques::SECURITE['attention_visuo_spatiale'].new(evenements_situation).calcule
     end
 
-    def nombre_reouverture_zone_sans_danger
-      evenements_situation.select(&:ouverture_zone_sans_danger?)
-                          .group_by { |e| e.donnees['zone'] }
-                          .inject(0) do |memo, (_danger, ouvertures)|
-                            memo + ouvertures.count - 1
-                          end
+    def nombre_reouverture_zones_sans_danger
+      Metriques::SECURITE['nombre_reouverture_zones_sans_danger'].new(evenements_situation).calcule
     end
 
     def delai_ouvertures_zones_dangers

--- a/app/models/restitution/securite/nombre_reouverture_zones_sans_danger.rb
+++ b/app/models/restitution/securite/nombre_reouverture_zones_sans_danger.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Restitution
+  class Securite
+    class NombreReouvertureZonesSansDanger
+      def initialize(evenements_situation)
+        @evenements_situation = evenements_situation
+      end
+
+      def calcule
+        @evenements_situation.select(&:ouverture_zone_sans_danger?)
+                             .group_by { |e| e.donnees['zone'] }
+                             .inject(0) do |memo, (_danger, ouvertures)|
+                               memo + ouvertures.count - 1
+                             end
+      end
+    end
+  end
+end

--- a/app/views/admin/restitutions/_restitution_securite.html.arb
+++ b/app/views/admin/restitutions/_restitution_securite.html.arb
@@ -40,7 +40,7 @@ panel t('.restitution_securite') do
       end
     end
     row t('.retours_zones_sans_danger') do |(_, r)|
-      r.nombre_reouverture_zone_sans_danger
+      r.nombre_reouverture_zones_sans_danger
     end
     row t('.temps_bonnes_qualifications_dangers') do |(_, r)|
       ul do

--- a/spec/features/stats_spec.rb
+++ b/spec/features/stats_spec.rb
@@ -59,7 +59,7 @@ describe 'Admin - Stats', type: :feature do
       nombre_retours_deja_qualifies: 21,
       delai_moyen_ouvertures_zones_dangers: 22,
       attention_visuo_spatiale: 'apte',
-      nombre_reouverture_zone_sans_danger: 23,
+      nombre_reouverture_zones_sans_danger: 23,
       temps_bonnes_qualifications_dangers: { 'bouche-egout' => 'tbqd1', 'camion' => 'tbqd2',
                                              'casque' => 'tbqd3', 'escabeau' => 'tbqd4',
                                              'signalisation' => 'tbqd5' },

--- a/spec/models/restitution/maintenance/nombre_bonnes_reponses_mot_francais_spec.rb
+++ b/spec/models/restitution/maintenance/nombre_bonnes_reponses_mot_francais_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe Restitution::Maintenance::NombreBonnesReponsesMotFrancais do
   let(:metrique_nombre_bonnes_reponses_mf) do
-    described_class.new(evenements_decores(evenements)).calcule
+    described_class.new(evenements_decores(evenements, :maintenance)).calcule
   end
 
   describe '#metrique nombre_bonnes_reponses_mot_français' do

--- a/spec/models/restitution/maintenance/nombre_bonnes_reponses_non_mot_spec.rb
+++ b/spec/models/restitution/maintenance/nombre_bonnes_reponses_non_mot_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe Restitution::Maintenance::NombreBonnesReponsesNonMot do
   let(:metrique_nombre_bonnes_reponses_non_mot) do
-    described_class.new(evenements_decores(evenements)).calcule
+    described_class.new(evenements_decores(evenements, :maintenance)).calcule
   end
 
   describe '#metrique metrique_nombre_bonnes_reponses_non_mot' do

--- a/spec/models/restitution/maintenance/nombre_erreurs_spec.rb
+++ b/spec/models/restitution/maintenance/nombre_erreurs_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe Restitution::Maintenance::NombreErreurs do
   let(:metrique_nombre_erreurs) do
-    described_class.new(evenements_decores(evenements)).calcule
+    described_class.new(evenements_decores(evenements, :maintenance)).calcule
   end
 
   describe '#metrique nombre_erreurs' do

--- a/spec/models/restitution/maintenance/nombre_non_reponse_spec.rb
+++ b/spec/models/restitution/maintenance/nombre_non_reponse_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe Restitution::Maintenance::NombreNonReponses do
   let(:metrique_nombre_erreurs) do
-    described_class.new(evenements_decores(evenements)).calcule
+    described_class.new(evenements_decores(evenements, :maintenance)).calcule
   end
 
   describe '#metrique nombre_non_reponses' do

--- a/spec/models/restitution/maintenance/temps_moyen_non_mots_spec.rb
+++ b/spec/models/restitution/maintenance/temps_moyen_non_mots_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe Restitution::Maintenance::TempsMoyenNonMots do
   let(:metrique_moyenne_non_mots) do
-    described_class.new(evenements_decores(evenements)).calcule
+    described_class.new(evenements_decores(evenements, :maintenance)).calcule
   end
 
   describe '#metrique metrique_moyenne_non_mots' do

--- a/spec/models/restitution/securite/attention_visuo_spaciale_spec.rb
+++ b/spec/models/restitution/securite/attention_visuo_spaciale_spec.rb
@@ -2,15 +2,16 @@
 
 require 'rails_helper'
 
-describe Restitution::Securite::NombreDangersBienIdentifies do
-  let(:campagne) { Campagne.new }
-  let(:restitution) { Restitution::Securite.new campagne, evenements }
+describe Restitution::Securite::AttentionVisuoSpaciale do
+  let(:metrique_attention_visuo_spaciale) do
+    described_class.new(evenements_decores(evenements, :securite)).calcule
+  end
 
   describe '#attention_visuo_spatiale' do
     let(:danger_visuo_spatial) { EvenementSecuriteDecorator::DANGER_VISUO_SPATIAL }
     context 'sans évenement: indéterminé' do
       let(:evenements) { [] }
-      it { expect(restitution.attention_visuo_spatiale).to eq Competence::NIVEAU_INDETERMINE }
+      it { expect(metrique_attention_visuo_spaciale).to eq Competence::NIVEAU_INDETERMINE }
     end
 
     context "avec identification du danger sans avoir activé l'aide" do
@@ -20,7 +21,7 @@ describe Restitution::Securite::NombreDangersBienIdentifies do
                donnees: { reponse: 'oui', danger: danger_visuo_spatial })]
       end
 
-      it { expect(restitution.attention_visuo_spatiale).to eq Competence::APTE }
+      it { expect(metrique_attention_visuo_spaciale).to eq Competence::APTE }
     end
 
     context "avec identification du danger après avoir activé l'aide" do
@@ -31,7 +32,7 @@ describe Restitution::Securite::NombreDangersBienIdentifies do
                donnees: { reponse: 'oui', danger: danger_visuo_spatial },
                date: 1.minute.ago)]
       end
-      it { expect(restitution.attention_visuo_spatiale).to eq Competence::APTE_AVEC_AIDE }
+      it { expect(metrique_attention_visuo_spaciale).to eq Competence::APTE_AVEC_AIDE }
     end
 
     context "avec identification du danger avant avoir activé l'aide" do
@@ -42,7 +43,7 @@ describe Restitution::Securite::NombreDangersBienIdentifies do
                date: 2.minute.ago),
          build(:activation_aide, date: 1.minutes.ago)]
       end
-      it { expect(restitution.attention_visuo_spatiale).to eq Competence::APTE }
+      it { expect(metrique_attention_visuo_spaciale).to eq Competence::APTE }
     end
   end
 end

--- a/spec/models/restitution/securite/nombre_dangers_bien_identifies_avant_aide_1_spec.rb
+++ b/spec/models/restitution/securite/nombre_dangers_bien_identifies_avant_aide_1_spec.rb
@@ -2,14 +2,15 @@
 
 require 'rails_helper'
 
-describe Restitution::Securite::NombreDangersBienIdentifies do
-  let(:campagne) { Campagne.new }
-  let(:restitution) { Restitution::Securite.new campagne, evenements }
+describe Restitution::Securite::NombreDangersBienIdentifiesAvantAide1 do
+  let(:metrique_nombre_dangers_bien_identifies_avant_aide_1) do
+    described_class.new(evenements_decores(evenements, :securite)).calcule
+  end
 
   describe '#nombre_dangers_bien_identifies_avant_aide_1' do
     context 'sans évenement' do
       let(:evenements) { [] }
-      it { expect(restitution.nombre_dangers_bien_identifies_avant_aide_1).to eq 0 }
+      it { expect(metrique_nombre_dangers_bien_identifies_avant_aide_1).to eq 0 }
     end
 
     context "avec des dangers identifiés en ayant activé l'aide" do
@@ -26,7 +27,7 @@ describe Restitution::Securite::NombreDangersBienIdentifies do
                donnees: { reponse: 'oui', danger: 'danger' },
                date: 2.minutes.from_now)]
       end
-      it { expect(restitution.nombre_dangers_bien_identifies_avant_aide_1).to eq 2 }
+      it { expect(metrique_nombre_dangers_bien_identifies_avant_aide_1).to eq 2 }
     end
 
     context "avec des dangers identifiés aprés avoir activé l'aide" do
@@ -37,7 +38,7 @@ describe Restitution::Securite::NombreDangersBienIdentifies do
                donnees: { reponse: 'oui', danger: 'danger' },
                date: 2.minutes.from_now)]
       end
-      it { expect(restitution.nombre_dangers_bien_identifies_avant_aide_1).to eq 0 }
+      it { expect(metrique_nombre_dangers_bien_identifies_avant_aide_1).to eq 0 }
     end
 
     context "avec un danger identifié sans avoir activé l'aide" do
@@ -47,7 +48,7 @@ describe Restitution::Securite::NombreDangersBienIdentifies do
                donnees: { reponse: 'oui', danger: 'danger' },
                date: 2.minutes.from_now)]
       end
-      it { expect(restitution.nombre_dangers_bien_identifies_avant_aide_1).to eq 1 }
+      it { expect(metrique_nombre_dangers_bien_identifies_avant_aide_1).to eq 1 }
     end
   end
 end

--- a/spec/models/restitution/securite/nombre_dangers_bien_identifies_spec.rb
+++ b/spec/models/restitution/securite/nombre_dangers_bien_identifies_spec.rb
@@ -3,13 +3,14 @@
 require 'rails_helper'
 
 describe Restitution::Securite::NombreDangersBienIdentifies do
-  let(:campagne) { Campagne.new }
-  let(:restitution) { Restitution::Securite.new campagne, evenements }
+  let(:metrique_nombre_dangers_bien_identifies) do
+    described_class.new(evenements_decores(evenements, :securite)).calcule
+  end
 
   describe '#nombre_dangers_bien_identifies' do
     context 'sans évenement' do
       let(:evenements) { [] }
-      it { expect(restitution.nombre_dangers_bien_identifies).to eq 0 }
+      it { expect(metrique_nombre_dangers_bien_identifies).to eq 0 }
     end
 
     context 'avec bonne identification' do
@@ -17,7 +18,7 @@ describe Restitution::Securite::NombreDangersBienIdentifies do
         [build(:evenement_demarrage),
          build(:evenement_identification_danger, donnees: { reponse: 'oui', danger: 'danger' })]
       end
-      it { expect(restitution.nombre_dangers_bien_identifies).to eq 1 }
+      it { expect(metrique_nombre_dangers_bien_identifies).to eq 1 }
     end
 
     context 'ignore les réponses négatives' do
@@ -25,7 +26,7 @@ describe Restitution::Securite::NombreDangersBienIdentifies do
         [build(:evenement_demarrage),
          build(:evenement_identification_danger, donnees: { reponse: 'non' })]
       end
-      it { expect(restitution.nombre_dangers_bien_identifies).to eq 0 }
+      it { expect(metrique_nombre_dangers_bien_identifies).to eq 0 }
     end
 
     context 'ignore les identifications de zone sans danger' do
@@ -33,7 +34,7 @@ describe Restitution::Securite::NombreDangersBienIdentifies do
         [build(:evenement_demarrage),
          build(:evenement_identification_danger, donnees: { reponse: 'oui' })]
       end
-      it { expect(restitution.nombre_dangers_bien_identifies).to eq 0 }
+      it { expect(metrique_nombre_dangers_bien_identifies).to eq 0 }
     end
   end
 end

--- a/spec/models/restitution/securite/nombre_dangers_bien_qualifies_spec.rb
+++ b/spec/models/restitution/securite/nombre_dangers_bien_qualifies_spec.rb
@@ -2,14 +2,15 @@
 
 require 'rails_helper'
 
-describe Restitution::Securite::NombreDangersBienIdentifies do
-  let(:campagne) { Campagne.new }
-  let(:restitution) { Restitution::Securite.new campagne, evenements }
+describe Restitution::Securite::NombreDangersBienQualifies do
+  let(:metrique_nombre_bien_qualifies) do
+    described_class.new(evenements_decores(evenements, :securite)).calcule
+  end
 
   describe '#nombre_bien_qualifies' do
     context 'sans évenement' do
       let(:evenements) { [] }
-      it { expect(restitution.nombre_bien_qualifies).to eq 0 }
+      it { expect(metrique_nombre_bien_qualifies).to eq 0 }
     end
 
     context 'avec bonne qualification' do
@@ -17,7 +18,7 @@ describe Restitution::Securite::NombreDangersBienIdentifies do
         [build(:evenement_demarrage),
          build(:evenement_qualification_danger, :bon)]
       end
-      it { expect(restitution.nombre_bien_qualifies).to eq 1 }
+      it { expect(metrique_nombre_bien_qualifies).to eq 1 }
     end
 
     context 'ignore les mauvaises qualifications' do
@@ -25,7 +26,7 @@ describe Restitution::Securite::NombreDangersBienIdentifies do
         [build(:evenement_demarrage),
          build(:evenement_qualification_danger, :mauvais)]
       end
-      it { expect(restitution.nombre_bien_qualifies).to eq 0 }
+      it { expect(metrique_nombre_bien_qualifies).to eq 0 }
     end
 
     context 'prend en compte la requalification' do
@@ -36,7 +37,7 @@ describe Restitution::Securite::NombreDangersBienIdentifies do
          build(:evenement_qualification_danger,
                donnees: { reponse: 'bonne', danger: 'danger' }, created_at: 2.minutes.ago)]
       end
-      it { expect(restitution.nombre_bien_qualifies).to eq 0 }
+      it { expect(metrique_nombre_bien_qualifies).to eq 0 }
     end
   end
 end

--- a/spec/models/restitution/securite/nombre_dangers_mal_identifies_spec.rb
+++ b/spec/models/restitution/securite/nombre_dangers_mal_identifies_spec.rb
@@ -3,13 +3,14 @@
 require 'rails_helper'
 
 describe Restitution::Securite::NombreDangersMalIdentifies do
-  let(:campagne) { Campagne.new }
-  let(:restitution) { Restitution::Securite.new campagne, evenements }
+  let(:metrique_nombre_dangers_mal_identifies) do
+    described_class.new(evenements_decores(evenements, :securite)).calcule
+  end
 
   describe '#nombre_dangers_mal_identifies' do
     context 'sans évenement' do
       let(:evenements) { [] }
-      it { expect(restitution.nombre_dangers_mal_identifies).to eq 0 }
+      it { expect(metrique_nombre_dangers_mal_identifies).to eq 0 }
     end
 
     context 'avec une bonne identification' do
@@ -17,7 +18,7 @@ describe Restitution::Securite::NombreDangersMalIdentifies do
         [build(:evenement_demarrage),
          build(:evenement_identification_danger, donnees: { reponse: 'oui', danger: 'danger' })]
       end
-      it { expect(restitution.nombre_dangers_mal_identifies).to eq 0 }
+      it { expect(metrique_nombre_dangers_mal_identifies).to eq 0 }
     end
 
     context 'avec une mauvaise identification' do
@@ -25,7 +26,7 @@ describe Restitution::Securite::NombreDangersMalIdentifies do
         [build(:evenement_demarrage),
          build(:evenement_identification_danger, donnees: { reponse: 'non', danger: 'danger' })]
       end
-      it { expect(restitution.nombre_dangers_mal_identifies).to eq 1 }
+      it { expect(metrique_nombre_dangers_mal_identifies).to eq 1 }
     end
   end
 end

--- a/spec/models/restitution/securite/nombre_reouverture_zones_sans_danger_spec.rb
+++ b/spec/models/restitution/securite/nombre_reouverture_zones_sans_danger_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Restitution::Securite::NombreReouvertureZonesSansDanger do
+  let(:campagne) { Campagne.new }
+  let(:restitution) { Restitution::Securite.new campagne, evenements }
+
+  describe '#nombre_reouverture_zones_sans_danger' do
+    context 'sans réouverture' do
+      let(:evenements) do
+        [build(:evenement_demarrage),
+         build(:evenement_ouverture_zone, donnees: { zone: 'zone1' })]
+      end
+
+      it { expect(restitution.nombre_reouverture_zones_sans_danger).to eq 0 }
+    end
+
+    context 'avec une réouverture' do
+      let(:evenements) do
+        [build(:evenement_demarrage),
+         build(:evenement_ouverture_zone, donnees: { zone: 'zone1' }),
+         build(:evenement_ouverture_zone, donnees: { zone: 'zone2' }),
+         build(:evenement_ouverture_zone, donnees: { zone: 'zone1' })]
+      end
+
+      it { expect(restitution.nombre_reouverture_zones_sans_danger).to eq 1 }
+    end
+
+    context "avec une autre réouverture d'une zone avec danger" do
+      let(:evenements) do
+        [build(:evenement_demarrage),
+         build(:evenement_ouverture_zone, donnees: { zone: 'zone1' }),
+         build(:evenement_ouverture_zone, donnees: { zone: 'zone2' }),
+         build(:evenement_ouverture_zone, donnees: { zone: 'zone3', danger: 'danger1' }),
+         build(:evenement_ouverture_zone, donnees: { zone: 'zone3', danger: 'danger1' }),
+         build(:evenement_ouverture_zone, donnees: { zone: 'zone1' })]
+      end
+
+      it { expect(restitution.nombre_reouverture_zones_sans_danger).to eq 1 }
+    end
+  end
+end

--- a/spec/models/restitution/securite/nombre_reouverture_zones_sans_danger_spec.rb
+++ b/spec/models/restitution/securite/nombre_reouverture_zones_sans_danger_spec.rb
@@ -3,17 +3,19 @@
 require 'rails_helper'
 
 describe Restitution::Securite::NombreReouvertureZonesSansDanger do
-  let(:campagne) { Campagne.new }
-  let(:restitution) { Restitution::Securite.new campagne, evenements }
+  let(:metrique_nombre_reouverture_zones_sans_danger) do
+    described_class.new(evenements_decores(evenements, :securite)).calcule
+  end
 
   describe '#nombre_reouverture_zones_sans_danger' do
     context 'sans réouverture' do
       let(:evenements) do
-        [build(:evenement_demarrage),
-         build(:evenement_ouverture_zone, donnees: { zone: 'zone1' })]
+        [
+          build(:evenement_demarrage),
+          build(:evenement_ouverture_zone, donnees: { zone: 'zone1' })
+        ]
       end
-
-      it { expect(restitution.nombre_reouverture_zones_sans_danger).to eq 0 }
+      it { expect(metrique_nombre_reouverture_zones_sans_danger).to eq 0 }
     end
 
     context 'avec une réouverture' do
@@ -24,7 +26,7 @@ describe Restitution::Securite::NombreReouvertureZonesSansDanger do
          build(:evenement_ouverture_zone, donnees: { zone: 'zone1' })]
       end
 
-      it { expect(restitution.nombre_reouverture_zones_sans_danger).to eq 1 }
+      it { expect(metrique_nombre_reouverture_zones_sans_danger).to eq 1 }
     end
 
     context "avec une autre réouverture d'une zone avec danger" do
@@ -37,7 +39,7 @@ describe Restitution::Securite::NombreReouvertureZonesSansDanger do
          build(:evenement_ouverture_zone, donnees: { zone: 'zone1' })]
       end
 
-      it { expect(restitution.nombre_reouverture_zones_sans_danger).to eq 1 }
+      it { expect(metrique_nombre_reouverture_zones_sans_danger).to eq 1 }
     end
   end
 end

--- a/spec/models/restitution/securite/nombre_retours_deja_qualifies_spec.rb
+++ b/spec/models/restitution/securite/nombre_retours_deja_qualifies_spec.rb
@@ -3,13 +3,14 @@
 require 'rails_helper'
 
 describe Restitution::Securite::NombreRetoursDejaQualifies do
-  let(:campagne) { Campagne.new }
-  let(:restitution) { Restitution::Securite.new campagne, evenements }
+  let(:metrique_nombre_retours_deja_qualifies) do
+    described_class.new(evenements_decores(evenements, :securite)).calcule
+  end
 
   describe '#nombre_retours_deja_qualifies' do
     context 'sans évenement' do
       let(:evenements) { [] }
-      it { expect(restitution.nombre_retours_deja_qualifies).to eq 0 }
+      it { expect(metrique_nombre_retours_deja_qualifies).to eq 0 }
     end
 
     context 'deux qualifications de dangers différents' do
@@ -20,7 +21,7 @@ describe Restitution::Securite::NombreRetoursDejaQualifies do
          build(:evenement_qualification_danger,
                donnees: { reponse: 'bonne', danger: 'danger2' })]
       end
-      it { expect(restitution.nombre_retours_deja_qualifies).to eq 0 }
+      it { expect(metrique_nombre_retours_deja_qualifies).to eq 0 }
     end
 
     context 'deux qualifications du même danger' do
@@ -31,7 +32,7 @@ describe Restitution::Securite::NombreRetoursDejaQualifies do
          build(:evenement_qualification_danger,
                donnees: { reponse: 'bonne', danger: 'danger' })]
       end
-      it { expect(restitution.nombre_retours_deja_qualifies).to eq 1 }
+      it { expect(metrique_nombre_retours_deja_qualifies).to eq 1 }
     end
   end
 end

--- a/spec/models/restitution/securite/temps_bonnes_qualification_dangers_spec.rb
+++ b/spec/models/restitution/securite/temps_bonnes_qualification_dangers_spec.rb
@@ -3,13 +3,14 @@
 require 'rails_helper'
 
 describe Restitution::Securite::TempsBonnesQualificationsDangers do
-  let(:campagne) { Campagne.new }
-  let(:restitution) { Restitution::Securite.new campagne, evenements }
+  let(:metrique_temps_bonnes_qualifications_dangers) do
+    described_class.new(evenements_decores(evenements, :securite)).calcule
+  end
 
   describe '#temps_bonnes_qualifications_dangers' do
     context 'sans évenement' do
       let(:evenements) { [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0))] }
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq({}) }
+      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq({}) }
     end
 
     context 'avec une bonne qualification' do
@@ -21,7 +22,7 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
                donnees: { reponse: 'bonne', danger: 'casque' },
                date: Time.local(2019, 10, 9, 10, 2))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq('casque' => 60) }
+      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq('casque' => 60) }
     end
 
     context 'avec deux bonnes qualifications pour des dangers différents' do
@@ -39,7 +40,7 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
                date: Time.local(2019, 10, 9, 10, 5))]
       end
       it do
-        temps = restitution.temps_bonnes_qualifications_dangers
+        temps = metrique_temps_bonnes_qualifications_dangers
         expect(temps).to eq('casque' => 60, 'camion' => 120)
       end
     end
@@ -59,7 +60,7 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
                date: Time.local(2019, 10, 9, 10, 5))]
       end
       it do
-        temps = restitution.temps_bonnes_qualifications_dangers
+        temps = metrique_temps_bonnes_qualifications_dangers
         expect(temps).to eq('casque' => 60)
       end
     end
@@ -72,7 +73,7 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
          build(:evenement_qualification_danger,
                donnees: { reponse: 'mauvais', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 2))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq({}) }
+      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq({}) }
     end
 
     context 'ignore les mauvaises qualifications précédant une bonne qualification' do
@@ -87,7 +88,7 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
          build(:evenement_qualification_danger,
                donnees: { reponse: 'bonne', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 5))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq('d1' => 120) }
+      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq('d1' => 120) }
     end
 
     context 'ignore les mauvaises qualifications même suivant une bonne qualification' do
@@ -102,7 +103,7 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
          build(:evenement_qualification_danger,
                donnees: { reponse: 'mauvais', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 5))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq('d1' => 60) }
+      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq('d1' => 60) }
     end
 
     context 'ouverture sans qualification' do
@@ -111,7 +112,7 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
          build(:evenement_ouverture_zone,
                donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq({}) }
+      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq({}) }
     end
 
     context 'ignore les événements hors ouverture et qualification' do
@@ -119,7 +120,7 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
         [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone, date: Time.local(2019, 10, 9, 10, 1))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq({}) }
+      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq({}) }
     end
 
     context 'ignore les zones non dangers ouvertes' do
@@ -133,7 +134,22 @@ describe Restitution::Securite::TempsBonnesQualificationsDangers do
                donnees: { reponse: 'bonne', danger: 'casque' },
                date: Time.local(2019, 10, 9, 10, 3))]
       end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq('casque' => 60) }
+      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq('casque' => 60) }
+    end
+
+    context 'plusieurs ouverture de la même zone' do
+      let(:evenements) do
+        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 1)),
+         build(:evenement_qualification_danger,
+               donnees: { reponse: 'mauvais', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 2)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 3)),
+         build(:evenement_qualification_danger,
+               donnees: { reponse: 'bonne', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 4))]
+      end
+      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq('d1' => 120) }
     end
   end
 end

--- a/spec/models/restitution/securite/temps_recherche_zones_dangers_spec.rb
+++ b/spec/models/restitution/securite/temps_recherche_zones_dangers_spec.rb
@@ -3,13 +3,14 @@
 require 'rails_helper'
 
 describe Restitution::Securite::TempsRechercheZonesDangers do
-  let(:campagne) { Campagne.new }
-  let(:restitution) { Restitution::Securite.new campagne, evenements }
+  let(:metrique_temps_recherche_zones_dangers) do
+    described_class.new(evenements_decores(evenements, :securite)).calcule
+  end
 
   describe '#temps_recherche_zones_dangers' do
     context 'sans zone danger ouverte' do
       let(:evenements) { [] }
-      it { expect(restitution.temps_recherche_zones_dangers).to eq({}) }
+      it { expect(metrique_temps_recherche_zones_dangers).to eq({}) }
     end
 
     context 'une zone danger ouverte' do
@@ -18,7 +19,7 @@ describe Restitution::Securite::TempsRechercheZonesDangers do
          build(:evenement_ouverture_zone,
                donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1))]
       end
-      it { expect(restitution.temps_recherche_zones_dangers).to eq('casque' => 60) }
+      it { expect(metrique_temps_recherche_zones_dangers).to eq('casque' => 60) }
     end
 
     context 'deux zones danger ouverts' do
@@ -31,11 +32,11 @@ describe Restitution::Securite::TempsRechercheZonesDangers do
                donnees: { danger: 'camion' }, date: Time.local(2019, 10, 9, 10, 4))]
       end
       it 'calcule les temps de recherche' do
-        temps = restitution.temps_recherche_zones_dangers
+        temps = metrique_temps_recherche_zones_dangers
         expect(temps).to eq('casque' => 60, 'camion' => 120)
       end
       it 'retournes les zones par ordre alphabétique' do
-        temps = restitution.temps_recherche_zones_dangers
+        temps = metrique_temps_recherche_zones_dangers
         expect(temps.keys).to eq(%w[camion casque])
       end
     end
@@ -48,7 +49,7 @@ describe Restitution::Securite::TempsRechercheZonesDangers do
          build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2))]
       end
 
-      it { expect(restitution.temps_recherche_zones_dangers).to eq('casque' => 60) }
+      it { expect(metrique_temps_recherche_zones_dangers).to eq('casque' => 60) }
     end
   end
 end

--- a/spec/models/restitution/securite/temps_total_ouverture_zones_dangers_spec.rb
+++ b/spec/models/restitution/securite/temps_total_ouverture_zones_dangers_spec.rb
@@ -3,13 +3,14 @@
 require 'rails_helper'
 
 describe Restitution::Securite::TempsTotalOuvertureZonesDangers do
-  let(:campagne) { Campagne.new }
-  let(:restitution) { Restitution::Securite.new campagne, evenements }
+  let(:metrique_temps_total_ouverture_zones_dangers) do
+    described_class.new(evenements_decores(evenements, :securite)).calcule
+  end
 
   describe '#temps_total_ouverture_zones_dangers' do
     context 'sans zone danger ouverte' do
       let(:evenements) { [] }
-      it { expect(restitution.temps_total_ouverture_zones_dangers).to eq({}) }
+      it { expect(metrique_temps_total_ouverture_zones_dangers).to eq({}) }
     end
 
     context 'une zone danger ouverte' do
@@ -21,7 +22,7 @@ describe Restitution::Securite::TempsTotalOuvertureZonesDangers do
                donnees: { danger: 'casque' },
                date: Time.local(2019, 10, 9, 10, 2))]
       end
-      it { expect(restitution.temps_total_ouverture_zones_dangers).to eq('casque' => 60) }
+      it { expect(metrique_temps_total_ouverture_zones_dangers).to eq('casque' => 60) }
     end
 
     context 'deux zones danger ouverts' do
@@ -37,28 +38,13 @@ describe Restitution::Securite::TempsTotalOuvertureZonesDangers do
                donnees: { danger: 'camion' }, date: Time.local(2019, 10, 9, 10, 6))]
       end
       it 'calcule les temps de chaque zone' do
-        temps = restitution.temps_total_ouverture_zones_dangers
+        temps = metrique_temps_total_ouverture_zones_dangers
         expect(temps).to eq('casque' => 60, 'camion' => 120)
       end
       it 'retournes les zones par ordre alphabétique' do
-        temps = restitution.temps_total_ouverture_zones_dangers
+        temps = metrique_temps_total_ouverture_zones_dangers
         expect(temps.keys).to eq(%w[camion casque])
       end
-    end
-
-    context 'plusieurs ouverture de la même zone' do
-      let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_ouverture_zone,
-               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 1)),
-         build(:evenement_qualification_danger,
-               donnees: { reponse: 'mauvais', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 2)),
-         build(:evenement_ouverture_zone,
-               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 3)),
-         build(:evenement_qualification_danger,
-               donnees: { reponse: 'bonne', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 4))]
-      end
-      it { expect(restitution.temps_bonnes_qualifications_dangers).to eq('d1' => 120) }
     end
 
     context 'quand on ne finit pas par une qualification' do
@@ -68,7 +54,7 @@ describe Restitution::Securite::TempsTotalOuvertureZonesDangers do
                donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1))]
       end
 
-      it { expect(restitution.temps_total_ouverture_zones_dangers).to eq({}) }
+      it { expect(metrique_temps_total_ouverture_zones_dangers).to eq({}) }
     end
   end
 end

--- a/spec/models/restitution/securite_spec.rb
+++ b/spec/models/restitution/securite_spec.rb
@@ -103,41 +103,6 @@ describe Restitution::Securite do
     end
   end
 
-  describe '#nombre_reouverture_zone_sans_danger' do
-    context 'sans réouverture' do
-      let(:evenements) do
-        [build(:evenement_demarrage),
-         build(:evenement_ouverture_zone, donnees: { zone: 'zone1' })]
-      end
-
-      it { expect(restitution.nombre_reouverture_zone_sans_danger).to eq 0 }
-    end
-
-    context 'avec une réouverture' do
-      let(:evenements) do
-        [build(:evenement_demarrage),
-         build(:evenement_ouverture_zone, donnees: { zone: 'zone1' }),
-         build(:evenement_ouverture_zone, donnees: { zone: 'zone2' }),
-         build(:evenement_ouverture_zone, donnees: { zone: 'zone1' })]
-      end
-
-      it { expect(restitution.nombre_reouverture_zone_sans_danger).to eq 1 }
-    end
-
-    context "avec une autre réouverture d'une zone avec danger" do
-      let(:evenements) do
-        [build(:evenement_demarrage),
-         build(:evenement_ouverture_zone, donnees: { zone: 'zone1' }),
-         build(:evenement_ouverture_zone, donnees: { zone: 'zone2' }),
-         build(:evenement_ouverture_zone, donnees: { zone: 'zone3', danger: 'danger1' }),
-         build(:evenement_ouverture_zone, donnees: { zone: 'zone3', danger: 'danger1' }),
-         build(:evenement_ouverture_zone, donnees: { zone: 'zone1' })]
-      end
-
-      it { expect(restitution.nombre_reouverture_zone_sans_danger).to eq 1 }
-    end
-  end
-
   describe '#persiste' do
     context "persiste l'ensemble des données de sécurité" do
       let(:situation) { create :situation_securite }
@@ -150,7 +115,7 @@ describe Restitution::Securite do
       end
 
       it do
-        expect(restitution).to receive(:nombre_reouverture_zone_sans_danger).and_return 1
+        expect(restitution).to receive(:nombre_reouverture_zones_sans_danger).and_return 1
         expect(restitution).to receive(:nombre_bien_qualifies).and_return 2
         expect(restitution).to receive(:nombre_dangers_bien_identifies).and_return 3
         expect(restitution).to receive(:nombre_retours_deja_qualifies).and_return 4
@@ -164,7 +129,7 @@ describe Restitution::Securite do
         expect(restitution).to receive(:nombre_dangers_mal_identifies).and_return 1
         restitution.persiste
         partie.reload
-        expect(partie.metriques['nombre_reouverture_zone_sans_danger']).to eq 1
+        expect(partie.metriques['nombre_reouverture_zones_sans_danger']).to eq 1
         expect(partie.metriques['nombre_bien_qualifies']).to eq 2
         expect(partie.metriques['nombre_dangers_bien_identifies']).to eq 3
         expect(partie.metriques['nombre_retours_deja_qualifies']).to eq 4

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,7 +49,7 @@ RSpec.configure do |config|
     compte
   end
 
-  def evenements_decores(evenements)
-    evenements.map { |e| EvenementMaintenanceDecorator.new e }
+  def evenements_decores(evenements, scope)
+    evenements.map { |e| Evenement::DECORATORS[scope].new e }
   end
 end


### PR DESCRIPTION
contribue à betagouv/eva#699