### PR TITLE
Standardisation du score de la Maintenance

### DIFF
--- a/app/models/partie.rb
+++ b/app/models/partie.rb
@@ -41,7 +41,7 @@ class Partie < ApplicationRecord
   end
 
   def cote_z_metriques
-    collect_metriques do |metrique|
+    @cote_z_metriques ||= collect_metriques do |metrique|
       if ecart_type_metriques[metrique].zero?
         0
       elsif metriques[metrique].present?

--- a/app/models/restitution/maintenance.rb
+++ b/app/models/restitution/maintenance.rb
@@ -59,7 +59,7 @@ module Restitution
     end
 
     def score
-      score_vocabulaire
+      partie.cote_z_metriques['score_vocabulaire']
     end
   end
 end

--- a/app/models/restitution/maintenance.rb
+++ b/app/models/restitution/maintenance.rb
@@ -32,6 +32,10 @@ module Restitution
       'temps_moyen_non_mots' => {
         'type' => :nombre,
         'instance' => Metriques::Moyenne.new(Maintenance::TempsNonMots.new)
+      },
+      'score_vocabulaire' => {
+        'type' => :nombre,
+        'instance' => Maintenance::ScoreVocabulaire.new
       }
     }.freeze
 
@@ -54,33 +58,8 @@ module Restitution
       partie.update(metriques: metriques)
     end
 
-    def temps_moyen_normalise(nom_moyenne, metrique_des_temps)
-      moyenne_glissante = partie.moyenne_metrique(nom_moyenne)
-      ecart_type_glissant = partie.ecart_type_metrique(nom_moyenne)
-
-      metrique_des_temps_normalises = Metriques::TempsNormalises.new(metrique_des_temps,
-                                                                     moyenne_glissante,
-                                                                     ecart_type_glissant)
-      Metriques::Moyenne
-        .new(metrique_des_temps_normalises)
-        .calcule(@evenements_situation, @evenements_entrainement)
-    end
-
-    def sous_score(nombre, nom_moyenne, metrique_des_temps)
-      return 0 if nombre.zero?
-
-      temps_moyen_normalise = temps_moyen_normalise(nom_moyenne, metrique_des_temps)
-
-      nombre / temps_moyen_normalise
-    end
-
     def score
-      sous_score(nombre_bonnes_reponses_francais,
-                 :temps_moyen_mots_francais,
-                 Maintenance::TempsMotsFrancais.new) *
-        sous_score(nombre_bonnes_reponses_non_mot,
-                   :temps_moyen_non_mots,
-                   Maintenance::TempsNonMots.new)
+      score_vocabulaire
     end
   end
 end

--- a/app/models/restitution/maintenance/score_vocabulaire.rb
+++ b/app/models/restitution/maintenance/score_vocabulaire.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Restitution
+  class Maintenance
+    class ScoreVocabulaire < Restitution::Metriques::Base
+      def initialize(metrique_nbr_mot_francais = Maintenance::NombreBonnesReponsesMotFrancais.new,
+                     metrique_nbr_non_mot = Maintenance::NombreBonnesReponsesNonMot.new)
+        @metrique_nbr_mot_francais = metrique_nbr_mot_francais
+        @metrique_nbr_non_mot = metrique_nbr_non_mot
+      end
+
+      def calcule(evenements_situation, _)
+        @evenements_situation = evenements_situation
+
+        sous_score(@metrique_nbr_mot_francais,
+                   :temps_moyen_mots_francais,
+                   Maintenance::TempsMotsFrancais.new) *
+          sous_score(@metrique_nbr_non_mot,
+                     :temps_moyen_non_mots,
+                     Maintenance::TempsNonMots.new)
+      end
+
+      def partie
+        @evenements_situation.first.partie
+      end
+
+      def temps_moyen_normalise(nom_moyenne, metrique_des_temps)
+        moyenne_glissante = partie.moyenne_metrique(nom_moyenne)
+        ecart_type_glissant = partie.ecart_type_metrique(nom_moyenne)
+
+        metrique_des_temps_normalises = Metriques::TempsNormalises.new(metrique_des_temps,
+                                                                       moyenne_glissante,
+                                                                       ecart_type_glissant)
+        Metriques::Moyenne
+          .new(metrique_des_temps_normalises)
+          .calcule(@evenements_situation, nil)
+      end
+
+      private
+
+      def sous_score(metrique_nombre, nom_moyenne, metrique_des_temps)
+        nombre = metrique_nombre.calcule(@evenements_situation, nil)
+        return 0 if nombre.zero?
+
+        temps_moyen_normalise = temps_moyen_normalise(nom_moyenne, metrique_des_temps)
+        return 0 unless temps_moyen_normalise.present?
+
+        nombre / temps_moyen_normalise
+      end
+    end
+  end
+end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -126,6 +126,7 @@ fr:
         temps_moyen_non_mots: Temps moyen de réponse correcte non-mots (en secondes)
         temps_moyen_mots_francais: Temps moyen de réponse correcte mot français (en secondes)
         nombre_bonnes_reponses_mot_français: Nombre de bonnes réponses (mot français)
+        score_vocabulaire: Score de reconnaissance du vocabulaire français
       restitution_colonnes:
         cote_z: Cote Z
         valeur_utilisateur: Valeur de l'évalué·e

--- a/spec/models/restitution/maintenance/score_vocabulaire_spec.rb
+++ b/spec/models/restitution/maintenance/score_vocabulaire_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Restitution::Maintenance::ScoreVocabulaire do
+  let(:mock_metrique_nombre_mot_francais) { double }
+  let(:mock_metrique_nombre_non_mot) { double }
+  let(:metrique_score_vocabulaire) do
+    described_class
+      .new(mock_metrique_nombre_mot_francais, mock_metrique_nombre_non_mot)
+  end
+
+  describe '#score' do
+    def pour_nombre(nombre_francais, nombre_non_mots)
+      allow(mock_metrique_nombre_mot_francais).to receive(:calcule).and_return(nombre_francais)
+      allow(mock_metrique_nombre_non_mot).to receive(:calcule).and_return(nombre_non_mots)
+    end
+
+    def score_pour(nombre_francais, temps_francais, nombre_non_mots, temps_non_mots)
+      pour_nombre(nombre_francais, nombre_non_mots)
+      allow(metrique_score_vocabulaire).to receive(:temps_moyen_normalise)
+        .and_return(temps_francais, temps_non_mots)
+
+      metrique_score_vocabulaire.calcule([], [])
+    end
+
+    it { expect(score_pour(0, nil, 0, nil)).to eq(0) }
+    it { expect(score_pour(2, 1.5, 0, nil)).to eq(0) }
+    it { expect(score_pour(2, nil, 5, 3)).to eq(0) }
+    it { expect(score_pour(2, 1.5, 5, 3)).to eq((2 / 1.5) * (5 / 3)) }
+  end
+
+  describe '#temps_moyen_normalise' do
+    context 'calcule le temps moyen normalises pour les mots francais' do
+      let!(:partie) { double }
+      let(:mock_metrique_temps) { double }
+
+      it do
+        allow(partie).to receive(:moyenne_metrique)
+          .with(:temps_moyen_mots_francais).and_return(2.7)
+        allow(partie).to receive(:ecart_type_metrique)
+          .with(:temps_moyen_mots_francais).and_return(0.5)
+
+        allow(metrique_score_vocabulaire).to receive(:partie).and_return(partie)
+
+        expect(mock_metrique_temps).to receive(:calcule).and_return([2.7, 3.7, 3.8])
+        temps_moyen_normalise = metrique_score_vocabulaire
+                                .temps_moyen_normalise(:temps_moyen_mots_francais,
+                                                       mock_metrique_temps)
+        expect(temps_moyen_normalise).to eq((2.7 + 3.7) / 2.0)
+      end
+    end
+  end
+end

--- a/spec/models/restitution/maintenance_spec.rb
+++ b/spec/models/restitution/maintenance_spec.rb
@@ -30,40 +30,4 @@ describe Restitution::Maintenance do
       end
     end
   end
-
-  describe '#score' do
-    def score_pour(nombre_francais, temps_francais, nombre_non_mots, temps_non_mots)
-      allow(restitution).to receive(:temps_moyen_normalise)
-        .and_return(temps_francais, temps_non_mots)
-      allow(restitution).to receive_messages(nombre_bonnes_reponses_francais: nombre_francais,
-                                             nombre_bonnes_reponses_non_mot: nombre_non_mots)
-      restitution.score
-    end
-
-    it { expect(score_pour(0, nil, 0, nil)).to eq(0) }
-    it { expect(score_pour(2, 1.5, 0, nil)).to eq(0) }
-    it { expect(score_pour(2, 1.5, 5, 3)).to eq((2 / 1.5) * (5 / 3)) }
-  end
-
-  describe '#temps_moyen_normalise' do
-    context 'calcule le temps moyen normalises pour les mots francais' do
-      let(:situation) { create :situation_maintenance }
-      let(:evaluation) { create :evaluation, campagne: campagne }
-      let!(:partie) { create :partie, situation: situation, evaluation: evaluation }
-      let(:mock_metrique_temps) { double }
-
-      it do
-        allow(partie).to receive(:moyenne_metrique)
-          .with(:temps_moyen_mots_francais).and_return(2.7)
-        allow(partie).to receive(:ecart_type_metrique)
-          .with(:temps_moyen_mots_francais).and_return(0.5)
-        allow(restitution).to receive(:partie).and_return(partie)
-
-        expect(mock_metrique_temps).to receive(:calcule).and_return([2.7, 3.7, 3.8])
-        temps_moyen_normalise = restitution.temps_moyen_normalise(:temps_moyen_mots_francais,
-                                                                  mock_metrique_temps)
-        expect(temps_moyen_normalise).to eq((2.7 + 3.7) / 2.0)
-      end
-    end
-  end
 end

--- a/spec/models/restitution/maintenance_spec.rb
+++ b/spec/models/restitution/maintenance_spec.rb
@@ -30,4 +30,20 @@ describe Restitution::Maintenance do
       end
     end
   end
+
+  describe '#score' do
+    context 'avec une partie dont la cote z du score est -1' do
+      let(:partie) { double }
+      let(:evenements) do
+        [build(:evenement_demarrage)]
+      end
+
+      it do
+        expect(partie).to receive(:cote_z_metriques).and_return('score_vocabulaire' => -1)
+
+        expect(evenements.first).to receive(:partie).and_return(partie)
+        expect(restitution.score).to eq(-1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
fix betagouv/eva#799

Le score de la maintenance est la code z du score de vocabulaire.

Cette PR déplace le calcule de score précédent dans une métrique, de manière à pouvoir en tirer le calcul de la cote Z.

Puis le score est simplement une reprise de cette cote z.

<img width="1384" alt="Capture d’écran 2020-03-10 à 16 11 21" src="https://user-images.githubusercontent.com/298214/76329156-7f8d6c00-62ec-11ea-81b2-7014a9926a39.png">
