### PR TITLE
Correction du titre du lien de références pour l'évaluation Français-Math

### DIFF
--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -305,5 +305,5 @@ fr:
           explications: |
             Les restitutions eva sont basées sur les référentiels européens d’évaluation du français et des mathématiques, ainsi que sur le référentiel Cléa.
           references: |
-            Le détail de l’utilisation de ces référentiels et les conditions d’interprétation sont disponibles ici :
+            Le détail de l’utilisation de ces référentiels et des conditions d’interprétation est disponible ici :
             [https://l.incubateur.net/eva-clea](https://l.incubateur.net/eva-clea)


### PR DESCRIPTION
![Capture d’écran 2020-10-21 à 11 59 21](https://user-images.githubusercontent.com/298214/96704913-e26fd700-1394-11eb-9fb8-b90e2ece8dfc.png)
