### PR TITLE
Corrige le calcule des moyennes et écarts types glissant

### DIFF
--- a/app/models/partie.rb
+++ b/app/models/partie.rb
@@ -21,19 +21,19 @@ class Partie < ApplicationRecord
   end
 
   def moyenne_metriques
-    @moyenne_metriques ||= collect_metriques do |metrique|
+    @moyenne_metriques ||= collect_metriques_numeriques do |metrique|
       moyenne_metrique(metrique)
     end
   end
 
   def ecart_type_metriques
-    @ecart_type_metriques ||= collect_metriques do |metrique|
+    @ecart_type_metriques ||= collect_metriques_numeriques do |metrique|
       ecart_type_metrique(metrique)
     end
   end
 
   def cote_z_metriques
-    @cote_z_metriques ||= collect_metriques do |metrique|
+    @cote_z_metriques ||= collect_metriques_numeriques do |metrique|
       if ecart_type_metriques[metrique].zero?
         0
       elsif metriques[metrique].present?
@@ -59,13 +59,8 @@ class Partie < ApplicationRecord
       .round(2)
   end
 
-  def collect_metriques
-    Partie
-      .where(situation: situation)
-      .where.not(metriques: {})
-      .first
-      &.metriques
-      &.each_with_object({}) do |(metrique, valeur), memo|
+  def collect_metriques_numeriques
+    metriques.each_with_object({}) do |(metrique, valeur), memo|
       memo[metrique] = valeur.is_a?(Numeric) ? yield(metrique) : nil
     end
   end

--- a/spec/integrations/partie_spec.rb
+++ b/spec/integrations/partie_spec.rb
@@ -58,11 +58,6 @@ describe Partie do
                                                  'test_metrique_tableau' => nil)
       end
     end
-
-    it "lorsqu'il n'y a aucune partie enregistré" do
-      partie1.update(metriques: {})
-      expect(partie1.moyenne_metriques).to be_nil
-    end
   end
 
   context '#ecart_type_metrique' do
@@ -83,11 +78,6 @@ describe Partie do
                                                     'test_metrique_tableau' => nil)
       end
     end
-
-    it "lorsqu'il n'y a aucune partie enregistré" do
-      partie1.update(metriques: {})
-      expect(partie1.ecart_type_metriques).to be_nil
-    end
   end
 
   context '#cote_z_metriques' do
@@ -106,9 +96,7 @@ describe Partie do
 
       it do
         partie1.update(metriques: {})
-        expect(partie1.cote_z_metriques).to eql('test_chaine' => nil,
-                                                'test_metrique' => nil,
-                                                'test_metrique_tableau' => nil)
+        expect(partie1.cote_z_metriques).to eql({})
       end
     end
 
@@ -118,11 +106,6 @@ describe Partie do
                                                 'test_metrique' => 0,
                                                 'test_metrique_tableau' => nil)
       end
-    end
-
-    it "lorsqu'il n'y a aucune partie enregistré" do
-      partie1.update(metriques: {})
-      expect(partie1.cote_z_metriques).to be_nil
     end
   end
 end


### PR DESCRIPTION
Quand la première partie ne contenait pas de valeur pour certaines
métriques nous n'étions plus en mesure de savoir si cette métrique était
numérique ou pas.

Avec cette correction, on se base sur les métriques de la partie en
cours pour connaitre le type des métriques. Si cette partie n'a pas de
valeur pour une métrique alors, aucun calcul n'est fait pour cette
métrique.

Cette PR adresse le problème discuté en commentaire de #446
Voici l'écran après correction :
<img width="1245" alt="Capture d’écran 2020-05-27 à 15 29 13" src="https://user-images.githubusercontent.com/298214/83024635-f81fe100-a02e-11ea-8899-e6a3d25a9133.png">
