### PR TITLE
Restitution : réduit d'un poil la taille des badges français-math

### DIFF
--- a/app/assets/stylesheets/restitution_globale/_base.scss
+++ b/app/assets/stylesheets/restitution_globale/_base.scss
@@ -230,7 +230,7 @@
 
   .col-auto.badge {
     img {
-      width: 5rem;
+      width: 4.5rem;
       margin-bottom: 1rem;
     }
   }


### PR DESCRIPTION
La réduction de la largeur des badges permet de gagner un peu d'espace
en longueur et ainsi d'afficher entièrement certaines restitutions qui
dépassaient de quelques lignes.
## Avant :
![Capture d’écran 2020-10-19 à 16 31 37](https://user-images.githubusercontent.com/298214/96464832-96078880-1228-11eb-9983-326ab5a383c3.png)

## Après : 
![Capture d’écran 2020-10-19 à 16 30 40](https://user-images.githubusercontent.com/298214/96464723-740e0600-1228-11eb-906f-f00be4ea4996.png)
