### PR TITLE
Ajoute plus d'aire sur la restitution PDF de l'auto-positionnement

### DIFF
--- a/app/assets/stylesheets/restitution_globale/_base.scss
+++ b/app/assets/stylesheets/restitution_globale/_base.scss
@@ -79,8 +79,13 @@
       color: $couleur-blanc;
     }
 
+    .row.question-standard {
+      margin-top: 2rem;
+    }
+
     .categorie {
       font-size: 1rem;
+      margin: 2rem 0;
     }
 
     .reponse {

--- a/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
+++ b/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
@@ -68,7 +68,11 @@
 
   .autopositionnement {
     .intitule-question {
-      margin-top: 1rem; // centrage par coïncidence
+      margin-top: 1.5rem; // centrage par coïncidence
+    }
+
+    .jauge {
+      height: 5rem;
     }
 
     .puce {
@@ -77,8 +81,13 @@
       line-height: 28px;
     }
 
+    .row.question-standard {
+      margin-top: 3rem;
+    }
+
     .categorie {
-      font-size: 1.2rem;
+      font-size: 1.3rem;
+      margin: 2.5rem 0;
     }
 
     .reponse {

--- a/app/views/admin/evaluations/_autopositionnement.arb
+++ b/app/views/admin/evaluations/_autopositionnement.arb
@@ -16,25 +16,23 @@ div class: 'autopositionnement' do
       end
     end
   end
-  div class: 'mt-5' do
-    div class: 'row mt-3' do
-      questions_et_reponses_standard = auto_positionnement.questions_et_reponses(:standard)
-      div class: 'col' do
-        render partial: 'categorie_autopositionnement', locals: {
-          categorie: t('.appareils'),
-          questions_reponses: questions_et_reponses_standard
-        }
-        render partial: 'categorie_autopositionnement', locals: {
-          categorie: t('.scolarite'),
-          questions_reponses: questions_et_reponses_standard
-        }
-      end
-      div class: 'col' do
-        render partial: 'categorie_autopositionnement', locals: {
-          categorie: t('.sante'),
-          questions_reponses: questions_et_reponses_standard
-        }
-      end
+  div class: 'row question-standard' do
+    questions_et_reponses_standard = auto_positionnement.questions_et_reponses(:standard)
+    div class: 'col' do
+      render partial: 'categorie_autopositionnement', locals: {
+        categorie: t('.appareils'),
+        questions_reponses: questions_et_reponses_standard
+      }
+      render partial: 'categorie_autopositionnement', locals: {
+        categorie: t('.scolarite'),
+        questions_reponses: questions_et_reponses_standard
+      }
+    end
+    div class: 'col' do
+      render partial: 'categorie_autopositionnement', locals: {
+        categorie: t('.sante'),
+        questions_reponses: questions_et_reponses_standard
+      }
     end
   end
 end

--- a/app/views/admin/evaluations/_categorie_autopositionnement.arb
+++ b/app/views/admin/evaluations/_categorie_autopositionnement.arb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-h2 categorie, class: 'categorie my-4'
+h2 categorie, class: 'categorie'
 questions_reponses.each do |question, reponse|
   if question.libelle.start_with?(categorie)
     div question.intitule

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -22,7 +22,7 @@ fr:
         <<: *commun
         reste_plateau: Reste plateau
       autopositionnement:
-        titre: Auto-positionnement
+        titre: Questionnaire d'auto-positionnement
         appareils: Appareils
         scolarite: Scolarité
         sante: Santé

--- a/spec/features/admin/evaluation_spec.rb
+++ b/spec/features/admin/evaluation_spec.rb
@@ -31,13 +31,13 @@ describe 'Admin - Evaluation', type: :feature do
 
     it 'sans auto_positionnement' do
       visit admin_campagne_evaluation_path(ma_campagne, mon_evaluation)
-      expect(page).to_not have_content 'Auto-positionnement'
+      expect(page).to_not have_content 'auto-positionnement'
       expect(page).to have_content 'Roger'
     end
 
     it 'avec auto_positionnement' do
       visit admin_campagne_evaluation_path(ma_campagne, mon_evaluation_bienvenue)
-      expect(page).to have_content 'Auto-positionnement'
+      expect(page).to have_content 'auto-positionnement'
       expect(page).to have_content 'Roger'
     end
 


### PR DESCRIPTION
J’ai essayé de mettre plus d’aire. à gauche mon dev, à droite figma

![Capture d’écran 2020-09-08 à 17 52 24](https://user-images.githubusercontent.com/298214/92499617-5fd3f380-f1fc-11ea-9419-d055e3b48dbe.png)
