### PR TITLE
Ajoute les réponses aux questions dans la restitution globale pour la Livraison

### DIFF
--- a/app/models/restitution/livraison.rb
+++ b/app/models/restitution/livraison.rb
@@ -1,6 +1,48 @@
 # frozen_string_literal: true
 
 module Restitution
-  class Livraison < Base
+  class Livraison < AvecEntrainement
+    EVENEMENT = {
+      REPONSE: 'reponse'
+    }.freeze
+
+    def termine?
+      super || reponses.size == questions.size
+    end
+
+    def questions_et_reponses
+      questions_repondues
+        .map do |question|
+        {
+          question: question,
+          reponse: trouve_reponse(question.id)
+        }
+      end
+    end
+
+    def reponses
+      evenements_situation.find_all { |e| e.nom == EVENEMENT[:REPONSE] }
+    end
+
+    def efficience
+      nil
+    end
+
+    private
+
+    def questions
+      situation.questionnaire.questions
+    end
+
+    def questions_repondues
+      questions_ids = reponses.collect { |r| r.donnees['question'] }
+      questions.where(id: questions_ids)
+    end
+
+    def trouve_reponse(question_id)
+      reponses.find do |evenement|
+        evenement.donnees['question'] == question_id
+      end.donnees['reponse']
+    end
   end
 end

--- a/app/views/admin/evaluations/_livraison.arb
+++ b/app/views/admin/evaluations/_livraison.arb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+div class: 'row questions' do
+  restitution.questions_et_reponses.each do |question_et_reponse|
+    div class: 'col-4 px-5 mb-4' do
+      div strong question_et_reponse[:question].libelle
+      if question_et_reponse[:question].is_a?(QuestionQcm)
+        div class: 'btn-group my-2' do
+          %w[bon mauvais].each do |nom|
+            choix = question_et_reponse[:question].choix.find(question_et_reponse[:reponse])
+            active = nom == choix.type_choix ? 'active' : ''
+            button class: "btn #{active}" do
+              t(".#{nom}")
+            end
+          end
+        end
+      else
+        div simple_format(question_et_reponse[:reponse]), class: 'reponse-communication-ecrite'
+      end
+    end
+  end
+end

--- a/spec/models/restitution/livraison_spec.rb
+++ b/spec/models/restitution/livraison_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Restitution::Livraison do
+  let(:evaluation) { create :evaluation, nom: 'Test' }
+  let(:question1)  { create :question_qcm, intitule: 'Ma question 1' }
+  let(:question2)  { create :question_qcm, intitule: 'Ma question 2' }
+  let(:questionnaire) { create :questionnaire, questions: [question1, question2] }
+  let!(:partie) { create :partie, situation: situation, evaluation: evaluation }
+  let(:situation) do
+    create :situation,
+           libelle: 'Livraison',
+           nom_technique: 'livraison',
+           questionnaire: questionnaire
+  end
+  let(:campagne) { build :campagne }
+
+  describe '#termine?' do
+    it "lorsque aucune questions n'a encore été répondu" do
+      evenements = [build(:evenement_demarrage)]
+      restitution = described_class.new(campagne, evenements)
+      expect(restitution).to_not be_termine
+    end
+
+    it 'lorsque une des questions a été répondu' do
+      evenements = [
+        build(:evenement_demarrage),
+        build(:evenement_reponse, donnees: { question: question1.id, reponse: 1 })
+      ]
+      restitution = described_class.new(campagne, evenements)
+      expect(restitution).to_not be_termine
+    end
+
+    it 'lorsque les 2 questions ont été répondu' do
+      evenements = [
+        build(:evenement_demarrage),
+        build(:evenement_reponse, donnees: { question: question1.id, reponse: 1 }),
+        build(:evenement_reponse, donnees: { question: question2.id, reponse: 2 })
+      ]
+      restitution = described_class.new(campagne, evenements)
+      expect(restitution).to be_termine
+    end
+
+    it "avec l'événement de fin de situation" do
+      evenements = [
+        build(:evenement_demarrage),
+        build(:evenement_fin_situation)
+      ]
+      restitution = described_class.new(campagne, evenements)
+      expect(restitution).to be_termine
+    end
+  end
+
+  describe '#questions_et_reponses' do
+    it "retourne aucune question et réponse si aucune n'a été répondu" do
+      evenements = [
+        build(:evenement_demarrage)
+      ]
+      restitution = described_class.new(campagne, evenements)
+      expect(restitution.questions_et_reponses.size).to eq(0)
+    end
+
+    it 'retourne les questions et les réponses du questionnaire' do
+      evenements = [
+        build(:evenement_demarrage),
+        build(:evenement_reponse,
+              donnees: { question: question1.id, reponse: 1 })
+      ]
+      restitution = described_class.new(campagne, evenements)
+      expect(restitution.questions_et_reponses.size).to eq(1)
+      expect(restitution.questions_et_reponses.first[:question]).to eql(question1)
+      expect(restitution.questions_et_reponses.first[:reponse]).to eql(1)
+    end
+  end
+
+  describe '#reponses' do
+    it 'retourne toutes les réponses' do
+      evenements = [
+        build(:evenement_demarrage),
+        build(:evenement_reponse),
+        build(:evenement_reponse)
+      ]
+      restitution = described_class.new(campagne, evenements)
+      expect(restitution.reponses.size).to eql(2)
+    end
+
+    it 'retourne seulement les événements réponses' do
+      evenements = [
+        build(:evenement_demarrage),
+        build(:evenement_reponse)
+      ]
+      restitution = described_class.new(campagne, evenements)
+      expect(restitution.reponses.size).to eql(1)
+    end
+  end
+
+  describe '#efficience' do
+    it 'retourne nil' do
+      restitution = described_class.new(campagne, [])
+      expect(restitution.efficience).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Fix betagouv/eva#814

<img width="959" alt="Capture d’écran 2020-03-13 à 13 00 44" src="https://user-images.githubusercontent.com/298214/76619252-b781f280-652a-11ea-9265-3e453a783c55.png">

Après discussion avec @GaelleOttan, cette PR n'implémente pas la remonté des informations dans le rapport de livraison car c'est innutile.
