### PR TITLE
Corrige le helper `svg_tag_base64` en production (sans l'asset pipeline)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,7 +25,7 @@ module ApplicationHelper
   end
 
   def svg_tag_base64(path, options = {})
-    raw = Rails.application.assets[path].to_s
+    raw = Rails.application.assets_manifest.find_sources(path).first
     encodage = Base64.strict_encode64 raw
     image_src64 = "data:image/svg+xml;base64,#{encodage}"
     image_tag image_src64, options


### PR DESCRIPTION
En production, quand l'asset pipeline est désactivé
(config.assets.compile = false), les assets peuvent être retrouvés avec
la propriété `Rails.application.assets_manifest`.

https://github.com/rails/sprockets-rails/issues/237#issuecomment-231948159