### PR TITLE
N'affiche que les parties des stuctures

### DIFF
--- a/app/admin/parties.rb
+++ b/app/admin/parties.rb
@@ -39,6 +39,8 @@ ActiveAdmin.register Partie do
 
     def scoped_collection
       Partie.where(situation_id: params[:situation_id])
+            .joins(evaluation: { campagne: :compte })
+            .where(comptes: { role: :organisation })
     end
   end
 end


### PR DESCRIPTION
Quand on regarde la liste des parties d'une situation on ne voit que les
parties des organisations. Toutes les parties de test, associés à des
comptes administrateur sont masquées.

<img width="1249" alt="Capture d’écran 2020-07-08 à 17 51 18" src="https://user-images.githubusercontent.com/298214/86940943-a5fcd000-c143-11ea-8969-3451c02725a0.png">
