### PR TITLE
evite un plantage de l'application si aucun temps n'est retenu par la normalisation

### DIFF
--- a/app/models/restitution/maintenance.rb
+++ b/app/models/restitution/maintenance.rb
@@ -71,6 +71,8 @@ module Restitution
 
       temps_moyen_normalise = temps_moyen_normalise(nom_moyenne, metrique_des_temps)
 
+      return 0 unless temps_moyen_normalise.present?
+
       nombre / temps_moyen_normalise
     end
 

--- a/spec/models/restitution/maintenance_spec.rb
+++ b/spec/models/restitution/maintenance_spec.rb
@@ -42,6 +42,7 @@ describe Restitution::Maintenance do
 
     it { expect(score_pour(0, nil, 0, nil)).to eq(0) }
     it { expect(score_pour(2, 1.5, 0, nil)).to eq(0) }
+    it { expect(score_pour(2, nil, 0, nil)).to eq(0) }
     it { expect(score_pour(2, 1.5, 5, 3)).to eq((2 / 1.5) * (5 / 3)) }
   end
 


### PR DESCRIPTION

Ce cas ne devrait jamais arrivé en utilisation normal mais arrive dans
nos tests. On traite le problème en affichant un score de zéro.