### PR TITLE
Utilise openstack en prod uniquement si l'environnement est configuré

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :openstack
+  config.active_storage.service = ENV['OS_USERNAME'].present? ? :openstack : :local
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
permet de déployer la prod actuelle sans qu'elle soit migrée sur Scalingo

relatif à betagouv/eva#821