### PR TITLE
Ajoute les valeurs figées pour la méta-compétences score_numératie

### DIFF
--- a/app/models/restitution/standardisateur_fige.rb
+++ b/app/models/restitution/standardisateur_fige.rb
@@ -18,9 +18,10 @@ module Restitution
       },
       plus_haut_niveau: {
         score_ccf: { moyenne: 0.16, ecart_type: 0.61 },
+        score_numeratie: { moyenne: 0.11, ecart_type: 0.48 },
         score_syntaxe_orthographe: { moyenne: 0.09, ecart_type: 0.83 },
         score_memorisation: { moyenne: 0.23, ecart_type: 0.93 },
-        numeratie: { moyenne: 0.11, ecart_type: 0.48 },
+        numeratie: { moyenne: 0, ecart_type: 0.83 },
         litteratie: { moyenne: 0.16, ecart_type: 0.65 }
       }
     }.freeze


### PR DESCRIPTION
J'ai appliqué les valeurs données par Alexis pour le niveau 1 au niveau 2 et j'ai mis pour le niveau 1 les valeurs que nous avions en production avant la mep v20201103.

Restera à demander à Alexis de calculer les bonnes valeurs sur la base de l'échantillon de référence.