### PR TITLE
Calcule le score de la maintenance sans éliminer les valeurs extrêmes

### DIFF
--- a/app/models/restitution/base.rb
+++ b/app/models/restitution/base.rb
@@ -83,6 +83,8 @@ module Restitution
       end / competences_utilisees.size
     end
 
+    def score; end
+
     def to_param
       partie.id
     end

--- a/app/models/restitution/maintenance.rb
+++ b/app/models/restitution/maintenance.rb
@@ -21,5 +21,19 @@ module Restitution
       end
       partie.update(metriques: metriques)
     end
+
+    def score
+      resultat = nil
+
+      if temps_moyen_mots_francais.present?
+        resultat = temps_moyen_mots_francais * nombre_bonnes_reponses_francais
+      end
+
+      if temps_moyen_non_mots.present?
+        resultat = nombre_bonnes_reponses_non_mot * temps_moyen_non_mots + (resultat || 0)
+      end
+
+      resultat
+    end
   end
 end

--- a/app/models/restitution/metriques.rb
+++ b/app/models/restitution/metriques.rb
@@ -25,7 +25,7 @@ module Restitution
       'nombre_bonnes_reponses_francais' => Maintenance::NombreBonnesReponsesMotFrancais,
       'nombre_bonnes_reponses_non_mot' => Maintenance::NombreBonnesReponsesNonMot,
       'nombre_non_reponses' => Maintenance::NombreNonReponses,
-      'temps_moyen_mots_français' => Maintenance::TempsMoyenMotsFrancais,
+      'temps_moyen_mots_francais' => Maintenance::TempsMoyenMotsFrancais,
       'temps_moyen_non_mots' => Maintenance::TempsMoyenNonMots
     }.freeze
   end

--- a/app/views/admin/restitutions/_restitution_competences.html.arb
+++ b/app/views/admin/restitutions/_restitution_competences.html.arb
@@ -7,5 +7,6 @@ panel t('.titre') do
             scope: 'admin.evaluations.restitution_competence')) { niveau }
     end
     row(t('.efficience')) { formate_efficience(restitution.efficience) }
+    row :score
   end
 end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -123,7 +123,7 @@ fr:
         nombre_bonnes_reponses_non_mot: "Nombre de bonnes réponses (non-mot)"
         nombre_non_reponses: "Nombre de non réponses"
         temps_moyen_non_mots: "Temps moyen de réponse correcte non-mots (en secondes)"
-        temps_moyen_mots_français: "Temps moyen de réponse correcte mot français (en secondes)"
+        temps_moyen_mots_francais: "Temps moyen de réponse correcte mot français (en secondes)"
         nombre_bonnes_reponses_mot_français: "Nombre de bonnes réponses (mot français)"
       restitution_colonnes:
         cote_z: Cote Z

--- a/spec/models/restitution/base_spec.rb
+++ b/spec/models/restitution/base_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 describe Restitution::Base do
+  let(:evenements)  { [] }
   let(:campagne)    { build(:campagne) }
   let(:restitution) { described_class.new(campagne, evenements) }
   let(:evaluation)  { create :evaluation }
@@ -46,8 +47,6 @@ describe Restitution::Base do
   end
 
   context 'renvoie par défaut une liste vide pour les compétences évaluées' do
-    let(:evenements) { [] }
-
     it { expect(restitution.competences).to eql({}) }
   end
 
@@ -75,8 +74,6 @@ describe Restitution::Base do
   end
 
   describe '#efficience' do
-    let(:evenements) { [] }
-
     it "retourne l'efficience sans les compétences persévérance et compréhension consigne" do
       expect(restitution).to receive(:competences).and_return(
         ::Competence::PERSEVERANCE => Competence::NIVEAU_1,
@@ -100,6 +97,12 @@ describe Restitution::Base do
     it "retourne 0 lorsque rien n'a été mesuré" do
       expect(restitution).to receive(:competences).and_return({})
       expect(restitution.efficience).to eql(0)
+    end
+  end
+
+  describe '#score' do
+    it 'renvoie nil par défaut' do
+      expect(restitution.score).to eql(nil)
     end
   end
 end

--- a/spec/models/restitution/maintenance_spec.rb
+++ b/spec/models/restitution/maintenance_spec.rb
@@ -40,6 +40,7 @@ describe Restitution::Maintenance do
       restitution.score
     end
 
+    it { expect(score_pour(0, nil, 0, nil)).to eq(nil) }
     it { expect(score_pour(0, nil, 5, 1)).to eq(5 * 1) }
     it { expect(score_pour(2, 1.5, 0, nil)).to eq(2 * 1.5) }
     it { expect(score_pour(2, 1.5, 5, 3)).to eq(2 * 1.5 + 5 * 3) }

--- a/spec/models/restitution/maintenance_spec.rb
+++ b/spec/models/restitution/maintenance_spec.rb
@@ -3,11 +3,12 @@
 require 'rails_helper'
 
 describe Restitution::Maintenance do
+  let(:evenements) { [] }
+  let(:campagne) { Campagne.new }
+  let(:restitution) { described_class.new campagne, evenements }
+
   describe '#persiste' do
     context "persiste l'ensemble des données de maintenance" do
-      let(:campagne) { Campagne.new }
-      let(:restitution) { described_class.new campagne, evenements }
-
       let(:situation) { create :situation_maintenance }
       let(:evaluation) { create :evaluation, campagne: campagne }
       let!(:partie) { create :partie, situation: situation, evaluation: evaluation }
@@ -18,15 +19,29 @@ describe Restitution::Maintenance do
       it do
         expect(restitution).to receive(:nombre_non_reponses).and_return 2
         expect(restitution).to receive(:nombre_bonnes_reponses_non_mot).and_return 20
-        expect(restitution).to receive(:temps_moyen_mots_français).and_return 0.789
+        expect(restitution).to receive(:temps_moyen_mots_francais).and_return 0.789
         expect(restitution).to receive(:temps_moyen_non_mots).and_return 1.5
         restitution.persiste
         partie.reload
         expect(partie.metriques['nombre_non_reponses']).to eq 2
         expect(partie.metriques['nombre_bonnes_reponses_non_mot']).to eq 20
-        expect(partie.metriques['temps_moyen_mots_français']).to eq 0.789
+        expect(partie.metriques['temps_moyen_mots_francais']).to eq 0.789
         expect(partie.metriques['temps_moyen_non_mots']).to eq 1.5
       end
     end
+  end
+
+  describe '#score' do
+    def score_pour(nombre_francais, temps_francais, nombre_non_mots, temps_non_mots)
+      allow(restitution).to receive_messages(nombre_bonnes_reponses_francais: nombre_francais,
+                                             temps_moyen_mots_francais: temps_francais,
+                                             nombre_bonnes_reponses_non_mot: nombre_non_mots,
+                                             temps_moyen_non_mots: temps_non_mots)
+      restitution.score
+    end
+
+    it { expect(score_pour(0, nil, 5, 1)).to eq(5 * 1) }
+    it { expect(score_pour(2, 1.5, 0, nil)).to eq(2 * 1.5) }
+    it { expect(score_pour(2, 1.5, 5, 3)).to eq(2 * 1.5 + 5 * 3) }
   end
 end


### PR DESCRIPTION
Contribue à betagouv/eva#740

cas standard :
![Capture d’écran 2020-02-21 à 13 24 57](https://user-images.githubusercontent.com/28393/75034555-b91d4500-54ad-11ea-8537-2c4a94b477db.png)

cas sans événement

![Capture d’écran 2020-02-21 à 13 26 27](https://user-images.githubusercontent.com/28393/75034601-d225f600-54ad-11ea-9e2e-092838eedf6b.png)
