### PR TITLE
remet "Ne compile plus les assets en production""

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,6 +23,7 @@ Rails.application.configure do
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
+  config.assets.compile = false
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache


### PR DESCRIPTION
This reverts commit 075fa677f3e10b77f7ff0f167a54a498cbc7a74f.

Cette PR remet la désactivation de la compilation des assets en production. Il faut absolument valider que ça marche en pré-production et ne particulier, refaire un parcours evalué·e.

Il faudra aussi vérifier que tout se passe bien pour les polices de caractères.