### PR TITLE
Retire l'efficience globale de la fiche de restitution

### DIFF
--- a/app/assets/stylesheets/restitution_globale/_base.scss
+++ b/app/assets/stylesheets/restitution_globale/_base.scss
@@ -1,10 +1,10 @@
 @import "variables";
 
 @mixin applique-theme($couleur) {
-  .progress, .btn {
+  .btn {
     background: rgba($couleur, .2);
   }
-  .progress-bar, .badge, .btn.active {
+  .badge, .btn.active {
     background: $couleur;
     border-color: $couleur;
   }
@@ -45,20 +45,6 @@
   #active_admin_content {
     border-top: none;
     padding-top: 0;
-  }
-
-  .progress {
-    height: 1.5rem;
-    border-radius: $border-radius;
-    border: solid 1px #9ebcd5;
-    box-shadow: inset 0px 0px 0px 1px #ffffff !important;
-    padding: 1px;
-    font-size: 0.875rem;
-    color-adjust: exact;
-
-    .progress-bar {
-      border-radius: $border-radius;
-    }
   }
 
   .badge {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,10 +7,6 @@ module ApplicationHelper
     number_to_percentage(nombre, precision: 0)
   end
 
-  def progression_efficience(nombre)
-    nombre.is_a?(Symbol) ? 0 : nombre
-  end
-
   def formate_duree(duree)
     return if duree.blank?
 

--- a/app/views/admin/evaluations/_restitution_globale.arb
+++ b/app/views/admin/evaluations/_restitution_globale.arb
@@ -62,27 +62,6 @@ div class: 'admin_restitution_globale' do
     end
   end
 
-  panel 'Efficiences par situations' do
-    div class: :row do
-      restitution_globale.restitutions.each do |restitution|
-        next if restitution.efficience.nil?
-
-        situation = restitution.situation
-        div class: "#{rapport_colonne_class} #{situation.nom_technique}" do
-          div t('.situation', situation: situation.libelle)
-          div class: :progress do
-            efficience = progression_efficience(restitution.efficience)
-            div class: 'progress-bar', role: 'progressbar', style: "width: #{efficience}%",
-                'aria-valuemin': 0, 'aria-valuemax': 100, 'aria-valuenow': efficience do
-              formate_efficience(restitution.efficience)
-            end
-          end
-        end
-      end
-      nil
-    end
-  end
-
   restitution_globale.restitutions.each do |restitution|
     situation = restitution.situation
     panel t('.situation', situation: situation.libelle) do

--- a/app/views/admin/evaluations/_restitution_globale.arb
+++ b/app/views/admin/evaluations/_restitution_globale.arb
@@ -62,12 +62,6 @@ div class: 'admin_restitution_globale' do
     end
   end
 
-  h2 class: 'text-center' do
-    span class: 'btn btn-info btn-lg' do
-      t('.efficience_globale', efficience: formate_efficience(restitution_globale.efficience))
-    end
-  end
-
   panel 'Efficiences par situations' do
     div class: :row do
       restitution_globale.restitutions.each do |restitution|

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -22,7 +22,6 @@ fr:
         reste_plateau: Reste plateau
       restitution_globale:
         situation: 'Situation %{situation}'
-        efficience_globale: "Efficience globale : %{efficience}"
         competences_fortes_titre: "Classement eva de vos compétences"
         legende_titre: "(de la plus forte à la moins forte)"
         url_competence: 'Détail et liste des métiers associés :'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -14,16 +14,6 @@ describe ApplicationHelper do
     end
   end
 
-  describe '#progression_efficience' do
-    it 'retourne la valeur' do
-      expect(helper.progression_efficience(5.3)).to eql(5.3)
-    end
-
-    it "retourne 0 si l'efficience est indéterminée" do
-      expect(helper.progression_efficience(::Competence::NIVEAU_INDETERMINE)).to eql(0)
-    end
-  end
-
   describe '#formate_duree' do
     it 'retourne la durée en minutes et secondes' do
       expect(helper.formate_duree(60)).to eql('01:00')


### PR DESCRIPTION
Retire l'affichage de l'efficience globale.

fix betagouv/eva#833

J'ai gardé le code qui calcule cette efficience et je ne sais pas si j'ai bien fait. Je manque d'éléments pour savoir si on fait un "hack" pour la présentation court terme ou bien si c'est une volonté sur le long terme.

![Capture d’écran 2020-03-23 à 16 56 31](https://user-images.githubusercontent.com/28393/77336264-8de57a00-6d27-11ea-9f5a-6c74c6e38624.png)
![Capture d’écran 2020-03-23 à 16 57 10](https://user-images.githubusercontent.com/28393/77336273-90e06a80-6d27-11ea-9e26-fc881b685d2e.png)
