### PR TITLE
Fige la moyenne et l'écart type pour les scores de niveau 3

### DIFF
--- a/app/admin/restitutions.rb
+++ b/app/admin/restitutions.rb
@@ -31,8 +31,8 @@ ActiveAdmin.register Partie, as: 'Restitutions' do
     end
     render 'restitution_metriques',
            metriques_partie: resource.partie.metriques,
-           moyenne_glissante: OpenStruct.new(resource.moyenne_metriques),
-           ecart_type_glissant: OpenStruct.new(resource.ecart_type_metriques),
+           moyenne_glissante: OpenStruct.new(resource.moyennes_metriques),
+           ecart_type_glissant: OpenStruct.new(resource.ecarts_types_metriques),
            cote_z: OpenStruct.new(resource.cote_z_metriques)
     render 'restitution_competences_de_base', restitution: resource
     render 'restitution_competences', restitution: resource

--- a/app/models/restitution/base.rb
+++ b/app/models/restitution/base.rb
@@ -122,7 +122,7 @@ module Restitution
     end
 
     def standardisateur
-      @standardisateur ||= Restitution::Standardisateur.new(
+      @standardisateur ||= Restitution::StandardisateurGlissant.new(
         partie.metriques_numeriques,
         proc { Partie.where(situation: partie.situation) }
       )

--- a/app/models/restitution/base.rb
+++ b/app/models/restitution/base.rb
@@ -23,7 +23,7 @@ module Restitution
     attr_reader :campagne, :evenements
 
     delegate :evaluation, :session_id, :situation, :created_at, to: :partie
-    delegate :moyenne_metriques, :ecart_type_metriques, to: :standardisateur
+    delegate :moyennes_metriques, :ecarts_types_metriques, to: :standardisateur
     alias date created_at
 
     def initialize(campagne, evenements)

--- a/app/models/restitution/globale.rb
+++ b/app/models/restitution/globale.rb
@@ -7,12 +7,12 @@ module Restitution
     NIVEAU_INDETERMINE = :indetermine
     RESTITUTION_SANS_EFFICIENCE = Restitution::Questions
 
-    delegate :moyennes_glissantes,
-             :ecarts_types_glissants,
+    delegate :moyennes_metriques,
+             :ecarts_types_metriques,
              to: :scores_niveau2_standardises,
              prefix: :niveau2
-    delegate :moyennes_glissantes,
-             :ecarts_types_glissants,
+    delegate :moyennes_metriques,
+             :ecarts_types_metriques,
              to: :scores_niveau1_standardises,
              prefix: :niveau1
 

--- a/app/models/restitution/maintenance/score_vocabulaire.rb
+++ b/app/models/restitution/maintenance/score_vocabulaire.rb
@@ -45,7 +45,7 @@ module Restitution
       end
 
       def standardisateur
-        @standardisateur ||= Restitution::Standardisateur.new(
+        @standardisateur ||= Restitution::StandardisateurGlissant.new(
           %i[temps_moyen_mots_francais temps_moyen_non_mots],
           proc { Partie.where(situation: Situation.where(nom_technique: 'maintenance')) }
         )

--- a/app/models/restitution/maintenance/score_vocabulaire.rb
+++ b/app/models/restitution/maintenance/score_vocabulaire.rb
@@ -21,8 +21,8 @@ module Restitution
       end
 
       def temps_moyen_normalise(nom_moyenne, metrique_des_temps)
-        moyenne_glissante = standardisateur.moyenne_metriques[nom_moyenne]
-        ecart_type_glissant = standardisateur.ecart_type_metriques[nom_moyenne]
+        moyenne_glissante = standardisateur.moyennes_metriques[nom_moyenne]
+        ecart_type_glissant = standardisateur.ecarts_types_metriques[nom_moyenne]
 
         metrique_des_temps_normalises = Metriques::TempsNormalises.new(metrique_des_temps,
                                                                        moyenne_glissante,

--- a/app/models/restitution/scores_niveau2.rb
+++ b/app/models/restitution/scores_niveau2.rb
@@ -48,10 +48,8 @@ module Restitution
     def standardisateurs_niveau3
       @standardisateurs_niveau3 ||=
         @parties.map(&:situation_id).uniq.each_with_object({}) do |situation_id, memo|
-          memo[situation_id] ||= Restitution::Standardisateur.new(
-            METRIQUES_ILLETRISME,
-            proc { Partie.where(situation_id: situation_id) }
-          )
+          nom_situation = Situation.find(situation_id).nom_technique
+          memo[situation_id] ||= StandardisateurFige.instancie_pour nom_situation.to_sym
         end
     end
 

--- a/app/models/restitution/scores_standardises.rb
+++ b/app/models/restitution/scores_standardises.rb
@@ -2,8 +2,8 @@
 
 module Restitution
   class ScoresStandardises
-    delegate :moyennes_glissantes,
-             :ecarts_types_glissants,
+    delegate :moyennes_metriques,
+             :ecarts_types_metriques,
              to: :standardisateur
 
     def initialize(scores, standardisateur = nil)

--- a/app/models/restitution/standardisateur.rb
+++ b/app/models/restitution/standardisateur.rb
@@ -2,31 +2,6 @@
 
 module Restitution
   class Standardisateur
-    def initialize(metriques, collect_metriques)
-      @metriques = metriques
-      @collect_metriques = collect_metriques
-    end
-
-    def moyenne_metrique(metrique)
-      aggrege_metrique(:average, metrique)
-    end
-
-    def ecart_type_metrique(metrique)
-      aggrege_metrique(:stddev_pop, metrique)
-    end
-
-    def moyenne_metriques
-      @moyenne_metriques ||= @metriques.each_with_object({}) do |metrique, memo|
-        memo[metrique] = moyenne_metrique(metrique)
-      end
-    end
-
-    def ecart_type_metriques
-      @ecart_type_metriques ||= @metriques.each_with_object({}) do |metrique, memo|
-        memo[metrique] = ecart_type_metrique(metrique)
-      end
-    end
-
     def standardise(metrique, valeur)
       return if valeur.nil? || ecart_type_metriques[metrique].nil?
 
@@ -37,16 +12,6 @@ module Restitution
           (valeur - moyenne_metriques[metrique]) / ecart_type_metriques[metrique]
         )
       end
-    end
-
-    private
-
-    def aggrege_metrique(fonction, metrique)
-      @collect_metriques
-        .call
-        .where.not(metriques: {})
-        .calculate(fonction, "(metriques ->> '#{metrique}')::numeric")
-        .to_f
     end
   end
 end

--- a/app/models/restitution/standardisateur.rb
+++ b/app/models/restitution/standardisateur.rb
@@ -3,13 +3,13 @@
 module Restitution
   class Standardisateur
     def standardise(metrique, valeur)
-      return if valeur.nil? || ecart_type_metriques[metrique].nil?
+      return if valeur.nil? || ecarts_types_metriques[metrique].nil?
 
-      if ecart_type_metriques[metrique].zero?
+      if ecarts_types_metriques[metrique].zero?
         0
       else
         (
-          (valeur - moyenne_metriques[metrique]) / ecart_type_metriques[metrique]
+          (valeur - moyennes_metriques[metrique]) / ecarts_types_metriques[metrique]
         )
       end
     end

--- a/app/models/restitution/standardisateur_echantillon.rb
+++ b/app/models/restitution/standardisateur_echantillon.rb
@@ -1,33 +1,21 @@
 # frozen_string_literal: true
 
 module Restitution
-  class StandardisateurEchantillon
+  class StandardisateurEchantillon < Standardisateur
     def initialize(metriques, scores_evaluations)
       @metriques = metriques
       @scores_evaluations = scores_evaluations
     end
 
-    def moyennes_glissantes
-      @moyennes_glissantes ||= @metriques.each_with_object({}) do |metrique, memo|
+    def moyennes_metriques
+      @moyennes_metriques ||= @metriques.each_with_object({}) do |metrique, memo|
         memo[metrique] = moyenne_metrique(metrique)
       end
     end
 
-    def ecarts_types_glissants
-      @ecarts_types_glissants ||= @metriques.each_with_object({}) do |metrique, memo|
+    def ecarts_types_metriques
+      @ecarts_types_metriques ||= @metriques.each_with_object({}) do |metrique, memo|
         memo[metrique] = ecart_type_metrique(metrique)
-      end
-    end
-
-    def standardise(metrique, valeur)
-      return if valeur.nil? || ecarts_types_glissants[metrique].nil?
-
-      if ecarts_types_glissants[metrique].zero?
-        0
-      else
-        (
-          (valeur - moyennes_glissantes[metrique]) / ecarts_types_glissants[metrique]
-        )
       end
     end
 

--- a/app/models/restitution/standardisateur_fige.rb
+++ b/app/models/restitution/standardisateur_fige.rb
@@ -22,11 +22,11 @@ module Restitution
       new STANDARDS[situation]
     end
 
-    attr_reader :moyenne_metriques, :ecart_type_metriques
+    attr_reader :moyennes_metriques, :ecarts_types_metriques
 
     def initialize(standards)
-      @moyenne_metriques = standards&.transform_values { |references| references[:moyenne] }
-      @ecart_type_metriques = standards&.transform_values { |references| references[:ecart_type] }
+      @moyennes_metriques = standards&.transform_values { |references| references[:moyenne] }
+      @ecarts_types_metriques = standards&.transform_values { |references| references[:ecart_type] }
     end
   end
 end

--- a/app/models/restitution/standardisateur_fige.rb
+++ b/app/models/restitution/standardisateur_fige.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Restitution
+  class StandardisateurFige < Standardisateur
+    STANDARDS = {
+      livraison: {
+        score_syntaxe_orthographe: { moyenne: 0.49, ecart_type: 0.24 },
+        score_numeratie: { moyenne: 0.09, ecart_type: 0.04 },
+        score_ccf: { moyenne: 0.71, ecart_type: 0.23 }
+      },
+      objets_trouves: {
+        score_numeratie: { moyenne: 0.09, ecart_type: 0.04 },
+        score_ccf: { moyenne: 0.28, ecart_type: 0.09 },
+        score_memorisation: { moyenne: 0.22, ecart_type: 0.11 }
+      },
+      maintenance: {
+        score_ccf: { moyenne: 425.04, ecart_type: 245.78 }
+      }
+    }.freeze
+
+    def self.instancie_pour(situation)
+      new STANDARDS[situation]
+    end
+
+    attr_reader :moyenne_metriques, :ecart_type_metriques
+
+    def initialize(standards)
+      @moyenne_metriques = standards&.transform_values { |references| references[:moyenne] }
+      @ecart_type_metriques = standards&.transform_values { |references| references[:ecart_type] }
+    end
+  end
+end

--- a/app/models/restitution/standardisateur_glissant.rb
+++ b/app/models/restitution/standardisateur_glissant.rb
@@ -15,14 +15,14 @@ module Restitution
       aggrege_metrique(:stddev_pop, metrique)
     end
 
-    def moyenne_metriques
-      @moyenne_metriques ||= @metriques.each_with_object({}) do |metrique, memo|
+    def moyennes_metriques
+      @moyennes_metriques ||= @metriques.each_with_object({}) do |metrique, memo|
         memo[metrique] = moyenne_metrique(metrique)
       end
     end
 
-    def ecart_type_metriques
-      @ecart_type_metriques ||= @metriques.each_with_object({}) do |metrique, memo|
+    def ecarts_types_metriques
+      @ecarts_types_metriques ||= @metriques.each_with_object({}) do |metrique, memo|
         memo[metrique] = ecart_type_metrique(metrique)
       end
     end

--- a/app/models/restitution/standardisateur_glissant.rb
+++ b/app/models/restitution/standardisateur_glissant.rb
@@ -7,14 +7,6 @@ module Restitution
       @collect_metriques = collect_metriques
     end
 
-    def moyenne_metrique(metrique)
-      aggrege_metrique(:average, metrique)
-    end
-
-    def ecart_type_metrique(metrique)
-      aggrege_metrique(:stddev_pop, metrique)
-    end
-
     def moyennes_metriques
       @moyennes_metriques ||= @metriques.each_with_object({}) do |metrique, memo|
         memo[metrique] = moyenne_metrique(metrique)
@@ -28,6 +20,14 @@ module Restitution
     end
 
     private
+
+    def moyenne_metrique(metrique)
+      aggrege_metrique(:average, metrique)
+    end
+
+    def ecart_type_metrique(metrique)
+      aggrege_metrique(:stddev_pop, metrique)
+    end
 
     def aggrege_metrique(fonction, metrique)
       @collect_metriques

--- a/app/models/restitution/standardisateur_glissant.rb
+++ b/app/models/restitution/standardisateur_glissant.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Restitution
+  class StandardisateurGlissant < Standardisateur
+    def initialize(metriques, collect_metriques)
+      @metriques = metriques
+      @collect_metriques = collect_metriques
+    end
+
+    def moyenne_metrique(metrique)
+      aggrege_metrique(:average, metrique)
+    end
+
+    def ecart_type_metrique(metrique)
+      aggrege_metrique(:stddev_pop, metrique)
+    end
+
+    def moyenne_metriques
+      @moyenne_metriques ||= @metriques.each_with_object({}) do |metrique, memo|
+        memo[metrique] = moyenne_metrique(metrique)
+      end
+    end
+
+    def ecart_type_metriques
+      @ecart_type_metriques ||= @metriques.each_with_object({}) do |metrique, memo|
+        memo[metrique] = ecart_type_metrique(metrique)
+      end
+    end
+
+    private
+
+    def aggrege_metrique(fonction, metrique)
+      @collect_metriques
+        .call
+        .where.not(metriques: {})
+        .calculate(fonction, "(metriques ->> '#{metrique}')::numeric")
+        .to_f
+    end
+  end
+end

--- a/app/views/admin/evaluations/_restitution_globale.arb
+++ b/app/views/admin/evaluations/_restitution_globale.arb
@@ -149,13 +149,13 @@ if can?(:manage, Compte) && !pdf
     tabs do
       tab 'Scores litteratie et numératie' do
         scores_niveau1 = restitution_globale.scores_niveau1.calcule
-        moyennes_glissantes = restitution_globale.niveau1_moyennes_glissantes
-        ecartstypes_glissants = restitution_globale.niveau1_ecarts_types_glissants
+        moyennes = restitution_globale.niveau1_moyennes_metriques
+        ecarts_types = restitution_globale.niveau1_ecarts_types_metriques
         scores_niveau1_standardises = restitution_globale.scores_niveau1_standardises.calcule
         attributes_table_for [
           [t('admin.restitutions.restitution_colonnes.valeur_utilisateur'), scores_niveau1],
-          [t('admin.restitutions.restitution_colonnes.moyenne_glissante'), moyennes_glissantes],
-          [t('admin.restitutions.restitution_colonnes.ecart_type_glissant'), ecartstypes_glissants],
+          [t('admin.restitutions.restitution_colonnes.moyenne'), moyennes],
+          [t('admin.restitutions.restitution_colonnes.ecart_type'), ecarts_types],
           [t('admin.restitutions.restitution_colonnes.cote_z'), scores_niveau1_standardises]
         ] do
           row do |(titre, _)|
@@ -171,13 +171,13 @@ if can?(:manage, Compte) && !pdf
 
       tab 'Scores meta-compétences' do
         scores_niveau2 = restitution_globale.scores_niveau2.calcule
-        moyennes_glissantes = restitution_globale.niveau2_moyennes_glissantes
-        ecartstypes_glissants = restitution_globale.niveau2_ecarts_types_glissants
+        moyennes = restitution_globale.niveau2_moyennes_metriques
+        ecarts_types = restitution_globale.niveau2_ecarts_types_metriques
         scores_niveau2_standardises = restitution_globale.scores_niveau2_standardises.calcule
         attributes_table_for [
           [t('admin.restitutions.restitution_colonnes.valeur_utilisateur'), scores_niveau2],
-          [t('admin.restitutions.restitution_colonnes.moyenne_glissante'), moyennes_glissantes],
-          [t('admin.restitutions.restitution_colonnes.ecart_type_glissant'), ecartstypes_glissants],
+          [t('admin.restitutions.restitution_colonnes.moyenne'), moyennes],
+          [t('admin.restitutions.restitution_colonnes.ecart_type'), ecarts_types],
           [t('admin.restitutions.restitution_colonnes.cote_z'), scores_niveau2_standardises]
         ] do
           row do |(titre, _)|

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -195,6 +195,8 @@ fr:
       restitution_colonnes:
         cote_z: Cote Z
         valeur_utilisateur: Valeur de l'évalué·e
+        moyenne: Moyenne
+        ecart_type: Écart type
         moyenne_glissante: Moyenne glissante
         ecart_type_glissant: Écart type glissant
       pas_de_score: |

--- a/spec/integrations/restitution/globale_spec.rb
+++ b/spec/integrations/restitution/globale_spec.rb
@@ -3,16 +3,16 @@
 require 'rails_helper'
 
 describe Restitution::Globale do
-  let(:situation)  { create :situation_securite }
+  let(:situation)  { create :situation_objets_trouves }
   let(:evaluation) { create :evaluation }
   let(:evaluation2) { create :evaluation }
-  let(:partie1) do
+  let(:partie_moyenne) do
     create :partie,
            situation: situation,
            evaluation: evaluation,
            metriques: {
-             score_ccf: 1,
-             score_memorisation: 1
+             score_ccf: 0.28,
+             score_memorisation: 0.22
            }
   end
   let(:partie2) do
@@ -29,7 +29,7 @@ describe Restitution::Globale do
            situation: situation,
            evaluation: evaluation,
            metriques: {
-             score_ccf: 2
+             score_ccf: 0.44
            }
   end
 
@@ -38,7 +38,7 @@ describe Restitution::Globale do
            situation: situation,
            evaluation: evaluation2,
            metriques: {
-             score_ccf: 2
+             score_ccf: 0.44
            }
   end
 
@@ -54,7 +54,7 @@ describe Restitution::Globale do
 
   before do
     # pour que les restitutions puisse retrouver les parties !
-    create(:evenement_demarrage, partie: partie1)
+    create(:evenement_demarrage, partie: partie_moyenne)
     create(:evenement_demarrage, partie: partie2)
     create(:evenement_demarrage, partie: partie3)
     create(:evenement_demarrage, partie: partie4)
@@ -67,17 +67,17 @@ describe Restitution::Globale do
       expect(restitution_evaluation1.niveau2_moyennes_glissantes[:score_numeratie]).to eql(nil)
     end
 
-    it "quand il n'y a qu'une seule valeur" do
+    it "quand il n'y a qu'une seule valeur (qui est pile sur la moyenne)" do
       expect(restitution_evaluation1.scores_niveau2.calcule[:score_memorisation]).to eql(0.0)
       expect(restitution_evaluation1.niveau2_moyennes_glissantes[:score_memorisation].round(2))
         .to eql(0.0)
     end
 
     it 'quand il y a plusieurs valeurs' do
-      expect(restitution_evaluation1.scores_niveau2.calcule[:score_ccf].round(2)).to eql(-0.30)
-      expect(restitution_evaluation2.scores_niveau2.calcule[:score_ccf].round(2)).to eql(0.90)
+      expect(restitution_evaluation1.scores_niveau2.calcule[:score_ccf].round(2)).to eql(-0.44)
+      expect(restitution_evaluation2.scores_niveau2.calcule[:score_ccf].round(2)).to eql(1.78)
       expect(restitution_evaluation1.niveau2_moyennes_glissantes[:score_ccf].round(2))
-        .to eql(((-0.30 + 0.90) / 2).round(2))
+        .to eql(((-0.44 + 1.78) / 2).round(2))
     end
   end
 

--- a/spec/integrations/restitution/globale_spec.rb
+++ b/spec/integrations/restitution/globale_spec.rb
@@ -64,19 +64,19 @@ describe Restitution::Globale do
   context "calcule la moyenne des scores pour l'ensemble des évaluations" do
     it "quand il n'y a aucune valeur" do
       expect(restitution_evaluation1.scores_niveau2.calcule[:score_numeratie]).to eql(nil)
-      expect(restitution_evaluation1.niveau2_moyennes_glissantes[:score_numeratie]).to eql(nil)
+      expect(restitution_evaluation1.niveau2_moyennes_metriques[:score_numeratie]).to eql(nil)
     end
 
     it "quand il n'y a qu'une seule valeur (qui est pile sur la moyenne)" do
       expect(restitution_evaluation1.scores_niveau2.calcule[:score_memorisation]).to eql(0.0)
-      expect(restitution_evaluation1.niveau2_moyennes_glissantes[:score_memorisation].round(2))
+      expect(restitution_evaluation1.niveau2_moyennes_metriques[:score_memorisation].round(2))
         .to eql(0.0)
     end
 
     it 'quand il y a plusieurs valeurs' do
       expect(restitution_evaluation1.scores_niveau2.calcule[:score_ccf].round(2)).to eql(-0.44)
       expect(restitution_evaluation2.scores_niveau2.calcule[:score_ccf].round(2)).to eql(1.78)
-      expect(restitution_evaluation1.niveau2_moyennes_glissantes[:score_ccf].round(2))
+      expect(restitution_evaluation1.niveau2_moyennes_metriques[:score_ccf].round(2))
         .to eql(((-0.44 + 1.78) / 2).round(2))
     end
   end
@@ -87,9 +87,9 @@ describe Restitution::Globale do
         .to eql(-0.5)
       expect(restitution_evaluation1.scores_niveau1.calcule[:numeratie])
         .to eql(nil)
-      expect(restitution_evaluation1.niveau1_moyennes_glissantes[:litteratie])
+      expect(restitution_evaluation1.niveau1_moyennes_metriques[:litteratie])
         .to eql(0.25)
-      expect(restitution_evaluation1.niveau1_moyennes_glissantes[:numeratie]).to eql(0.0)
+      expect(restitution_evaluation1.niveau1_moyennes_metriques[:numeratie]).to eql(0.0)
     end
   end
 end

--- a/spec/integrations/standardisateur_spec.rb
+++ b/spec/integrations/standardisateur_spec.rb
@@ -44,22 +44,22 @@ describe Restitution::Standardisateur do
     create(:evenement_demarrage, partie: partie1)
   end
 
-  context '#moyenne_metriques' do
-    context "calcule la moyenne pour l'ensemble des metriques" do
+  context '#moyennes_metriques' do
+    context "calcule les moyennes pour l'ensemble des metriques" do
       before { [partie1, partie2, partie3] }
 
       it do
-        expect(restitution.moyenne_metriques).to eql('test_metrique' => 1.0)
+        expect(restitution.moyennes_metriques).to eql('test_metrique' => 1.0)
       end
     end
   end
 
-  context '#ecart_type_metriques' do
-    context "calcule la moyenne pour l'ensemble des metriques" do
+  context '#ecarts_types_metriques' do
+    context "calcule les écarts types pour l'ensemble des metriques" do
       before { [partie1, partie2, partie3] }
 
       it do
-        expect(restitution.ecart_type_metriques).to eql('test_metrique' => 0.816496580927726)
+        expect(restitution.ecarts_types_metriques).to eql('test_metrique' => 0.816496580927726)
       end
     end
   end

--- a/spec/models/restitution/maintenance/score_vocabulaire_spec.rb
+++ b/spec/models/restitution/maintenance/score_vocabulaire_spec.rb
@@ -36,9 +36,9 @@ describe Restitution::Maintenance::ScoreVocabulaire do
       let(:mock_metrique_temps) { double }
 
       it do
-        allow(standardisateur).to receive(:moyenne_metriques)
+        allow(standardisateur).to receive(:moyennes_metriques)
           .and_return(temps_moyen_mots_francais: 2.7)
-        allow(standardisateur).to receive(:ecart_type_metriques)
+        allow(standardisateur).to receive(:ecarts_types_metriques)
           .and_return(temps_moyen_mots_francais: 0.5)
 
         allow(metrique_score_ccf).to receive(:standardisateur).and_return(standardisateur)

--- a/spec/models/restitution/standardisateur_echantillon_spec.rb
+++ b/spec/models/restitution/standardisateur_echantillon_spec.rb
@@ -6,15 +6,15 @@ describe Restitution::StandardisateurEchantillon do
   describe 'retourne moyenne et écart type des scores CCF de toutes les Restitutions globales' do
     standardisateur = Restitution::StandardisateurEchantillon
                       .new %i[score_ccf], { score_ccf: [1, 2] }
-    it { expect(standardisateur.moyennes_glissantes).to eq(score_ccf: 1.5) }
-    it { expect(standardisateur.ecarts_types_glissants).to eq(score_ccf: 0.5) }
+    it { expect(standardisateur.moyennes_metriques).to eq(score_ccf: 1.5) }
+    it { expect(standardisateur.ecarts_types_metriques).to eq(score_ccf: 0.5) }
   end
 
   describe "retourne nil si la métrique n'est pas présente" do
     standardisateur = Restitution::StandardisateurEchantillon
                       .new %i[score_ccf], { score_memorisation: [1, 2] }
-    it { expect(standardisateur.moyennes_glissantes).to eq(score_ccf: nil) }
-    it { expect(standardisateur.ecarts_types_glissants).to eq(score_ccf: nil) }
+    it { expect(standardisateur.moyennes_metriques).to eq(score_ccf: nil) }
+    it { expect(standardisateur.ecarts_types_metriques).to eq(score_ccf: nil) }
   end
 
   describe 'sait standardiser une valeur' do

--- a/spec/models/restitution/standardisateur_fige_spec.rb
+++ b/spec/models/restitution/standardisateur_fige_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Restitution::StandardisateurFige do
+  let(:standards) do
+    {
+      ccf: { moyenne: 12, ecart_type: 3 },
+      syntaxe: { moyenne: 2, ecart_type: 0.5 }
+    }
+  end
+  let(:subject) { described_class.new standards }
+
+  it { expect(subject.moyenne_metriques).to eq({ ccf: 12, syntaxe: 2 }) }
+
+  it { expect(subject.ecart_type_metriques).to eq({ ccf: 3, syntaxe: 0.5 }) }
+
+  it { expect(subject.standardise(:ccf, 12 + 3)).to eq 1 }
+end

--- a/spec/models/restitution/standardisateur_fige_spec.rb
+++ b/spec/models/restitution/standardisateur_fige_spec.rb
@@ -11,9 +11,9 @@ describe Restitution::StandardisateurFige do
   end
   let(:subject) { described_class.new standards }
 
-  it { expect(subject.moyenne_metriques).to eq({ ccf: 12, syntaxe: 2 }) }
+  it { expect(subject.moyennes_metriques).to eq({ ccf: 12, syntaxe: 2 }) }
 
-  it { expect(subject.ecart_type_metriques).to eq({ ccf: 3, syntaxe: 0.5 }) }
+  it { expect(subject.ecarts_types_metriques).to eq({ ccf: 3, syntaxe: 0.5 }) }
 
   it { expect(subject.standardise(:ccf, 12 + 3)).to eq 1 }
 end


### PR DESCRIPTION
Répond au ticket : https://trello.com/c/gaSa8Sbn

Plutôt que de baser notre algo sur une moyenne glissante qui s’enrichie chaque jour des nouvelles restitutions, on se basera sur une moyenne et un écart type calculé une fois pour toute sur un échantillon représentatif.

Nous avons assez de données dans notre base pour calculer ces deux éléments.