### PR TITLE
Gestion fin inventaire

### DIFF
--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -37,3 +37,11 @@
     background-color: gray;
   }
 }
+
+.green {
+    background-color: green;
+}
+
+.red {
+    background-color: red;
+}

--- a/app/views/admin/restitutions/_restitution_inventaire.html.arb
+++ b/app/views/admin/restitutions/_restitution_inventaire.html.arb
@@ -17,10 +17,10 @@ panel t('.restitution_essais') do
         status_tag t('admin.restitutions.evaluation.reussite'), class: 'green'
       elsif essai.abandon?
         status_tag t('admin.restitutions.evaluation.abandon'), class: 'red'
-      elsif essai.en_cours?
-        status_tag t('admin.restitutions.evaluation.en_cours')
-      else
+      elsif essai.verifie?
         status_tag t('admin.restitutions.evaluation.echec'), class: 'red'
+      else
+        status_tag t('admin.restitutions.evaluation.en_cours')
       end
     end
     column t('admin.restitutions.evaluation.temps') do |essai|

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -75,7 +75,7 @@ describe 'Evaluation API', type: :request do
 
       context 'avec une évaluation avec des compétences identifiées' do
         let!(:saisie) { create(:evenement_saisie_inventaire, :ok, partie: partie) }
-        let(:partie) { create :partie, situation: situation_inventaire, evaluation: evaluation }
+        let!(:fin) { create :evenement_fin_situation, partie: partie }
 
         context 'avec une campagne configurée sans compétences fortes' do
           before do


### PR DESCRIPTION
Cette PR corrige plusieurs problèmes de la restitution de l'inventaire qui sont apparus suite à l'introduction de l'événement fin : 

- La restitution rapportait un essai de trop
- de la couleur en plus
- refactoring
- contribue à #417
- corrige les indicateurs (non montré sur les écrans ci-dessous)

Avant : 
<img width="1230" alt="Capture d’écran 2020-06-02 à 15 49 22" src="https://user-images.githubusercontent.com/298214/83527885-ad97dc00-a4e8-11ea-93c5-8d5e9c3b4f14.png">
<img width="1219" alt="Capture d’écran 2020-06-02 à 15 49 11" src="https://user-images.githubusercontent.com/298214/83527898-b1c3f980-a4e8-11ea-846e-a8ba64de658d.png">


Après : 
<img width="1233" alt="Capture d’écran 2020-06-02 à 15 46 34" src="https://user-images.githubusercontent.com/298214/83527753-7fb29780-a4e8-11ea-9003-a1c614d11b1f.png">
<img width="1238" alt="Capture d’écran 2020-06-02 à 15 46 17" src="https://user-images.githubusercontent.com/298214/83527763-82ad8800-a4e8-11ea-9370-52cda7168931.png">

