### PR TITLE
Affiche les utilisations par les structures dans l'admin

### DIFF
--- a/app/views/admin/dashboard/_dashboard.html.arb
+++ b/app/views/admin/dashboard/_dashboard.html.arb
@@ -12,3 +12,15 @@ panel t('.dernieres_evaluations.titre') do
     end
   end
 end
+
+if can?(:manage, Compte)
+  panel t('.statistiques.titre') do
+    text_node %(<iframe
+      src="http://metabase.eva.beta.gouv.fr/public/dashboard/f9549f07-b9a1-4fe7-8961-2a127bf27d22"
+      frameborder="0"
+      width="100%"
+      height="600"
+      allowtransparency
+    ></iframe>).html_safe
+  end
+end

--- a/config/locales/views/dashboard.yml
+++ b/config/locales/views/dashboard.yml
@@ -4,3 +4,5 @@ fr:
       dashboard:
         dernieres_evaluations:
           titre: Dernières évaluations
+        statistiques:
+          titre: Statistiques


### PR DESCRIPTION
Afin de nous garder focalisé sur le déploiement et de constater nos progrès, cette PR propose d'afficher l'usage pas les structures directement sur la page d'accueil de l'admin.

Puisqu'on voit tous cette page au moins fois par semaine en démo, ça m'a semblé opportun de le mettre ici.

Ces statistiques ne sont affichées qu'aux admin pour des raisons de confidentialité

![Capture d’écran 2020-04-03 à 14 11 49](https://user-images.githubusercontent.com/28393/78359340-33fd7380-75b5-11ea-8071-386ec9985bd5.png)
