### PR TITLE
Corrige les standards de numératie et litteratie qui étaient inversés

### DIFF
--- a/app/models/restitution/standardisateur_fige.rb
+++ b/app/models/restitution/standardisateur_fige.rb
@@ -20,8 +20,8 @@ module Restitution
         score_ccf: { moyenne: 0.16, ecart_type: 0.61 },
         score_syntaxe_orthographe: { moyenne: 0.09, ecart_type: 0.83 },
         score_memorisation: { moyenne: 0.23, ecart_type: 0.93 },
-        litteratie: { moyenne: 0.11, ecart_type: 0.48 },
-        numeratie: { moyenne: 0.16, ecart_type: 0.65 }
+        numeratie: { moyenne: 0.11, ecart_type: 0.48 },
+        litteratie: { moyenne: 0.16, ecart_type: 0.65 }
       }
     }.freeze
 

--- a/spec/integrations/restitution/globale_spec.rb
+++ b/spec/integrations/restitution/globale_spec.rb
@@ -102,7 +102,7 @@ describe Restitution::Globale do
 
     context 'de niveau 1' do
       let(:score_litteratie) { -0.08 } # moyenne des scores standardisés niveau 2
-      let(:score_litteratie_standardise) { -0.4 } # (-0.08 - 0.11) / 0.48
+      let(:score_litteratie_standardise) { -0.37 } # (-0.08 - 0.16) / 0.65
 
       it do
         expect(restitution_evaluation1.scores_niveau1.calcule[:litteratie].round(2))


### PR DESCRIPTION
pour https://trello.com/c/uYfw0RtW/249-figer-les-niveau-2-et-niveau-1-de-lalgo