### PR TITLE
Permet au conseiller d'enregistrer un contact depuis le tableau de bord

### DIFF
--- a/app/admin/contacts.rb
+++ b/app/admin/contacts.rb
@@ -1,12 +1,20 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Contact do
-  actions :index
+  actions :index, :create
+  permit_params :email, :nom, :compte_id
 
   index do
     column :nom
     column :email
     column :saisi_par
     column :structure
+  end
+
+  controller do
+    def create
+      params[:contact][:compte_id] ||= current_compte.id
+      create! { admin_root_path }
+    end
   end
 end

--- a/app/admin/contacts.rb
+++ b/app/admin/contacts.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register Contact do
+  actions :index
+
+  index do
+    column :nom
+    column :email
+    column :saisi_par
+    column :structure
+  end
+end

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -11,10 +11,12 @@ ActiveAdmin.register_page 'Dashboard' do
                 end
 
     evaluations = Evaluation.where(campagne: campagnes).order(created_at: :desc).limit(10)
+    contacts = Contact.where(saisi_par: current_compte)
 
     render partial: 'dashboard',
            locals: {
-             evaluations: evaluations
+             evaluations: evaluations,
+             contacts: contacts
            }
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -100,5 +100,6 @@ class Ability
     can :manage, :all if compte.administrateur?
     cannot :destroy, Campagne
     can :read, ActiveAdmin::Page, name: 'Dashboard', namespace_name: 'admin'
+    can :create, Contact
   end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -3,4 +3,8 @@
 class Contact < ApplicationRecord
   belongs_to :saisi_par, class_name: 'Compte', foreign_key: 'compte_id'
   delegate :structure, to: :saisi_par
+
+  def display_name
+    "#{nom} (#{email})"
+  end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Contact < ApplicationRecord
+  belongs_to :saisi_par, class_name: 'Compte', foreign_key: 'compte_id'
+  delegate :structure, to: :saisi_par
+end

--- a/app/views/admin/contacts/_form.html.arb
+++ b/app/views/admin/contacts/_form.html.arb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+active_admin_form_for [:admin, Contact.new] do |f|
+  f.inputs :nom, :email
+  f.actions
+end

--- a/app/views/admin/dashboard/_dashboard.html.arb
+++ b/app/views/admin/dashboard/_dashboard.html.arb
@@ -17,10 +17,16 @@ columns do
   end
 
   column do
-    panel t('.contacts') do
-      ul do
-        contacts.each do |contact|
-          li contact.display_name
+    panel t('.contacts.titre') do
+      h4 t('.contacts.intro')
+      render 'admin/contacts/form'
+      if contacts.present?
+        hr
+        h4 t('.contacts.deja_enregistres')
+        ul do
+          contacts.each do |contact|
+            li contact.display_name
+          end
         end
       end
     end

--- a/app/views/admin/dashboard/_dashboard.html.arb
+++ b/app/views/admin/dashboard/_dashboard.html.arb
@@ -1,13 +1,27 @@
 # frozen_string_literal: true
 
-panel t('.dernieres_evaluations.titre') do
-  ul do
-    evaluations.each do |evaluation|
-      li do
-        text_node link_to evaluation.nom,
-                          admin_campagne_evaluation_path(evaluation.campagne, evaluation)
-        text_node ' il y a '
-        text_node time_ago_in_words(evaluation.created_at)
+columns do
+  column do
+    panel t('.dernieres_evaluations.titre') do
+      ul do
+        evaluations.each do |evaluation|
+          li do
+            text_node link_to evaluation.nom,
+                              admin_campagne_evaluation_path(evaluation.campagne, evaluation)
+            text_node ' il y a '
+            text_node time_ago_in_words(evaluation.created_at)
+          end
+        end
+      end
+    end
+  end
+
+  column do
+    panel t('.contacts') do
+      ul do
+        contacts.each do |contact|
+          li contact.display_name
+        end
       end
     end
   end

--- a/config/locales/models/contact.yml
+++ b/config/locales/models/contact.yml
@@ -1,0 +1,5 @@
+fr:
+  formtastic:
+    actions:
+      contact:
+        create: Ajouter un contact

--- a/config/locales/views/dashboard.yml
+++ b/config/locales/views/dashboard.yml
@@ -2,6 +2,10 @@ fr:
   admin:
     dashboard:
       dashboard:
+        contacts:
+          titre: Vos coordonnées de contacts
+          intro: Pour nous aider à améliorer le service, laissez-nous votre nom et adresse email et nous vous solliciterons pour un suivi personnalisé
+          deja_enregistres: "Les contacts que vous avez déjà enregistrés :"
         dernieres_evaluations:
           titre: Dernières évaluations
         statistiques:

--- a/db/migrate/20200717064904_create_contacts.rb
+++ b/db/migrate/20200717064904_create_contacts.rb
@@ -1,0 +1,11 @@
+class CreateContacts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :contacts, id: :uuid do |t|
+      t.string :nom
+      t.string :email
+      t.references :compte, null: false, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -89,6 +89,15 @@ ActiveRecord::Schema.define(version: 2020_07_20_142630) do
     t.index ["structure_id"], name: "index_comptes_on_structure_id"
   end
 
+  create_table "contacts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "nom"
+    t.string "email"
+    t.uuid "compte_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["compte_id"], name: "index_contacts_on_compte_id"
+  end
+
   create_table "evaluations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "nom"
     t.datetime "created_at", null: false
@@ -185,6 +194,7 @@ ActiveRecord::Schema.define(version: 2020_07_20_142630) do
   add_foreign_key "campagnes", "questionnaires"
   add_foreign_key "choix", "questions", on_delete: :cascade
   add_foreign_key "comptes", "structures"
+  add_foreign_key "contacts", "comptes"
   add_foreign_key "evaluations", "campagnes"
   add_foreign_key "evenements", "parties", column: "session_id", primary_key: "session_id", on_delete: :cascade
   add_foreign_key "parties", "evaluations", on_delete: :cascade

--- a/spec/factories/contact.rb
+++ b/spec/factories/contact.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :contact do
+  end
+end

--- a/spec/features/admin/contacts_spec.rb
+++ b/spec/features/admin/contacts_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Admin - Contacts', type: :feature do
+  before(:each) { se_connecter_comme_administrateur }
+
+  describe 'lister les contacts' do
+    let(:structure) { create :structure, nom: 'Ma structure' }
+    let(:compte) { create :compte, email: 'emailcompte@structure.com', structure: structure }
+    let!(:contact) do
+      create :contact, email: 'emailcontact@structure.com',
+                       nom: 'Mon nom contact',
+                       saisi_par: compte
+    end
+
+    before { visit admin_contacts_path }
+
+    it do
+      expect(page).to have_content 'Mon nom contact'
+      expect(page).to have_content 'emailcontact@structure.com'
+      expect(page).to have_content 'emailcompte@structure.com'
+      expect(page).to have_content 'Ma structure'
+    end
+  end
+end

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -19,9 +19,26 @@ describe 'Admin - Dashboard' do
       end
 
       before { visit admin_root_path }
+
       it do
         expect(page).to have_content 'Monsieur Plus (monsieur@plus.com)'
         expect(page).to_not have_content 'Monsieur Absent'
+      end
+    end
+
+    describe 'Ajouter un contact' do
+      before do
+        visit admin_root_path
+        fill_in :contact_nom, with: 'Nouveau Contact'
+        fill_in :contact_email, with: 'nouveau@email.com'
+      end
+
+      it do
+        expect { click_on 'Ajouter' }.to(change { Contact.count })
+        nouveau_contact = Contact.last
+        expect(nouveau_contact.nom).to eq 'Nouveau Contact'
+        expect(nouveau_contact.email).to eq 'nouveau@email.com'
+        expect(nouveau_contact.saisi_par).to eq compte_organisation
       end
     end
   end

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Admin - Dashboard' do
+  context 'En organisation' do
+    before { connecte compte_organisation }
+    let(:compte_organisation) { create :compte, role: 'organisation' }
+
+    describe 'Lister mes contacts' do
+      let!(:contact_autre) do
+        create :contact, nom: 'Monsieur Absent',
+                         saisi_par: create(:compte)
+      end
+      let!(:contact_organisation) do
+        create :contact, nom: 'Monsieur Plus',
+                         email: 'monsieur@plus.com',
+                         saisi_par: compte_organisation
+      end
+
+      before { visit admin_root_path }
+      it do
+        expect(page).to have_content 'Monsieur Plus (monsieur@plus.com)'
+        expect(page).to_not have_content 'Monsieur Absent'
+      end
+    end
+  end
+end

--- a/spec/integrations/ability_spec.rb
+++ b/spec/integrations/ability_spec.rb
@@ -166,5 +166,6 @@ describe Ability do
     it { is_expected.to be_able_to(:read, Questionnaire.new) }
     it { is_expected.to be_able_to(:read, Situation.new) }
     it { is_expected.to be_able_to(:manage, Restitution::Base.new(campagne_organisation, nil)) }
+    it { is_expected.to be_able_to(:create, Contact.new) }
   end
 end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Contact, type: :model do
+  it { should belong_to(:saisi_par).class_name('Compte').with_foreign_key('compte_id') }
+end


### PR DESCRIPTION
pour https://trello.com/c/cob8ifpm/146-en-tant-que-conseiller-quand-je-me-connecte-sur-ladmin-je-peux-donner-mon-nom-et-mon-e-mail-sur-le-tableau-de-bord

Et l'administrateur peut lister tous les contacts enregistrés