### PR TITLE
Ajoute un filtre par situation dans les événements

### DIFF
--- a/app/admin/evenements.rb
+++ b/app/admin/evenements.rb
@@ -6,12 +6,15 @@ ActiveAdmin.register Evenement do
   includes partie: %i[situation evaluation]
 
   filter :partie, collection: proc { Partie.pluck(:session_id) }
+  filter :partie_situation_nom_technique, label: 'Situation',
+                                          as: :select,
+                                          collection: proc { Situation.pluck(:nom_technique) }
   filter :date
 
   colonnes_evenement = proc do
     column(:evaluation) { |e| e.evaluation.display_name }
     column(:situation) { |e| e.situation.display_name }
-    column(:partie) { |e| e.partie.display_name }
+    column(:partie) { |e| auto_link(e.partie) }
     column :nom
     column :donnees
     column(:date) { |e| l(e.date, format: :date_heure) }


### PR DESCRIPTION
**Problème**: Avec la multiplication des évaluations c'est compliqué de retrouver une restitution pour une situation donnée, sachant que l'on ne sait pas quelle situation a été faite dans une évaluation. (cf: le nombre d'essais infructueux que l'on fait en démo produit pour démontrer l'ajout d'une métrique sur une restitution)

**Solution**: Ajout d'un filtre par situation dans l'index des `évenements` et ajout d'un lien sur la `partie` pour arriver directement sur la `restitution`.



