### PR TITLE
Restitution: réduit la taille de l'entête PDF pour éviter un saut de page

### DIFF
--- a/app/assets/images/vague.svg
+++ b/app/assets/images/vague.svg
@@ -1,3 +1,3 @@
-<svg width="595" height="146" viewBox="0 0 595 146" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M0 0H595V138.5C595 138.5 486.5 120 390 120C293.5 120 246 146 138 146C30 146 0 129 0 129V0Z" fill="#6E84FE"/>
+<svg width="595" height="126" viewBox="0 0 595 126" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 0H595V118.5C595 118.5 486.5 100 390 100C293.5 100 246 126 138 126C30 126 0 109 0 109V0Z" fill="#6E84FE"/>
 </svg>

--- a/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
+++ b/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
@@ -13,9 +13,8 @@
     background-image: asset-data-url('vague.svg');
     background-size: 100%;
     background-repeat: no-repeat;
-    height: 300px;
+    height: 233px;
     padding: 3.75rem 5rem 0 5rem;
-    margin-bottom: 4rem;
 
     .eva-logo {
       margin-right: 1.5rem;


### PR DESCRIPTION
avant - après

<img width="1602" alt="Capture d’écran 2020-09-29 à 15 11 15" src="https://user-images.githubusercontent.com/298214/94562773-09d7f600-0266-11eb-983e-cf4429c4a26c.png">
