### PR TITLE
Supprime la capacité pour les organisations de créer des campagnes

### DIFF
--- a/app/admin/campagnes.rb
+++ b/app/admin/campagnes.rb
@@ -42,11 +42,4 @@ ActiveAdmin.register Campagne do
     end
     f.actions
   end
-
-  controller do
-    def create
-      params[:campagne][:compte_id] ||= current_compte.id
-      create!
-    end
-  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -28,8 +28,7 @@ class Ability
   end
 
   def droit_campagne(compte)
-    can :create, Campagne
-    can %i[create update read], Campagne, compte_id: compte.id
+    can %i[update read], Campagne, compte_id: compte.id
     can :destroy, Campagne do |c|
       Evaluation.where(campagne: c).count.zero?
     end

--- a/spec/features/admin/campagne_spec.rb
+++ b/spec/features/admin/campagne_spec.rb
@@ -61,48 +61,34 @@ describe 'Admin - Campagne', type: :feature do
   describe 'création' do
     let!(:questionnaire) { create :questionnaire, libelle: 'Mon QCM' }
 
-    context 'en organisation' do
-      before do
-        visit new_admin_campagne_path
-        fill_in :campagne_libelle, with: 'Belfort, pack demandeur'
-      end
-
-      context 'génère un code si on en saisit pas' do
-        before do
-          fill_in :campagne_code, with: ''
-          select 'Mon QCM'
-        end
-
-        it do
-          expect { click_on 'Créer' }.to(change { Campagne.count })
-          expect(Campagne.last.code).to be_present
-          expect(Campagne.last.compte).to eq compte_connecte
-          expect(page).to have_content 'Mon QCM'
-        end
-
-        context 'conserve le code saisi si précisé' do
-          before { fill_in :campagne_code, with: 'EUROCKS' }
-          it do
-            expect { click_on 'Créer' }.to(change { Campagne.count })
-            expect(Campagne.last.code).to eq 'EUROCKS'
-          end
-        end
-      end
-    end
-
     context 'en administrateur' do
       before do
         Compte.first.update(role: 'administrateur')
         visit new_admin_campagne_path
         fill_in :campagne_libelle, with: 'Belfort, pack demandeur'
-        fill_in :campagne_code, with: ''
         select 'Mon QCM'
         select 'orga@eva.fr'
       end
 
-      it do
-        expect { click_on 'Créer' }.to(change { Campagne.count })
-        expect(Campagne.last.compte).to eq compte_organisation
+      context 'génère un code si on en saisit pas' do
+        before do
+          fill_in :campagne_code, with: ''
+        end
+
+        it do
+          expect { click_on 'Créer' }.to(change { Campagne.count })
+          expect(Campagne.last.code).to be_present
+          expect(Campagne.last.compte).to eq compte_organisation
+          expect(page).to have_content 'Mon QCM'
+        end
+      end
+
+      context 'conserve le code saisi si précisé' do
+        before { fill_in :campagne_code, with: 'EUROCKS' }
+        it do
+          expect { click_on 'Créer' }.to(change { Campagne.count })
+          expect(Campagne.last.code).to eq 'EUROCKS'
+        end
       end
     end
   end

--- a/spec/integrations/ability_spec.rb
+++ b/spec/integrations/ability_spec.rb
@@ -157,11 +157,11 @@ describe Ability do
     it { is_expected.to_not be_able_to(%i[read destroy], evaluation_administrateur) }
     it { is_expected.to_not be_able_to(:read, Evenement.new) }
     it { is_expected.to_not be_able_to(:read, evenement_administrateur) }
+    it { is_expected.to_not be_able_to(:create, Campagne.new) }
     it { is_expected.to be_able_to(:read, Question.new) }
     it { is_expected.to be_able_to(%i[read destroy], evaluation_organisation) }
     it { is_expected.to be_able_to(:read, evenement_organisation) }
-    it { is_expected.to be_able_to(:create, Campagne.new) }
-    it { is_expected.to be_able_to(%i[create update read], Campagne.new(compte: compte)) }
+    it { is_expected.to be_able_to(%i[update read], Campagne.new(compte: compte)) }
     it { is_expected.to be_able_to(:destroy, Campagne.new(compte: compte)) }
     it { is_expected.to be_able_to(:read, Questionnaire.new) }
     it { is_expected.to be_able_to(:read, Situation.new) }


### PR DESCRIPTION
Fix https://trello.com/c/Qc1BZ4rX/102-supprimer-le-bouton-cr%C3%A9er-une-campagne-pour-les-comptes-de-type-organisation

<img width="1004" alt="Capture d’écran 2020-06-09 à 17 37 50" src="https://user-images.githubusercontent.com/298214/84168682-fa932980-aa77-11ea-97f4-70dc3fd3da04.png">
