### PR TITLE
Permet de calculer et persister les scores d'une évaluation

### DIFF
--- a/app/actions/cree_evenement_action.rb
+++ b/app/actions/cree_evenement_action.rb
@@ -16,10 +16,7 @@ class CreeEvenementAction
 
       next unless evenement.nom == FIN_SITUATION
 
-      restitution = FabriqueRestitution.instancie partie.id
-      restitution.persiste
-      restitution_globale = FabriqueRestitution.restitution_globale partie.evaluation
-      restitution_globale.persiste
+      FabriqueRestitution.persiste(partie)
     end
   end
 end

--- a/app/actions/cree_evenement_action.rb
+++ b/app/actions/cree_evenement_action.rb
@@ -18,6 +18,8 @@ class CreeEvenementAction
 
       restitution = FabriqueRestitution.instancie partie.id
       restitution.persiste
+      restitution_globale = FabriqueRestitution.restitution_globale partie.evaluation
+      restitution_globale.persiste
     end
   end
 end

--- a/app/admin/situations.rb
+++ b/app/admin/situations.rb
@@ -24,8 +24,7 @@ ActiveAdmin.register Situation do
     Partie
       .where(situation: resource)
       .find_each do |partie|
-        restitution = FabriqueRestitution.instancie partie.id
-        restitution.persiste if restitution.termine?
+        FabriqueRestitution.persiste(partie)
       end
 
     redirect_to admin_situation_path(resource),

--- a/app/models/fabrique_restitution.rb
+++ b/app/models/fabrique_restitution.rb
@@ -21,5 +21,13 @@ class FabriqueRestitution
       end
       Restitution::Globale.new restitutions: restitutions_retenues, evaluation: evaluation
     end
+
+    def persiste(partie)
+      restitution = instancie(partie.id)
+      return unless restitution.termine?
+
+      restitution.persiste
+      restitution_globale(partie.evaluation).persiste
+    end
   end
 end

--- a/app/models/fabrique_restitution.rb
+++ b/app/models/fabrique_restitution.rb
@@ -16,10 +16,10 @@ class FabriqueRestitution
     def restitution_globale(evaluation, parties_selectionnees_ids = nil)
       parties_selectionnees_ids =
         initialise_selection(evaluation, parties_selectionnees_ids)
-      parties_retenues = parties_selectionnees_ids.map do |id|
+      restitutions_retenues = parties_selectionnees_ids.map do |id|
         instancie id
       end
-      Restitution::Globale.new restitutions: parties_retenues, evaluation: evaluation
+      Restitution::Globale.new restitutions: restitutions_retenues, evaluation: evaluation
     end
   end
 end

--- a/app/models/restitution/globale.rb
+++ b/app/models/restitution/globale.rb
@@ -80,10 +80,11 @@ module Restitution
     def valeurs_des_metriques
       METRIQUES_A_PERSISTER.each_with_object({}) do |metrique, memo|
         restitutions.each do |r|
-          next unless r.respond_to?(metrique)
+          cote_z = r.partie.cote_z_metriques[metrique.to_s]
+          next if cote_z.nil?
 
           memo[metrique] ||= []
-          memo[metrique] << r.send(metrique)
+          memo[metrique] << cote_z
         end
         memo
       end

--- a/app/models/restitution/globale.rb
+++ b/app/models/restitution/globale.rb
@@ -7,7 +7,11 @@ module Restitution
     NIVEAU_INDETERMINE = :indetermine
     RESTITUTION_SANS_EFFICIENCE = Restitution::Questions
 
-    SCORES_A_PERSISTER = %i[score_ccf score_numeratie].freeze
+    METRIQUES_A_PERSISTER = %i[score_vocabulaire
+                               score_ccf
+                               score_numeratie
+                               score_syntaxe_orthographe
+                               score_memorisation].freeze
 
     def initialize(restitutions:, evaluation:)
       @restitutions = restitutions
@@ -45,11 +49,11 @@ module Restitution
     end
 
     def persiste
-      scores_moyens_par_metacompetence = {}
-      scores_des_metacompetences.each do |metacompetence, scores|
-        scores_moyens_par_metacompetence[metacompetence] = scores.sum.fdiv(scores.count)
+      moyennes_par_metrique = {}
+      valeurs_des_metriques.each do |metrique, valeurs|
+        moyennes_par_metrique[metrique] = valeurs.sum.fdiv(valeurs.count)
       end
-      evaluation.update(metriques: scores_moyens_par_metacompetence)
+      evaluation.update(metriques: moyennes_par_metrique)
     end
 
     private
@@ -73,13 +77,13 @@ module Restitution
       end
     end
 
-    def scores_des_metacompetences
-      SCORES_A_PERSISTER.each_with_object({}) do |metrique_score, memo|
+    def valeurs_des_metriques
+      METRIQUES_A_PERSISTER.each_with_object({}) do |metrique, memo|
         restitutions.each do |r|
-          next unless r.respond_to?(metrique_score)
+          next unless r.respond_to?(metrique)
 
-          memo[metrique_score] ||= []
-          memo[metrique_score] << r.send(metrique_score)
+          memo[metrique] ||= []
+          memo[metrique] << r.send(metrique)
         end
         memo
       end

--- a/db/migrate/20200605105833_add_metriques_to_evaluation.rb
+++ b/db/migrate/20200605105833_add_metriques_to_evaluation.rb
@@ -1,0 +1,5 @@
+class AddMetriquesToEvaluation < ActiveRecord::Migration[6.0]
+  def change
+    add_column :evaluations, :metriques, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_090100) do
+ActiveRecord::Schema.define(version: 2020_06_05_105833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -94,6 +94,7 @@ ActiveRecord::Schema.define(version: 2020_05_26_090100) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "campagne_id"
+    t.jsonb "metriques", default: {}
     t.index ["campagne_id"], name: "index_evaluations_on_campagne_id"
   end
 

--- a/spec/actions/cree_evenement_action_spec.rb
+++ b/spec/actions/cree_evenement_action_spec.rb
@@ -34,6 +34,7 @@ describe CreeEvenementAction do
     end
 
     it 'persiste la restitution quand il se sauve' do
+      expect(restitution).to receive(:termine?).and_return(true)
       expect(restitution).to receive(:persiste)
       expect(restitution_globale).to receive(:persiste)
       described_class.new(partie, evenement_fin).call

--- a/spec/actions/cree_evenement_action_spec.rb
+++ b/spec/actions/cree_evenement_action_spec.rb
@@ -8,9 +8,13 @@ describe CreeEvenementAction do
   let!(:demarrage) { create :evenement_demarrage, partie: partie }
   let(:partie) { create :partie, situation: situation, evaluation: evaluation }
   let(:restitution) { double }
+  let(:restitution_globale) { double }
 
   before do
     allow(FabriqueRestitution).to receive(:instancie).with(partie.id).and_return restitution
+    allow(FabriqueRestitution).to receive(:restitution_globale)
+      .with(evaluation)
+      .and_return restitution_globale
   end
 
   context "sauve l'évenement" do
@@ -25,11 +29,13 @@ describe CreeEvenementAction do
     it 'ne persiste pas la restitution quand il ne se sauve pas' do
       expect(evenement_fin).to receive(:save).and_return(false)
       expect(restitution).to_not receive(:persiste)
+      expect(restitution_globale).to_not receive(:persiste)
       described_class.new(partie, evenement_fin).call
     end
 
     it 'persiste la restitution quand il se sauve' do
       expect(restitution).to receive(:persiste)
+      expect(restitution_globale).to receive(:persiste)
       described_class.new(partie, evenement_fin).call
     end
   end

--- a/spec/features/admin/situation_spec.rb
+++ b/spec/features/admin/situation_spec.rb
@@ -32,23 +32,30 @@ describe 'Admin - Situation', type: :feature do
 
     before do
       allow(FabriqueRestitution).to receive(:instancie).with(partie.id).and_return restitution
+      allow(FabriqueRestitution).to receive(:restitution_globale)
+        .with(evaluation)
+        .and_return restitution_globale
       visit admin_situation_path(tri)
     end
 
     context 'persiste les restitutions terminées' do
+      let(:restitution_globale) { double }
       let(:restitution) { double(termine?: true) }
 
       it do
         expect(restitution).to receive(:persiste)
+        expect(restitution_globale).to receive(:persiste)
         click_on 'Recalcule les métriques'
       end
     end
 
     context 'ignore les restitutions non terminees' do
+      let(:restitution_globale) { double }
       let(:restitution) { double(termine?: false) }
 
       it do
         expect(restitution).to_not receive(:persiste)
+        expect(restitution_globale).to_not receive(:persiste)
         click_on 'Recalcule les métriques'
       end
     end

--- a/spec/integrations/restitution/globale_spec.rb
+++ b/spec/integrations/restitution/globale_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Restitution::Globale, type: :integration do
+  context "Calcule le score global d'une méta-compétence d'une restitution" do
+    let(:livraison) { create :situation_livraison }
+
+    let(:partie) { create :partie, situation: livraison }
+    let(:partie2) { create :partie, situation: livraison }
+
+    let(:restitution_livraison) { FabriqueRestitution.instancie partie.id }
+    let(:restitution2_livraison) { FabriqueRestitution.instancie partie2.id }
+
+    let(:bon_choix) { create :choix, :bon }
+    let(:question_numeratie) do
+      create :question_qcm, metacompetence: :numeratie, choix: [bon_choix]
+    end
+
+    let(:campagne) { Campagne.new }
+    let(:evaluation) { create :evaluation, campagne: campagne }
+
+    before do
+      create(:evenement_demarrage, partie: partie, date: Time.local(2019, 10, 9, 10, 1, 20))
+      create(:evenement_affichage_question_qcm,
+             partie: partie,
+             donnees: { question: question_numeratie.id },
+             date: Time.local(2019, 10, 9, 10, 1, 21))
+      create(:evenement_reponse,
+             partie: partie,
+             donnees: { question: question_numeratie.id, reponse: bon_choix.id },
+             date: Time.local(2019, 10, 9, 10, 1, 22))
+      restitution_livraison.persiste
+
+      create(:evenement_demarrage, partie: partie2, date: Time.local(2019, 10, 9, 10, 1, 20))
+      create(:evenement_affichage_question_qcm,
+             partie: partie2,
+             donnees: { question: question_numeratie.id },
+             date: Time.local(2019, 10, 9, 10, 1, 21))
+      create(:evenement_reponse,
+             partie: partie2,
+             donnees: { question: question_numeratie.id, reponse: bon_choix.id },
+             date: Time.local(2019, 10, 9, 10, 1, 23))
+      restitution2_livraison.persiste
+
+      expect(restitution_livraison.partie.metriques['score_numeratie']).to eq(1)
+      expect(restitution_livraison.partie.cote_z_metriques['score_numeratie']).to eq(1)
+      expect(restitution2_livraison.partie.cote_z_metriques['score_numeratie']).to eq(-1)
+    end
+
+    it do
+      restitution_globale =
+        Restitution::Globale.new restitutions: [restitution_livraison, restitution2_livraison],
+                                 evaluation: evaluation
+      restitution_globale.persiste
+      expect(restitution_globale.evaluation.metriques['score_numeratie']).to eq((1 + -1) / 2)
+    end
+  end
+end

--- a/spec/models/evaluation_spec.rb
+++ b/spec/models/evaluation_spec.rb
@@ -5,4 +5,5 @@ require 'rails_helper'
 describe Evaluation do
   it { should validate_presence_of :nom }
   it { should belong_to :campagne }
+  it { expect(Evaluation.new.metriques).to eq({}) }
 end

--- a/spec/models/restitution/globale_spec.rb
+++ b/spec/models/restitution/globale_spec.rb
@@ -9,10 +9,6 @@ describe Restitution::Globale do
   end
   let(:evaluation) { double }
 
-  def une_restitution(nom: nil, efficience: nil)
-    double(nom, efficience: efficience)
-  end
-
   describe "#utilisateur retourne le nom de l'évaluation" do
     let(:restitutions) { [double] }
     let(:evaluation) { double(nom: 'Jean Bon') }

--- a/spec/models/restitution/globale_spec.rb
+++ b/spec/models/restitution/globale_spec.rb
@@ -150,4 +150,43 @@ describe Restitution::Globale do
       it { expect(restitution_globale.niveaux_competences).to eq([]) }
     end
   end
+
+  describe '#persiste' do
+    def verifie_enregistrement(metriques)
+      expect(evaluation).to receive(:update).with(metriques: metriques)
+    end
+
+    context 'pas de restitution' do
+      let(:restitutions) { [] }
+      it do
+        verifie_enregistrement({})
+        restitution_globale.persiste
+      end
+    end
+
+    context 'une restitution avec score' do
+      let(:restitutions) { [double(score_ccf: 12)] }
+      it do
+        verifie_enregistrement score_ccf: 12
+        restitution_globale.persiste
+      end
+    end
+
+    context 'fait la moyenne des scores de restitution' do
+      let(:restitutions) { [double(score_ccf: 30), double(score_ccf: 28)] }
+      it do
+        verifie_enregistrement score_ccf: 29
+        restitution_globale.persiste
+      end
+    end
+
+    context 'sépare les scores des compétences différentes' do
+      let(:restitutions) { [double(score_ccf: 3), double(score_numeratie: 7)] }
+
+      it do
+        verifie_enregistrement score_ccf: 3, score_numeratie: 7
+        restitution_globale.persiste
+      end
+    end
+  end
 end

--- a/spec/models/restitution/globale_spec.rb
+++ b/spec/models/restitution/globale_spec.rb
@@ -161,9 +161,9 @@ describe Restitution::Globale do
     end
 
     context 'une restitution avec score' do
-      let(:partie) { double }
+      let(:partie) { double(situation: :livraison) }
       let(:restitutions) { [double(score_ccf: 12, partie: partie)] }
-      it do
+      fit do
         allow(partie).to receive(:cote_z_metriques).and_return({ 'score_ccf' => 1.1 })
         verifie_enregistrement score_ccf: 1.1
         restitution_globale.persiste

--- a/spec/models/restitution/globale_spec.rb
+++ b/spec/models/restitution/globale_spec.rb
@@ -165,26 +165,48 @@ describe Restitution::Globale do
     end
 
     context 'une restitution avec score' do
-      let(:restitutions) { [double(score_ccf: 12)] }
+      let(:partie) { double }
+      let(:restitutions) { [double(score_ccf: 12, partie: partie)] }
       it do
-        verifie_enregistrement score_ccf: 12
+        allow(partie).to receive(:cote_z_metriques).and_return({ 'score_ccf' => 1.1 })
+        verifie_enregistrement score_ccf: 1.1
         restitution_globale.persiste
       end
     end
 
     context 'fait la moyenne des scores de restitution' do
-      let(:restitutions) { [double(score_ccf: 30), double(score_ccf: 28)] }
+      let(:partie1) { double }
+      let(:partie2) { double }
+      let(:restitutions) do
+        [
+          double(score_ccf: 30, partie: partie1),
+          double(score_ccf: 28, partie: partie2)
+        ]
+      end
       it do
-        verifie_enregistrement score_ccf: 29
+        allow(partie1).to receive(:cote_z_metriques).and_return({ 'score_ccf' => 1.1 })
+        allow(partie2).to receive(:cote_z_metriques).and_return({ 'score_ccf' => 1.2 })
+        verifie_enregistrement score_ccf: 1.15
         restitution_globale.persiste
       end
     end
 
     context 'sépare les scores des compétences différentes' do
-      let(:restitutions) { [double(score_ccf: 3), double(score_numeratie: 7)] }
+      let(:partie1) { double }
+      let(:partie2) { double }
+      let(:restitutions) do
+        [
+          double(score_ccf: 30, score_memorisation: 10, partie: partie1),
+          double(score_numeratie: 28, partie: partie2)
+        ]
+      end
 
       it do
-        verifie_enregistrement score_ccf: 3, score_numeratie: 7
+        allow(partie1).to receive(:cote_z_metriques).times.and_return(
+          { 'score_ccf' => 1.1, 'score_memorisation' => 1.2 }
+        )
+        allow(partie2).to receive(:cote_z_metriques).and_return({ 'score_numeratie' => 1.3 })
+        verifie_enregistrement score_ccf: 1.1, score_memorisation: 1.2, score_numeratie: 1.3
         restitution_globale.persiste
       end
     end


### PR DESCRIPTION
Cette PR contribue à la mission de restituer des scores normalisés par metacompetence.
Avec cette PR, la restitution globale sait persister sur son `Evaluation`.
