### PR TITLE
Accepte email téléphone dans les évaluations

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -20,6 +20,8 @@ ActiveAdmin.register Evaluation do
   index download_links: -> { params[:action] == 'show' ? [:pdf] : [:csv] } do
     selectable_column
     column :nom
+    column :telephone
+    column :email
     column :created_at
     actions
   end

--- a/app/params/evaluation_params.rb
+++ b/app/params/evaluation_params.rb
@@ -5,7 +5,9 @@ class EvaluationParams
     def from(params)
       permitted = params.permit(
         :nom,
-        :code_campagne
+        :code_campagne,
+        :email,
+        :telephone
       )
       relie_campagne!(permitted)
       permitted

--- a/config/locales/models/evaluation.yml
+++ b/config/locales/models/evaluation.yml
@@ -17,6 +17,9 @@ fr:
         created_at: Créée le
         updated_at: Mise à jour le
         libelle: Libellé
+        telephone: Téléphone
+        nom: Nom
+        email: Email
   active_admin:
     resources:
       evaluation:

--- a/db/migrate/20200612101417_add_email_et_telephone_to_evaluation.rb
+++ b/db/migrate/20200612101417_add_email_et_telephone_to_evaluation.rb
@@ -1,0 +1,6 @@
+class AddEmailEtTelephoneToEvaluation < ActiveRecord::Migration[6.0]
+  def change
+    add_column :evaluations, :email, :string
+    add_column :evaluations, :telephone, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_090100) do
+ActiveRecord::Schema.define(version: 2020_06_12_101417) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -94,6 +94,8 @@ ActiveRecord::Schema.define(version: 2020_05_26_090100) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "campagne_id"
+    t.string "email"
+    t.string "telephone"
     t.index ["campagne_id"], name: "index_evaluations_on_campagne_id"
   end
 

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -7,9 +7,19 @@ describe 'Evaluation API', type: :request do
     let!(:campagne_ete19) { create :campagne, code: 'ETE19' }
 
     context 'Quand une requête est valide' do
-      let(:payload_valide_avec_campagne) { { nom: 'Roger', code_campagne: 'ETE19' } }
+      let(:payload_valide_avec_campagne) do
+        { nom: 'Roger', code_campagne: 'ETE19',
+          email: 'coucou@eva.fr', telephone: '01 02 03 04 05' }
+      end
       before { post '/api/evaluations', params: payload_valide_avec_campagne }
-      it { expect(Evaluation.last.campagne).to eq campagne_ete19 }
+
+      it do
+        evaluation = Evaluation.last
+        expect(evaluation.campagne).to eq campagne_ete19
+        expect(evaluation.nom).to eq 'Roger'
+        expect(evaluation.email).to eq 'coucou@eva.fr'
+        expect(evaluation.telephone).to eq '01 02 03 04 05'
+      end
     end
 
     context 'Quand une requête est invalide' do


### PR DESCRIPTION
pour https://trello.com/c/TphzrB5A/98-ajouter-un-champ-mail-et-num%C3%A9ro-de-t%C3%A9l%C3%A9phone-sur-le-premier-%C3%A9cran-du-parcours-eva

Remarque : j'ai fait le choix pour le moment de mettre les champs dans `Evaluation`, on a effectivement parlé de créer un modèle `Evalue` à part mais pour faire ça proprement il faudrait migrer aussi le nom, et j'avais envie de séparer la problématique de la migration des données de la création d'API