### PR TITLE
Supprime le lien PDF tout en bas de la liste des évaluations d'une campagne

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -9,7 +9,7 @@ ActiveAdmin.register Evaluation do
   filter :nom
   filter :created_at
 
-  action_item :pdf, only: :show do
+  action_item :pdf_restitution, only: :show do
     link_to('Export PDF', {
               parties_selectionnees: params[:parties_selectionnees],
               format: :pdf
@@ -17,7 +17,7 @@ ActiveAdmin.register Evaluation do
             target: '_blank')
   end
 
-  index download_links: %i[csv pdf] do
+  index download_links: -> { params[:action] == 'show' ? [:pdf] : [:csv] } do
     selectable_column
     column :nom
     column :created_at


### PR DESCRIPTION
fix #427

<img width="1271" alt="Capture d’écran 2020-05-11 à 12 39 55" src="https://user-images.githubusercontent.com/298214/81552874-8be18400-9384-11ea-86fe-8dbd0c6c3f2c.png">

J'ai vérifié que le bouton [export PDF] d'une évaluation fonctionne toujours. A vérifier lors de la validation de cette issue.