### PR TITLE
Restitution : rend cliquable le lien vers les Conditions d’interprétation des restitutions eva

### DIFF
--- a/app/assets/stylesheets/restitution_globale/_base.scss
+++ b/app/assets/stylesheets/restitution_globale/_base.scss
@@ -249,6 +249,14 @@
     color: $couleur-blanc;
     padding: 1rem 0;
 
+    a {
+      text-decoration: none;
+      color: $couleur-blanc;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+
     .icone {
       height: 3rem;
     }

--- a/app/assets/stylesheets/restitution_globale/_base.scss
+++ b/app/assets/stylesheets/restitution_globale/_base.scss
@@ -37,6 +37,15 @@
     font-weight: 600;
   }
 
+  a {
+    text-decoration: none;
+    color: $couleur-texte;
+    &:hover {
+      color: $couleur-texte;
+      text-decoration: underline;
+    }
+  }
+
   .marges-page {
     margin : 0 3rem;
   }
@@ -176,13 +185,7 @@
 
     .description-competence {
       a {
-        text-decoration: none;
-        color: adjust-color($couleur-liens, $alpha: -0.5);
-      }
-
-      a:hover {
-        text-decoration: underline;
-        color: $couleur-liens;
+        color: $couleur-principale;
       }
     }
   }
@@ -232,13 +235,6 @@
     }
   }
 
-  a {
-    color: $couleur-texte;
-    &:hover {
-      color: $couleur-texte;
-    }
-  }
-
   .label {
     vertical-align: top;
   }
@@ -250,11 +246,7 @@
     padding: 1rem 0;
 
     a {
-      text-decoration: none;
       color: $couleur-blanc;
-      &:hover {
-        text-decoration: underline;
-      }
     }
 
     .icone {

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -304,4 +304,4 @@ fr:
             Les restitutions eva sont basées sur les référentiels européens d’évaluation du français et des mathématiques, ainsi que sur le référentiel Cléa.
           references: |
             Le détail de l’utilisation de ces référentiels et conditions d’interprétation sont disponibles ici :
-            https://l.incubateur.net/eva-clea
+            [https://l.incubateur.net/eva-clea](https://l.incubateur.net/eva-clea)


### PR DESCRIPTION
Rend cliquable le lien vers les Conditions d’interprétation des restitutions eva

<img width="496" alt="Capture d’écran 2020-10-13 à 22 17 21" src="https://user-images.githubusercontent.com/298214/95911525-e2267900-0da1-11eb-8b5a-74172b4fc366.png">

Cette PR corrige aussi le style des liens de la restitution en général.