### PR TITLE
Nettoyage des événements seulement après la date de fin

### DIFF
--- a/lib/tasks/nettoyage.rake
+++ b/lib/tasks/nettoyage.rake
@@ -20,13 +20,15 @@ namespace :nettoyage do
     logger = RakeLogger.logger
     logger.info 'Evenements effacées:'
     Partie.find_each do |partie|
+      date_fin = nil
       evenements = Evenement.where(partie: partie).order(:date)
       evenements_jusqua_fin = evenements.take_while do |evenement|
-        evenement.nom != 'finSituation'
+        date_fin ||= evenement.date if evenement.nom == 'finSituation'
+
+        date_fin.nil? || evenement.date == date_fin
       end
 
       evenements_apres_fin = evenements - evenements_jusqua_fin
-      evenements_apres_fin = evenements_apres_fin.drop(1)
       evenements_apres_fin.each { |evenement| logger.info evenement }
       Evenement.where(id: evenements_apres_fin.collect(&:id)).destroy_all
     end

--- a/spec/tasks/supprime_evenements_apres_la_fin_spec.rb
+++ b/spec/tasks/supprime_evenements_apres_la_fin_spec.rb
@@ -33,6 +33,18 @@ describe 'nettoyage:supprime_evenements_apres_la_fin' do
     end
   end
 
+  context 'avec un événement au même moment que la fin' do
+    une_date = DateTime.new(2020, 5, 1, 12, 0, 1.0)
+    let!(:evenements) do
+      [create(:evenement_fin_situation, partie: partie, date: une_date),
+       create(:evenement_piece_bien_placee, partie: partie, date: une_date)]
+    end
+
+    it do
+      expect { subject.invoke }.to_not(change { Evenement.count })
+    end
+  end
+
   context 'sans événement fin' do
     let!(:evenements) { [create(:evenement_piece_bien_placee, partie: partie)] }
 


### PR DESCRIPTION
On garde tous les événements avant ou avec la date de fin.

Pour des événements anciens, avant qu'on enregistre les millisecondes de la date des événements, on pouvait se retrouver dans certain cas avec une date de l'événement fin exactement égale (à la seconde près) à la date de l'avant dernier événement.

fix #438