### PR TITLE
Réduit l'entête de la restitution version pdf

### DIFF
--- a/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
+++ b/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
@@ -21,10 +21,10 @@
   .en-tete-page {
     display: block;
     background-image: asset-data-url('vague.svg');
-    background-size: 100%;
+    background-size: 100% 200px;
     background-repeat: no-repeat;
-    height: 233px;
-    padding: 3.75rem 5rem 0 5rem;
+    height: 200px;
+    padding: 2.25rem 5rem 0 5rem;
 
     .eva-logo {
       margin-right: 1.5rem;
@@ -42,7 +42,8 @@
 
     .structure {
       color: #FBF9FA;
-      font-size: 1.6rem;
+      font-size: 1.4rem;
+      line-height: 1;
     }
 
     .date-restitution {


### PR DESCRIPTION
https://trello.com/c/Z4iqMNHP/267-r%C3%A9duire-lent%C3%AAte-du-pdf-pour-%C3%A9viter-que-%C3%A7a-d%C3%A9passe

<img width="969" alt="Capture d’écran 2020-10-28 à 11 42 06" src="https://user-images.githubusercontent.com/1309612/97425657-b31c1580-1912-11eb-8430-4d3b5132f029.png">
