### PR TITLE
Déplace les decorators dans un dossier Decorators

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
     - 'tmp/**/*'
     - 'test/**/*'
     - 'vendor/**/*'
+    - 'spec/spec_helper.rb'
 
 Style/Documentation:
   Enabled: false

--- a/app/decorators/evenement_maintenance.rb
+++ b/app/decorators/evenement_maintenance.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EvenementMaintenanceDecorator < SimpleDelegator
+class EvenementMaintenance < SimpleDelegator
   EVENEMENT = {
     NON_MOT: 'non-mot',
     REPONSE_NON_FRANCAIS: 'pasfrancais',

--- a/app/decorators/evenement_securite.rb
+++ b/app/decorators/evenement_securite.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EvenementSecuriteDecorator < SimpleDelegator
+class EvenementSecurite < SimpleDelegator
   BONNE_QUALIFICATION = 'bonne'
   IDENTIFICATION_POSITIVE = 'oui'
   DANGER_VISUO_SPATIAL = 'signalisation'

--- a/app/models/evenement.rb
+++ b/app/models/evenement.rb
@@ -1,14 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../decorators/evenement_maintenance'
-require_relative '../decorators/evenement_securite'
-
 class Evenement < ApplicationRecord
-  DECORATORS = {
-    maintenance: EvenementMaintenance,
-    securite: EvenementSecurite
-  }.freeze
-
   validates :nom, :date, presence: true
   belongs_to :partie, foreign_key: :session_id, primary_key: :session_id
   delegate :situation, :evaluation, to: :partie

--- a/app/models/evenement.rb
+++ b/app/models/evenement.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+require_relative '../decorators/evenement_maintenance'
+require_relative '../decorators/evenement_securite'
+
 class Evenement < ApplicationRecord
   DECORATORS = {
-    maintenance: EvenementMaintenanceDecorator,
-    securite: EvenementSecuriteDecorator
+    maintenance: EvenementMaintenance,
+    securite: EvenementSecurite
   }.freeze
 
   validates :nom, :date, presence: true

--- a/app/models/restitution/maintenance.rb
+++ b/app/models/restitution/maintenance.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../decorators/evenement_maintenance'
+
 module Restitution
   class Maintenance < AvecEntrainement
     METRIQUES = {
@@ -13,7 +15,7 @@ module Restitution
     }.freeze
 
     def initialize(campagne, evenements)
-      evenements = evenements.map { |e| EvenementMaintenanceDecorator.new e }
+      evenements = evenements.map { |e| EvenementMaintenance.new e }
       super(campagne, evenements)
     end
 

--- a/app/models/restitution/securite.rb
+++ b/app/models/restitution/securite.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../decorators/evenement_securite'
+
 module Restitution
   class Securite < AvecEntrainement
     ZONES_DANGER = %w[bouche-egout camion casque escabeau signalisation].freeze
@@ -22,7 +24,7 @@ module Restitution
     }.freeze
 
     def initialize(campagne, evenements)
-      evenements = evenements.map { |e| EvenementSecuriteDecorator.new e }
+      evenements = evenements.map { |e| EvenementSecurite.new e }
       super(campagne, evenements)
     end
 

--- a/spec/models/restitution/securite/attention_visuo_spaciale_spec.rb
+++ b/spec/models/restitution/securite/attention_visuo_spaciale_spec.rb
@@ -8,7 +8,7 @@ describe Restitution::Securite::AttentionVisuoSpaciale do
   end
 
   describe '#attention_visuo_spatiale' do
-    let(:danger_visuo_spatial) { EvenementSecuriteDecorator::DANGER_VISUO_SPATIAL }
+    let(:danger_visuo_spatial) { EvenementSecurite::DANGER_VISUO_SPATIAL }
     context 'sans évenement: indéterminé' do
       let(:evenements) { [] }
       it { expect(metrique_attention_visuo_spaciale).to eq Competence::NIVEAU_INDETERMINE }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'capybara/rspec'
+require_relative '../app/decorators/evenement_maintenance'
+require_relative '../app/decorators/evenement_securite'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
@@ -33,6 +35,11 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  DECORATORS = {
+    maintenance: EvenementMaintenance,
+    securite: EvenementSecurite
+  }.freeze
+
   def se_connecter_comme_administrateur
     connecte create(:compte_admin, email: 'admin@exemple.fr', password: 'password')
   end
@@ -50,6 +57,6 @@ RSpec.configure do |config|
   end
 
   def evenements_decores(evenements, scope)
-    evenements.map { |e| Evenement::DECORATORS[scope].new e }
+    evenements.map { |e| DECORATORS[scope].new e }
   end
 end


### PR DESCRIPTION
Cette PR fait 2 choses:

- Déplace les `decorators` de `Maintenance` et de `Securite` dans un dossier `Decorators`. ✨ 
- Déplace la constante `DECORATORS` dans `spec_helper`,  cette dernière étant seulement utilisée dans les specs.