### PR TITLE
Deux petites modifications pour éviter les soucis

### DIFF
--- a/app/controllers/api/evaluations_controller.rb
+++ b/app/controllers/api/evaluations_controller.rb
@@ -51,7 +51,7 @@ module Api
                       scope: 'admin.evaluations.restitution_competence'),
           description: I18n.t("#{identifiant}.description",
                               scope: 'admin.evaluations.restitution_competence'),
-          picto: ActionController::Base.helpers.asset_url(identifiant)
+          picto: ActionController::Base.helpers.asset_url("#{identifiant}.svg")
         }
       end
     end

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -133,6 +133,7 @@ describe 'Evaluation API', type: :request do
             expect(premiere_competence['description'])
               .to eql(I18n.t("#{Competence::RAPIDITE}.description",
                              scope: 'admin.evaluations.restitution_competence'))
+            expect(premiere_competence['description']).to_not start_with('translation missing')
           end
 
           it "envoie aussi l'URL du picto des compétences" do


### PR DESCRIPTION
- ajout d'un test qui vérifie la présence des descriptions de compétences transversales pour l'api évaluation
- précise que les pictos sont en svg (pour qu'ils soient trouvé, même quand on a désactivé la compilation des assets)