### PR TITLE
Corrige l'affichage pdf des énumérés contenant "non obs."

### DIFF
--- a/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
+++ b/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
@@ -76,6 +76,10 @@
 
   .btn-group {
     border: none;
+
+    .btn {
+      font-size: 0.75rem;
+    }
   }
   h3 {
     margin: 2rem;


### PR DESCRIPTION
Avant :
<img width="929" alt="Capture d’écran 2020-03-13 à 13 29 13" src="https://user-images.githubusercontent.com/298214/76621164-0b8ed600-652f-11ea-8ac8-a2b64441f364.png">
Après
<img width="951" alt="Capture d’écran 2020-03-13 à 13 28 58" src="https://user-images.githubusercontent.com/298214/76621170-0fbaf380-652f-11ea-8a24-93503cdf48be.png">
