### PR TITLE
Admin : reduit les drois de suppressions des questions et des questionnaires

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -62,6 +62,9 @@ class Ability
 
   def droit_question
     can :read, Question
+    cannot :destroy, Question do |q|
+      QuestionnaireQuestion.where(question: q).present?
+    end
   end
 
   def droits_generiques(compte)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -53,7 +53,10 @@ class Ability
   def droit_questionnaire
     can :read, Questionnaire
     cannot :destroy, Questionnaire do |q|
-      Campagne.where(questionnaire: q).present?
+      Campagne.where(questionnaire: q).present? ||
+        Situation.where(questionnaire: q)
+                 .or(Situation.where(questionnaire_entrainement: q))
+                 .present?
     end
   end
 

--- a/db/migrate/20200313143848_ajoute_foreign_key_choix_question_suppression_cascade.rb
+++ b/db/migrate/20200313143848_ajoute_foreign_key_choix_question_suppression_cascade.rb
@@ -1,0 +1,6 @@
+class AjouteForeignKeyChoixQuestionSuppressionCascade < ActiveRecord::Migration[6.0]
+  def change
+    remove_foreign_key :choix, :questions
+    add_foreign_key :choix, :questions, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_26_110444) do
+ActiveRecord::Schema.define(version: 2020_03_13_143848) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -169,7 +169,7 @@ ActiveRecord::Schema.define(version: 2020_02_26_110444) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "campagnes", "comptes"
   add_foreign_key "campagnes", "questionnaires"
-  add_foreign_key "choix", "questions"
+  add_foreign_key "choix", "questions", on_delete: :cascade
   add_foreign_key "evaluations", "campagnes"
   add_foreign_key "evenements", "parties", column: "session_id", primary_key: "session_id", on_delete: :cascade
   add_foreign_key "parties", "evaluations", on_delete: :cascade

--- a/spec/factories/situation.rb
+++ b/spec/factories/situation.rb
@@ -26,5 +26,10 @@ FactoryBot.define do
       libelle { 'Maintenance' }
       nom_technique { 'maintenance' }
     end
+
+    factory :situation_livraison do
+      libelle { 'Livraison' }
+      nom_technique { 'livraison' }
+    end
   end
 end

--- a/spec/features/questionnaire_spec.rb
+++ b/spec/features/questionnaire_spec.rb
@@ -5,16 +5,10 @@ require 'rails_helper'
 describe 'Admin - Questionnaire', type: :feature do
   before { se_connecter_comme_administrateur }
   let!(:questionnaire) { create :questionnaire, libelle: 'Numératie et Litératie' }
-  let!(:campagne) { create :campagne, questionnaire: questionnaire }
 
   describe 'index' do
     before { visit admin_questionnaires_path }
-    it do
-      expect(page).to have_content 'Numératie et Litératie'
-      within '.paginated_collection' do
-        expect(page).to_not have_content 'Supprimer'
-      end
-    end
+    it { expect(page).to have_content 'Numératie et Litératie' }
   end
 
   describe 'création' do

--- a/spec/integrations/ability_spec.rb
+++ b/spec/integrations/ability_spec.rb
@@ -35,7 +35,6 @@ describe Ability do
     it { is_expected.to be_able_to(:read, Evenement.new) }
     it { is_expected.to be_able_to(:manage, Situation.new) }
     it { is_expected.to be_able_to(:manage, Campagne.new) }
-    it { is_expected.to be_able_to(:manage, Question.new) }
     it { is_expected.to be_able_to(:manage, Restitution::Base.new(nil, nil)) }
 
     it 'avec une campagne qui a des évaluations' do
@@ -75,6 +74,18 @@ describe Ability do
         let!(:situation) { create :situation_livraison, questionnaire_entrainement: questionnaire }
 
         it { is_expected.to_not be_able_to(:destroy, questionnaire) }
+      end
+    end
+
+    describe 'Droits des questions' do
+      let(:question) { create(:question) }
+
+      it { is_expected.to be_able_to(:manage, Question.new) }
+
+      context "quand un questionnaire l'utilise" do
+        let!(:questionnaire) { create :questionnaire, questions: [question] }
+
+        it { is_expected.to_not be_able_to(:destroy, question) }
       end
     end
   end

--- a/spec/integrations/ability_spec.rb
+++ b/spec/integrations/ability_spec.rb
@@ -35,7 +35,6 @@ describe Ability do
     it { is_expected.to be_able_to(:read, Evenement.new) }
     it { is_expected.to be_able_to(:manage, Situation.new) }
     it { is_expected.to be_able_to(:manage, Campagne.new) }
-    it { is_expected.to be_able_to(:manage, Questionnaire.new) }
     it { is_expected.to be_able_to(:manage, Question.new) }
     it { is_expected.to be_able_to(:manage, Restitution::Base.new(nil, nil)) }
 
@@ -53,6 +52,30 @@ describe Ability do
 
     it 'avec une situation non utilisé dans des campagne' do
       is_expected.to be_able_to(:destroy, situation)
+    end
+
+    describe 'Droits des questionnaires' do
+      let(:questionnaire) { create :questionnaire }
+
+      it { is_expected.to be_able_to(:manage, Questionnaire.new) }
+
+      context "quand une campagne l'utilise" do
+        let!(:campagne) { create :campagne, questionnaire: questionnaire }
+
+        it { is_expected.to_not be_able_to(:destroy, questionnaire) }
+      end
+
+      context "quand une situation l'utilise comme questionnaire principal" do
+        let!(:situation) { create :situation_livraison, questionnaire: questionnaire }
+
+        it { is_expected.to_not be_able_to(:destroy, questionnaire) }
+      end
+
+      context "quand une situation l'utilise comme questionnaire d'entrainement" do
+        let!(:situation) { create :situation_livraison, questionnaire_entrainement: questionnaire }
+
+        it { is_expected.to_not be_able_to(:destroy, questionnaire) }
+      end
     end
   end
 


### PR DESCRIPTION
- Les questionnaires ne sont plus supprimables s'ils sont utilisés dans des situations
- Les questions ne sont pas supprimables si elles sont utilisés dans les questionnaires
- Supprimer une question supprime aussi ses choix.

fix: betagouv/eva#816