### PR TITLE
On build ffmpeg avant ruby

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
-https://github.com/Scalingo/ruby-buildpack.git
 https://github.com/Scalingo/ffmpeg-buildpack.git
+https://github.com/Scalingo/ruby-buildpack.git
 


### PR DESCRIPTION
ffmpeg est potentiellement utilisé par le build ruby donc ça parrait
plus logique de le builder avant.