### PR TITLE
Enlève "Ne compile plus les assets en production"

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,6 @@ Rails.application.configure do
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
-  config.assets.compile = false
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache


### PR DESCRIPTION
This reverts commit 2b1c66502e35208ff5265dc2b9ce993e079d4d93.

Pour https://trello.com/c/5N0vreTa/191-configassetscompile-false

C'est triste, mais les images PDF ne s'affichent pas sinon

![Capture d’écran 2020-10-05 à 16 18 49](https://user-images.githubusercontent.com/28393/95091535-e0681000-0726-11eb-9522-73c0389d77ff.png)
![Capture d’écran 2020-10-05 à 16 18 53](https://user-images.githubusercontent.com/28393/95091549-e231d380-0726-11eb-8671-bda77b688de0.png)

Je n'ai pas encore trouvé la bonne config.
