### PR TITLE
Permet d'enregistrer une position d'événement et de l'afficher en admin

### DIFF
--- a/app/admin/evenements.rb
+++ b/app/admin/evenements.rb
@@ -17,6 +17,7 @@ ActiveAdmin.register Evenement do
     column(:partie) { |e| auto_link(e.partie) }
     column :nom
     column :donnees
+    column :position
     column(:date) { |e| l(e.date, format: :date_heure) }
     column(:created_at) { |e| l(e.created_at, format: :date_heure) }
   end

--- a/app/params/evenement_params.rb
+++ b/app/params/evenement_params.rb
@@ -7,6 +7,7 @@ class EvenementParams
         :date,
         :nom,
         :session_id,
+        :position,
         donnees: {}
       )
       formate!(permitted)

--- a/db/migrate/20200720142630_add_position_to_evenement.rb
+++ b/db/migrate/20200720142630_add_position_to_evenement.rb
@@ -1,0 +1,6 @@
+class AddPositionToEvenement < ActiveRecord::Migration[6.0]
+  def change
+    add_column :evenements, :position, :integer
+    add_index :evenements, :position
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_12_101417) do
+ActiveRecord::Schema.define(version: 2020_07_20_142630) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -106,6 +106,8 @@ ActiveRecord::Schema.define(version: 2020_06_12_101417) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "session_id"
+    t.integer "position"
+    t.index ["position"], name: "index_evenements_on_position"
   end
 
   create_table "parties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/requests/evenements_spec.rb
+++ b/spec/requests/evenements_spec.rb
@@ -15,6 +15,7 @@ describe 'Evenement API', type: :request do
         "nom": 'ouvertureContenant',
         "donnees": donnees,
         "situation": 'inventaire',
+        "position": 58,
         "session_id": 'O8j78U2xcb2',
         "evaluation_id": evaluation.id
       }
@@ -36,22 +37,20 @@ describe 'Evenement API', type: :request do
         expect { post '/api/evenements', params: payload_valide }
           .to change { Evenement.count }.by(1)
                                         .and change { Partie.count }.by(1)
+        expect(response).to have_http_status(201)
         evenement = Evenement.last
         expect(evenement.date.to_datetime).to eq Time.at(1_551_111_089, 238_000).to_datetime
-      end
+        expect(evenement.position).to eq 58
 
-      it 'retourne une 201' do
-        post '/api/evenements', params: payload_valide
-        expect(response).to have_http_status(201)
-      end
-
-      it "relie l'évenement à sa partie" do
-        expect do
-          2.times { post '/api/evenements', params: payload_valide }
-        end.to change { Partie.count }.by 1
         partie = Partie.last
         expect(partie.evaluation).to eq evaluation
         expect(partie.situation).to eq situation_inventaire
+      end
+
+      it 'crée une seule fois la partie' do
+        expect do
+          2.times { post '/api/evenements', params: payload_valide }
+        end.to change { Partie.count }.by 1
       end
     end
 


### PR DESCRIPTION
pour https://trello.com/c/tYEuufE6/148-ajouter-un-champ-num%C3%A9ro-d%C3%A9v%C3%A9nement-c%C3%B4t%C3%A9-client