### PR TITLE
Restitution PDF : diminue les titres et augmente l'interligne

### DIFF
--- a/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
+++ b/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
@@ -2,8 +2,12 @@
 @import "base";
 
 .admin_restitution_globale {
-  line-height: 1.1;
+  line-height: 1.3;
   width: 1100px;
+
+  h2 {
+    font-size: 1.80rem;
+  }
 
   .en-tete-page {
     background-image: asset-data-url('vague.svg');


### PR DESCRIPTION
<img width="1598" alt="Capture d’écran 2020-09-21 à 11 44 15" src="https://user-images.githubusercontent.com/298214/93753317-41a8c300-fc00-11ea-9466-0f1e22f51af0.png">
