### PR TITLE
Ajoute une tâche rake pour mettre des dates différentes pour les évén…

### DIFF
--- a/lib/tasks/nettoyage.rake
+++ b/lib/tasks/nettoyage.rake
@@ -62,6 +62,22 @@ namespace :nettoyage do
       Evenement.where(id: evenements_apres_fin.collect(&:id)).destroy_all
     end
   end
+
+  desc 'Assure une date de fin correcte'
+  task date_evenements_fin: :environment do
+    Partie.find_each do |partie|
+      derniers_evenements = Evenement.order(:date).where(partie: partie).last(2)
+      next if derniers_evenements.count < 2 ||
+              derniers_evenements.first.date != derniers_evenements.last.date
+
+      fin = derniers_evenements.detect { |e| e.nom == 'finSituation' }
+
+      next if fin.blank?
+
+      fin.date += 0.001
+      fin.save!
+    end
+  end
 end
 
 class RakeLogger

--- a/lib/tasks/nettoyage.rake
+++ b/lib/tasks/nettoyage.rake
@@ -65,6 +65,9 @@ namespace :nettoyage do
 
   desc 'Assure une date de fin correcte'
   task date_evenements_fin: :environment do
+    logger = RakeLogger.logger
+    logger.info "Décale événements fin qui ont la mieme date que l'événement précédent..."
+
     Partie.find_each do |partie|
       derniers_evenements = Evenement.order(:date).where(partie: partie).last(2)
       next if derniers_evenements.count < 2 ||
@@ -75,6 +78,7 @@ namespace :nettoyage do
       next if fin.blank?
 
       fin.date += 0.001
+      logger.info "Nouvelle date pour l'événement ##{fin.id} : #{fin.date}"
       fin.save!
     end
   end

--- a/spec/tasks/date_evenements_fin_spec.rb
+++ b/spec/tasks/date_evenements_fin_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 describe 'nettoyage:date_evenements_fin' do
   include_context 'rake'
+  let(:logger) { RakeLogger.logger }
 
   let(:situation) { create :situation_livraison }
   let!(:partie) { create :partie, situation: situation }
@@ -13,6 +14,7 @@ describe 'nettoyage:date_evenements_fin' do
   end
   let!(:evenements) { [evenement_precedent, evenement_fin] }
 
+  before { allow(logger).to receive :info }
   before { subject.invoke }
 
   context 'événement avec date unique' do

--- a/spec/tasks/date_evenements_fin_spec.rb
+++ b/spec/tasks/date_evenements_fin_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'nettoyage:date_evenements_fin' do
+  include_context 'rake'
+
+  let(:situation) { create :situation_livraison }
+  let!(:partie) { create :partie, situation: situation }
+  let(:evenement_fin) { create(:evenement_fin_situation, partie: partie, date: date_fin) }
+  let(:evenement_precedent) do
+    create(:evenement, partie: partie, date: 2.days.ago.beginning_of_day)
+  end
+  let!(:evenements) { [evenement_precedent, evenement_fin] }
+
+  before { subject.invoke }
+
+  context 'événement avec date unique' do
+    let(:date_fin) { 1.day.ago.beginning_of_day }
+
+    it { expect(evenement_fin.reload.date).to eq date_fin }
+  end
+
+  context "la date de fin égale à l'événement précédent" do
+    let(:date_fin) { evenement_precedent.date }
+
+    it do
+      expect(evenement_fin.reload.date - evenement_precedent.reload.date).to eq(0.001)
+    end
+  end
+
+  context 'même date mais sans événement fin' do
+    let(:autre_evenement) { create(:evenement, partie: partie, date: evenement_precedent.date) }
+    let!(:evenements) { [evenement_precedent, autre_evenement] }
+
+    it { expect(autre_evenement.reload.date).to eq evenement_precedent.date }
+  end
+
+  context 'même date, deux parties différentes' do
+    let(:date_fin) { evenement_autre_partie.date }
+
+    let(:autre_partie) { create :partie, situation: situation }
+    let(:evenement_autre_partie) do
+      create(:evenement, partie: autre_partie, date: 3.days.ago.beginning_of_day)
+    end
+
+    let!(:evenements) { [evenement_autre_partie, evenement_fin] }
+
+    it { expect(evenement_fin.reload.date).to eq date_fin }
+  end
+
+  context 'trie les événements par date' do
+    let(:date_fin) { evenement_precedent.date }
+    let(:evenement_le_plus_tot) { create(:evenement, partie: partie, date: date_fin - 1.minute) }
+    let!(:evenements) { [evenement_precedent, evenement_fin, evenement_le_plus_tot] }
+
+    it do
+      expect(evenement_fin.reload.date - evenement_precedent.reload.date).to eq(0.001)
+    end
+  end
+end


### PR DESCRIPTION
…ements fin ajoutés

pour https://trello.com/c/Pmzr65au/193-nettoyage-des-%C3%A9v%C3%A9nements-fin-mal-dat%C3%A9-ceux-quon-avait-ajout%C3%A9

Certains événements fin ont exactement la même date que leur événement précédent.
Conséquence : lorsqu'on trie les événements par date, l'événement fin n'est pas forcément le dernier.

Cela empêche en partie de traiter ce sujet : https://trello.com/c/YmHXXzaI/16-refactorer-termine-dans-les-restitutions-417
Ce n'est pas clair pour moi s'il y a des impacts pour l'utilisateurs ( de mauvaises restitutions ) ou s'il s'agit juste d'un problème de qualité.

Cette PR introduit une tâche rake qui décale les événements fin d'une milliseconde afin que l'événement fin repasse à la fin.

Mais j'ai constaté en la testant que c'est un cas fréquent que le client envoie les 2 derniers événements à la même date.

J'ai envie de capitaliser sur la solution qu'on a mise en place pour traiter les changements de fuseau horaire référencé ici https://trello.com/c/svmzeB0A/115-traiter-les-probl%C3%A8mes-des-ordinateurs-clients-qui-change-dheure-en-plein-milieu-dune-partie

À savoir, positionner les événements. C'est désormais le cas côté client, mais pas encore utilisé dans le serveur.

Voici le plan d'action que je propose :

1. trier les événements par position et non plus par date dans le code côté serveur
2. exécuter cette tâche rake pour décaler les événements fin
3. écrire et rédiger une nouvelle tâche rake pour attribuer une position aux anciens événements.

L'ensemble du plan dépasse le cadre de cette PR.
