### PR TITLE
Ajoute la colonne date de création pour les campagnes

### DIFF
--- a/app/admin/campagnes.rb
+++ b/app/admin/campagnes.rb
@@ -18,6 +18,7 @@ ActiveAdmin.register Campagne do
     column :code
     column :nombre_evaluations
     column :compte if can?(:manage, Compte)
+    column :created_at
     actions
   end
 


### PR DESCRIPTION
Pour pouvoir retrouver plus facilement les campagnes créer récemment

<img width="1262" alt="Capture d’écran 2020-04-28 à 19 30 03" src="https://user-images.githubusercontent.com/298214/80518388-b0059400-8986-11ea-998a-c86520f87df8.png">
