### PR TITLE
Évalue la compétence de base "Vocabulaire" dans la Maintenance

### DIFF
--- a/app/admin/restitutions.rb
+++ b/app/admin/restitutions.rb
@@ -34,6 +34,7 @@ ActiveAdmin.register Partie, as: 'Restitutions' do
            moyenne_glissante: OpenStruct.new(resource.partie.moyenne_metriques),
            ecart_type_glissant: OpenStruct.new(resource.partie.ecart_type_metriques),
            cote_z: OpenStruct.new(resource.partie.cote_z_metriques)
+    render 'restitution_competences_de_base', restitution: resource
     render 'restitution_competences', restitution: resource
   end
 

--- a/app/models/competence.rb
+++ b/app/models/competence.rb
@@ -18,4 +18,6 @@ module Competence
   ATTENTION_CONCENTRATION = :attention_concentration
   ORGANISATION_METHODE = :organisation_methode
   VIGILANCE_CONTROLE = :vigilance_controle
+
+  VOCABULAIRE = :vocabulaire
 end

--- a/app/models/restitution/base.rb
+++ b/app/models/restitution/base.rb
@@ -64,6 +64,10 @@ module Restitution
       evenements.last.nom == EVENEMENT[:FIN_SITUATION]
     end
 
+    def competences_de_base
+      {}
+    end
+
     def competences
       {}
     end

--- a/app/models/restitution/maintenance.rb
+++ b/app/models/restitution/maintenance.rb
@@ -58,10 +58,6 @@ module Restitution
       partie.update(metriques: metriques)
     end
 
-    def score
-      partie.cote_z_metriques['score_vocabulaire']
-    end
-
     def competences_de_base
       calcule_competences(
         ::Competence::VOCABULAIRE => Maintenance::Vocabulaire

--- a/app/models/restitution/maintenance.rb
+++ b/app/models/restitution/maintenance.rb
@@ -61,5 +61,11 @@ module Restitution
     def score
       partie.cote_z_metriques['score_vocabulaire']
     end
+
+    def competences_de_base
+      calcule_competences(
+        ::Competence::VOCABULAIRE => Maintenance::Vocabulaire
+      )
+    end
   end
 end

--- a/app/models/restitution/maintenance/vocabulaire.rb
+++ b/app/models/restitution/maintenance/vocabulaire.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Restitution
+  class Maintenance
+    class Vocabulaire < Restitution::Competence::Base
+      def niveau
+        score = @restitution.score
+        if score > -0.4 then ::Competence::NIVEAU_1
+        elsif score > -2 then ::Competence::NIVEAU_2
+        else ::Competence::NIVEAU_3
+        end
+      end
+    end
+  end
+end

--- a/app/models/restitution/maintenance/vocabulaire.rb
+++ b/app/models/restitution/maintenance/vocabulaire.rb
@@ -4,7 +4,7 @@ module Restitution
   class Maintenance
     class Vocabulaire < Restitution::Competence::Base
       def niveau
-        score = @restitution.score
+        score = @restitution.partie.cote_z_metriques['score_vocabulaire']
         if score > -0.4 then ::Competence::NIVEAU_1
         elsif score > -2 then ::Competence::NIVEAU_2
         else ::Competence::NIVEAU_3

--- a/app/views/admin/restitutions/_restitution_competences.html.arb
+++ b/app/views/admin/restitutions/_restitution_competences.html.arb
@@ -7,6 +7,5 @@ panel t('.titre') do
             scope: 'admin.evaluations.restitution_competence')) { niveau }
     end
     row(t('.efficience')) { formate_efficience(restitution.efficience) }
-    row :score
   end
 end

--- a/app/views/admin/restitutions/_restitution_competences_de_base.html.arb
+++ b/app/views/admin/restitutions/_restitution_competences_de_base.html.arb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+panel t('.titre') do
+  return if resource.competences_de_base.empty?
+
+  attributes_table_for restitution do
+    restitution.competences_de_base.each do |competence, niveau|
+      row(t("#{competence}.nom",
+            scope: 'admin.evaluations.restitution_competence')) { niveau }
+    end
+  end
+end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -35,6 +35,8 @@ fr:
         apte: Apte
         apte_avec_aide: Apte avec aide
 
+        vocabulaire:
+          nom: Vocabulaire
         comprehension_consigne:
           nom: Compréhension de la consigne
           titre: La consigne de l’exercice a été comprise
@@ -78,6 +80,8 @@ fr:
         echec: Échec
         termine: Terminé
         indetermine: Indéterminée car abandon
+      restitution_competences_de_base:
+        titre: Évaluation des compétences de base
       restitution_competences:
         titre: Évaluation des compétences
         efficience: Efficience

--- a/spec/models/restitution/maintenance/vocabulaire_spec.rb
+++ b/spec/models/restitution/maintenance/vocabulaire_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Restitution::Maintenance::Vocabulaire do
+  let(:restitution) { double }
+
+  def niveau_pour_score(score)
+    allow(restitution).to receive(:score).and_return(score)
+
+    described_class.new(restitution)
+  end
+
+  it { expect(niveau_pour_score(-0.39)).to evalue_a(Competence::NIVEAU_1) }
+  it { expect(niveau_pour_score(-0.4)).to evalue_a(Competence::NIVEAU_2) }
+  it { expect(niveau_pour_score(-1.99)).to evalue_a(Competence::NIVEAU_2) }
+  it { expect(niveau_pour_score(-2)).to evalue_a(Competence::NIVEAU_3) }
+end

--- a/spec/models/restitution/maintenance/vocabulaire_spec.rb
+++ b/spec/models/restitution/maintenance/vocabulaire_spec.rb
@@ -4,9 +4,11 @@ require 'rails_helper'
 
 describe Restitution::Maintenance::Vocabulaire do
   let(:restitution) { double }
+  let(:partie) { double }
 
   def niveau_pour_score(score)
-    allow(restitution).to receive(:score).and_return(score)
+    expect(partie).to receive(:cote_z_metriques).and_return('score_vocabulaire' => score)
+    allow(restitution).to receive(:partie).and_return(partie)
 
     described_class.new(restitution)
   end

--- a/spec/models/restitution/maintenance_spec.rb
+++ b/spec/models/restitution/maintenance_spec.rb
@@ -30,20 +30,4 @@ describe Restitution::Maintenance do
       end
     end
   end
-
-  describe '#score' do
-    context 'avec une partie dont la cote z du score est -1' do
-      let(:partie) { double }
-      let(:evenements) do
-        [build(:evenement_demarrage)]
-      end
-
-      it do
-        expect(partie).to receive(:cote_z_metriques).and_return('score_vocabulaire' => -1)
-
-        expect(evenements.first).to receive(:partie).and_return(partie)
-        expect(restitution.score).to eq(-1)
-      end
-    end
-  end
 end


### PR DESCRIPTION
Cette PR contribue à betagouv/eva#815

Elle évalue sur une échelle de 1 à 3 le niveau de vocabulaire en fonction du score et l'affiche dans le rapport.

<img width="1410" alt="Capture d’écran 2020-03-15 à 08 26 13" src="https://user-images.githubusercontent.com/298214/76697362-ad7d0280-6696-11ea-9e33-0e50595b5740.png">

J'ai ré-utilisé une parti de la structure des compétences transversales… 