### PR TITLE
Rester sur la propriété `page-break-after` pour la génération de PDF

### DIFF
--- a/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
+++ b/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
@@ -107,7 +107,7 @@
   }
 
   .saut-de-page {
-    break-after: always;
+    page-break-after: always;
   }
 
   .btn-group {


### PR DESCRIPTION
Le générateur de pdf ne supporte pas la nouvelle propriété `break-after`.