### PR TITLE
Évaluation : Déplace le tableau des parties en bas de l'évaluation

### DIFF
--- a/app/views/admin/evaluations/_show.html.arb
+++ b/app/views/admin/evaluations/_show.html.arb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
-panel t('.titre.restitutions') do
+if auto_positionnement
+  panel t('.titre.auto_positionnement') do
+    render partial: 'bienvenue', locals: { auto_positionnement: auto_positionnement }
+  end
+end
+
+panel t('.titre.restitution_globale') do
+  render partial: 'restitution_globale', locals: { pdf: false }
+end
+
+panel t('.titre.parties') do
   form method: :get do
     table_for parties do
       column :selection do |partie|
@@ -22,14 +32,4 @@ panel t('.titre.restitutions') do
     end
     div submit_tag 'Valider la sélection'
   end
-end
-
-if auto_positionnement
-  panel t('.titre.auto_positionnement') do
-    render partial: 'bienvenue', locals: { auto_positionnement: auto_positionnement }
-  end
-end
-
-panel t('.titre.restitution_globale') do
-  render partial: 'restitution_globale', locals: { pdf: false }
 end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -68,7 +68,7 @@ fr:
         titre:
           restitution_globale: Restitution globale
           auto_positionnement: Auto-positionnement
-          restitutions: Restitutions
+          parties: Situations jouées
     restitutions:
       reponse_expression_ecrite: "Votre réponse à la question '%{question}' :"
       evaluation:


### PR DESCRIPTION
Pour répondre à https://trello.com/c/yLOmScRY

Ceci a été fait dans le but de mettre plus en avant l'évaluation elle même.