### PR TITLE
Corrige le calcul des scores de l'illettrisme

### DIFF
--- a/app/models/restitution/illettrisme/score_metacompetence.rb
+++ b/app/models/restitution/illettrisme/score_metacompetence.rb
@@ -4,24 +4,21 @@ module Restitution
   module Illettrisme
     class ScoreMetacompetence < Restitution::Metriques::Base
       def calcule(evenements, metacompetence)
-        return if temps_moyen_bonnes_reponses(evenements, metacompetence).nil? ||
-                  temps_moyen_bonnes_reponses(evenements, metacompetence).zero?
+        temps_moyen = temps_moyen_bonnes_reponses(evenements, metacompetence)
+        return if temps_moyen.nil? || temps_moyen.zero?
 
-        nombre_bonnes_reponses(evenements, metacompetence)
-          .fdiv(temps_moyen_bonnes_reponses(evenements, metacompetence))
+        nombre_bonnes_reponses(evenements, metacompetence).fdiv(temps_moyen)
       end
 
       private
 
       def nombre_bonnes_reponses(evenements, metacompetence)
-        metrique = Illettrisme::NombreBonnesReponses.new
-        @nombre_bonnes_reponses ||= metrique.calcule(evenements, metacompetence)
+        Illettrisme::NombreBonnesReponses.new.calcule(evenements, metacompetence)
       end
 
       def temps_moyen_bonnes_reponses(evenements, metacompetence)
         metrique = Illettrisme::TempsBonnesReponses.new
-        @temps_moyen_bonnes_reponses ||= Metriques::Moyenne.new(metrique)
-                                                           .calcule(evenements, metacompetence)
+        Metriques::Moyenne.new(metrique).calcule(evenements, metacompetence)
       end
     end
   end

--- a/spec/integrations/restitution/livraison_spec.rb
+++ b/spec/integrations/restitution/livraison_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Restitution::Livraison, type: :integration do
+  context 'Calcule le score de deux parties et attend deux résultats différents' do
+    let(:situation) { create :situation_livraison }
+
+    let(:partie1) { create :partie, situation: situation, session_id: 'id1' }
+    let(:partie2) { create :partie, situation: situation, session_id: 'id2' }
+    let(:restitution1) { FabriqueRestitution.instancie partie1.id }
+    let(:restitution2) { FabriqueRestitution.instancie partie2.id }
+
+    let(:bon_choix) { create :choix, :bon }
+    let(:question_numeratie) do
+      create :question_qcm, metacompetence: :numeratie, choix: [bon_choix]
+    end
+
+    before do
+      create(:evenement_demarrage,
+             partie: partie1,
+             date: Time.local(2019, 10, 9, 10, 1, 20))
+      create(:evenement_affichage_question_qcm,
+             partie: partie1,
+             donnees: { question: question_numeratie.id },
+             date: Time.local(2019, 10, 9, 10, 1, 21))
+      create(:evenement_reponse,
+             partie: partie1,
+             donnees: { question: question_numeratie.id, reponse: bon_choix.id },
+             date: Time.local(2019, 10, 9, 10, 1, 22))
+    end
+
+    it do
+      expect(restitution1.score_numeratie).to_not eq(restitution2.score_numeratie)
+    end
+  end
+end


### PR DESCRIPTION
Les règles de calculs des métriques ne peuvent pas avoir d'état quand
elles sont utilisées dans les maps de metriques freezed