### PR TITLE
Livraison/métrique bonnes réponses

### DIFF
--- a/app/models/restitution/livraison.rb
+++ b/app/models/restitution/livraison.rb
@@ -21,7 +21,7 @@ module Restitution
         .map do |question|
         {
           question: question,
-          reponse: trouve_reponse(question.id)
+          reponse: trouve_reponse(question)
         }
       end
     end
@@ -36,8 +36,7 @@ module Restitution
 
     def nombre_bonnes_reponses
       questions_et_reponses.select do |question_et_reponse|
-        choix = question_et_reponse[:question].choix.find(question_et_reponse[:reponse])
-        choix.bon?
+        question_et_reponse[:reponse].bon?
       end.count
     end
 
@@ -52,10 +51,11 @@ module Restitution
       questions.where(id: questions_ids, type: 'QuestionQcm')
     end
 
-    def trouve_reponse(question_id)
-      reponses.find do |evenement|
-        evenement.donnees['question'] == question_id
+    def trouve_reponse(question)
+      reponse_id = reponses.find do |evenement|
+        evenement.donnees['question'] == question.id
       end.donnees['reponse']
+      question.choix.find reponse_id
     end
   end
 end

--- a/app/models/restitution/livraison.rb
+++ b/app/models/restitution/livraison.rb
@@ -17,7 +17,7 @@ module Restitution
     end
 
     def questions_et_reponses
-      questions_repondues
+      questions_qcm_repondues
         .map do |question|
         {
           question: question,
@@ -47,9 +47,9 @@ module Restitution
       situation.questionnaire.questions
     end
 
-    def questions_repondues
+    def questions_qcm_repondues
       questions_ids = reponses.collect { |r| r.donnees['question'] }
-      questions.where(id: questions_ids)
+      questions.where(id: questions_ids, type: 'QuestionQcm')
     end
 
     def trouve_reponse(question_id)

--- a/app/models/restitution/livraison.rb
+++ b/app/models/restitution/livraison.rb
@@ -6,6 +6,12 @@ module Restitution
       REPONSE: 'reponse'
     }.freeze
 
+    METRIQUES = {
+      'nombre_bonnes_reponses' => {
+        'type' => :nombre
+      }
+    }.freeze
+
     def termine?
       super || reponses.size == questions.size
     end
@@ -26,6 +32,13 @@ module Restitution
 
     def efficience
       nil
+    end
+
+    def nombre_bonnes_reponses
+      questions_et_reponses.select do |question_et_reponse|
+        choix = question_et_reponse[:question].choix.find(question_et_reponse[:reponse])
+        choix.bon?
+      end.count
     end
 
     private

--- a/app/views/admin/evaluations/_livraison.arb
+++ b/app/views/admin/evaluations/_livraison.arb
@@ -2,20 +2,18 @@
 
 div class: 'row questions' do
   restitution.questions_et_reponses.each do |question_et_reponse|
+    choix = question_et_reponse[:reponse]
+    question = question_et_reponse[:question]
+
     div class: 'col-4 px-5 mb-4' do
-      div strong question_et_reponse[:question].libelle
-      if question_et_reponse[:question].is_a?(QuestionQcm)
-        div class: 'btn-group my-2' do
-          %w[bon mauvais].each do |nom|
-            choix = question_et_reponse[:question].choix.find(question_et_reponse[:reponse])
-            active = nom == choix.type_choix ? 'active' : ''
-            button class: "btn #{active}" do
-              t(".#{nom}")
-            end
+      div strong question.libelle
+      div class: 'btn-group my-2' do
+        %w[bon mauvais].each do |nom|
+          active = nom == choix.type_choix ? 'active' : ''
+          button class: "btn #{active}" do
+            t(".#{nom}")
           end
         end
-      else
-        div simple_format(question_et_reponse[:reponse]), class: 'reponse-communication-ecrite'
       end
     end
   end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -130,6 +130,8 @@ fr:
         temps_moyen_mots_francais: Temps moyen de réponse correcte mot français (en secondes)
         nombre_bonnes_reponses_mot_français: Nombre de bonnes réponses (mot français)
         score_vocabulaire: Score de reconnaissance du vocabulaire français
+
+        nombre_bonnes_reponses: Nombre de bonnes réponses
       restitution_colonnes:
         cote_z: Cote Z
         valeur_utilisateur: Valeur de l'évalué·e

--- a/spec/factories/choix.rb
+++ b/spec/factories/choix.rb
@@ -2,5 +2,9 @@
 
 FactoryBot.define do
   factory :choix do
+    trait :bon do
+      type_choix { :bon }
+      intitule { 'bon choix' }
+    end
   end
 end

--- a/spec/factories/question.rb
+++ b/spec/factories/question.rb
@@ -7,6 +7,11 @@ FactoryBot.define do
   end
 
   factory :question_qcm do
-    libelle { 'Question' }
+    libelle { 'Question QCM' }
+  end
+
+  factory :question_redaction_note do
+    libelle { 'Question Redaction Note' }
+    intitule { 'Ecrivez une note' }
   end
 end

--- a/spec/models/restitution/livraison_spec.rb
+++ b/spec/models/restitution/livraison_spec.rb
@@ -53,24 +53,39 @@ describe Restitution::Livraison do
   end
 
   describe '#questions_et_reponses' do
-    it "retourne aucune question et réponse si aucune n'a été répondu" do
-      evenements = [
-        build(:evenement_demarrage)
-      ]
-      restitution = described_class.new(campagne, evenements)
-      expect(restitution.questions_et_reponses.size).to eq(0)
+    let(:restitution) { described_class.new(campagne, evenements) }
+    context "retourne aucune question et réponse si aucune n'a été répondu" do
+      let(:evenements) { [build(:evenement_demarrage)] }
+      it { expect(restitution.questions_et_reponses).to eq([]) }
     end
 
-    it 'retourne les questions et les réponses du questionnaire' do
-      evenements = [
-        build(:evenement_demarrage),
-        build(:evenement_reponse,
-              donnees: { question: question1.id, reponse: 1 })
-      ]
-      restitution = described_class.new(campagne, evenements)
-      expect(restitution.questions_et_reponses.size).to eq(1)
-      expect(restitution.questions_et_reponses.first[:question]).to eql(question1)
-      expect(restitution.questions_et_reponses.first[:reponse]).to eql(1)
+    context 'retourne les questions et les réponses du questionnaire' do
+      let(:evenements) do
+        [
+          build(:evenement_demarrage),
+          build(:evenement_reponse,
+                donnees: { question: question1.id, reponse: 1 })
+        ]
+      end
+      it do
+        expect(restitution.questions_et_reponses.size).to eq(1)
+        expect(restitution.questions_et_reponses.first[:question]).to eql(question1)
+        expect(restitution.questions_et_reponses.first[:reponse]).to eql(1)
+      end
+    end
+
+    context 'ignore les réponses aux questions qui ne sont pas une Question QCM' do
+      let(:question_redaction_note) { create :question_redaction_note }
+      let(:questionnaire) { create :questionnaire, questions: [question_redaction_note] }
+
+      let(:evenements) do
+        [
+          build(:evenement_demarrage),
+          build(:evenement_reponse,
+                donnees: { question: question_redaction_note.id, reponse: 'coucou' })
+        ]
+      end
+      it { expect(restitution.questions_et_reponses).to eq([]) }
     end
   end
 

--- a/spec/models/restitution/livraison_spec.rb
+++ b/spec/models/restitution/livraison_spec.rb
@@ -101,4 +101,57 @@ describe Restitution::Livraison do
       expect(restitution.efficience).to be_nil
     end
   end
+
+  describe '#nombre_bonnes_reponses' do
+    let(:question3) { create :question_qcm, intitule: 'Ma question 3' }
+
+    let(:bon_choix) do
+      create :choix, type_choix: :bon, question_id: question1.id, intitule: 'bon'
+    end
+
+    let(:mauvais_choix) do
+      create :choix, type_choix: :mauvais, question_id: question2.id, intitule: 'mauvais'
+    end
+
+    let(:abstention_choix) do
+      create :choix, type_choix: :abstention, question_id: question3.id, intitule: 'abstention'
+    end
+
+    context "pas d'événements réponse" do
+      it 'retourne nil' do
+        evenements = [
+          build(:evenement_demarrage)
+        ]
+
+        restitution = described_class.new(campagne, evenements)
+        expect(restitution.nombre_bonnes_reponses).to eq(0)
+      end
+    end
+
+    context 'avec une bonne réponse' do
+      it do
+        evenements = [
+          build(:evenement_demarrage),
+          build(:evenement_reponse,
+                donnees: { question: question1.id, reponse: bon_choix.id })
+        ]
+        restitution = described_class.new(campagne, evenements)
+        expect(restitution.nombre_bonnes_reponses).to eq(1)
+      end
+    end
+
+    context 'avec des réponses autre que bonnes' do
+      it do
+        evenements = [
+          build(:evenement_demarrage),
+          build(:evenement_reponse,
+                donnees: { question: question2.id, reponse: mauvais_choix.id }),
+          build(:evenement_reponse,
+                donnees: { question: question3.id, reponse: abstention_choix.id })
+        ]
+        restitution = described_class.new(campagne, evenements)
+        expect(restitution.nombre_bonnes_reponses).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/models/restitution/livraison_spec.rb
+++ b/spec/models/restitution/livraison_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 describe Restitution::Livraison do
   let(:evaluation) { create :evaluation, nom: 'Test' }
-  let(:question1)  { create :question_qcm, intitule: 'Ma question 1' }
+  let(:bon_choix_q1) { create :choix, :bon }
+  let(:question1)  { create :question_qcm, intitule: 'Ma question 1', choix: [bon_choix_q1] }
   let(:question2)  { create :question_qcm, intitule: 'Ma question 2' }
   let(:questionnaire) { create :questionnaire, questions: [question1, question2] }
   let!(:partie) { create :partie, situation: situation, evaluation: evaluation }
@@ -64,13 +65,13 @@ describe Restitution::Livraison do
         [
           build(:evenement_demarrage),
           build(:evenement_reponse,
-                donnees: { question: question1.id, reponse: 1 })
+                donnees: { question: question1.id, reponse: bon_choix_q1.id })
         ]
       end
       it do
         expect(restitution.questions_et_reponses.size).to eq(1)
         expect(restitution.questions_et_reponses.first[:question]).to eql(question1)
-        expect(restitution.questions_et_reponses.first[:reponse]).to eql(1)
+        expect(restitution.questions_et_reponses.first[:reponse]).to eql(bon_choix_q1)
       end
     end
 
@@ -120,10 +121,6 @@ describe Restitution::Livraison do
   describe '#nombre_bonnes_reponses' do
     let(:question3) { create :question_qcm, intitule: 'Ma question 3' }
 
-    let(:bon_choix) do
-      create :choix, type_choix: :bon, question_id: question1.id, intitule: 'bon'
-    end
-
     let(:mauvais_choix) do
       create :choix, type_choix: :mauvais, question_id: question2.id, intitule: 'mauvais'
     end
@@ -148,7 +145,7 @@ describe Restitution::Livraison do
         evenements = [
           build(:evenement_demarrage),
           build(:evenement_reponse,
-                donnees: { question: question1.id, reponse: bon_choix.id })
+                donnees: { question: question1.id, reponse: bon_choix_q1.id })
         ]
         restitution = described_class.new(campagne, evenements)
         expect(restitution.nombre_bonnes_reponses).to eq(1)

--- a/spec/models/restitution/livraison_spec.rb
+++ b/spec/models/restitution/livraison_spec.rb
@@ -16,47 +16,49 @@ describe Restitution::Livraison do
            questionnaire: questionnaire
   end
   let(:campagne) { build :campagne }
+  let(:restitution) { described_class.new(campagne, evenements) }
+  let(:evenements) { [build(:evenement_demarrage)] }
 
   describe '#termine?' do
-    it "lorsque aucune questions n'a encore été répondu" do
-      evenements = [build(:evenement_demarrage)]
-      restitution = described_class.new(campagne, evenements)
-      expect(restitution).to_not be_termine
+    context "lorsque aucune questions n'a encore été répondu" do
+      it { expect(restitution).to_not be_termine }
     end
 
-    it 'lorsque une des questions a été répondu' do
-      evenements = [
-        build(:evenement_demarrage),
-        build(:evenement_reponse, donnees: { question: question1.id, reponse: 1 })
-      ]
-      restitution = described_class.new(campagne, evenements)
-      expect(restitution).to_not be_termine
+    context 'lorsque une des questions a été répondu' do
+      let(:evenements) do
+        [
+          build(:evenement_demarrage),
+          build(:evenement_reponse, donnees: { question: question1.id, reponse: 1 })
+        ]
+      end
+      it { expect(restitution).to_not be_termine }
     end
 
-    it 'lorsque les 2 questions ont été répondu' do
-      evenements = [
-        build(:evenement_demarrage),
-        build(:evenement_reponse, donnees: { question: question1.id, reponse: 1 }),
-        build(:evenement_reponse, donnees: { question: question2.id, reponse: 2 })
-      ]
-      restitution = described_class.new(campagne, evenements)
-      expect(restitution).to be_termine
+    context 'lorsque les 2 questions ont été répondu' do
+      let(:evenements) do
+        [
+          build(:evenement_demarrage),
+          build(:evenement_reponse, donnees: { question: question1.id, reponse: 1 }),
+          build(:evenement_reponse, donnees: { question: question2.id, reponse: 2 })
+        ]
+      end
+      it { expect(restitution).to be_termine }
     end
 
-    it "avec l'événement de fin de situation" do
-      evenements = [
-        build(:evenement_demarrage),
-        build(:evenement_fin_situation)
-      ]
-      restitution = described_class.new(campagne, evenements)
-      expect(restitution).to be_termine
+    context "avec l'événement de fin de situation" do
+      let(:evenements) do
+        [
+          build(:evenement_demarrage),
+          build(:evenement_fin_situation)
+        ]
+      end
+
+      it { expect(restitution).to be_termine }
     end
   end
 
   describe '#questions_et_reponses' do
-    let(:restitution) { described_class.new(campagne, evenements) }
     context "retourne aucune question et réponse si aucune n'a été répondu" do
-      let(:evenements) { [build(:evenement_demarrage)] }
       it { expect(restitution.questions_et_reponses).to eq([]) }
     end
 
@@ -91,29 +93,19 @@ describe Restitution::Livraison do
   end
 
   describe '#reponses' do
-    it 'retourne toutes les réponses' do
-      evenements = [
-        build(:evenement_demarrage),
-        build(:evenement_reponse),
-        build(:evenement_reponse)
-      ]
-      restitution = described_class.new(campagne, evenements)
-      expect(restitution.reponses.size).to eql(2)
-    end
-
-    it 'retourne seulement les événements réponses' do
-      evenements = [
-        build(:evenement_demarrage),
-        build(:evenement_reponse)
-      ]
-      restitution = described_class.new(campagne, evenements)
-      expect(restitution.reponses.size).to eql(1)
+    context 'retourne uniquement les réponses' do
+      let(:evenements) do
+        [
+          build(:evenement_demarrage),
+          build(:evenement_reponse)
+        ]
+      end
+      it { expect(restitution.reponses.size).to eql(1) }
     end
   end
 
   describe '#efficience' do
     it 'retourne nil' do
-      restitution = described_class.new(campagne, [])
       expect(restitution.efficience).to be_nil
     end
   end
@@ -130,40 +122,32 @@ describe Restitution::Livraison do
     end
 
     context "pas d'événements réponse" do
-      it 'retourne nil' do
-        evenements = [
-          build(:evenement_demarrage)
-        ]
-
-        restitution = described_class.new(campagne, evenements)
-        expect(restitution.nombre_bonnes_reponses).to eq(0)
-      end
+      it { expect(restitution.nombre_bonnes_reponses).to eq(0) }
     end
 
     context 'avec une bonne réponse' do
-      it do
-        evenements = [
+      let(:evenements) do
+        [
           build(:evenement_demarrage),
           build(:evenement_reponse,
                 donnees: { question: question1.id, reponse: bon_choix_q1.id })
         ]
-        restitution = described_class.new(campagne, evenements)
-        expect(restitution.nombre_bonnes_reponses).to eq(1)
       end
+      it { expect(restitution.nombre_bonnes_reponses).to eq(1) }
     end
 
     context 'avec des réponses autre que bonnes' do
-      it do
-        evenements = [
+      let(:evenements) do
+        [
           build(:evenement_demarrage),
           build(:evenement_reponse,
                 donnees: { question: question2.id, reponse: mauvais_choix.id }),
           build(:evenement_reponse,
                 donnees: { question: question3.id, reponse: abstention_choix.id })
         ]
-        restitution = described_class.new(campagne, evenements)
-        expect(restitution.nombre_bonnes_reponses).to eq(0)
       end
+
+      it { expect(restitution.nombre_bonnes_reponses).to eq(0) }
     end
   end
 end


### PR DESCRIPTION
Ajoute la métrique nombre de bonne réponse pour la Livraison.

L'ajout de cette métrique ne suit pas le pattern classique du fait que le client nous envois des événements réponse non typé (contrairement à Maintenance). C'est le serveur qui détermine si l'événement réponse est une bonne réponse. Cela à aussi une incidence dans la vue. 
Dans l'attente de vos avis. 

Cordialement,

<img width="1123" alt="Capture d’écran 2020-04-07 à 11 47 47" src="https://user-images.githubusercontent.com/20596535/78654962-a035eb00-78c5-11ea-8c2c-c903c7a80f2f.png">
