### PR TITLE
Fixe le problème de scroll suite à la modification du header

### DIFF
--- a/app/assets/stylesheets/admin/_header.scss
+++ b/app/assets/stylesheets/admin/_header.scss
@@ -3,6 +3,7 @@
   display: table;
   height: 64px;
   padding: 0.6rem 1.9rem;
+  overflow: hidden;
   text-shadow: none;
   border-bottom: 0;
   box-shadow: none;


### PR DESCRIPTION
Un scroll vertical apparaissait suite aux modifications du header : 
![Capture d’écran 2020-11-06 à 15 23 33](https://user-images.githubusercontent.com/1309612/98376635-13623400-2044-11eb-9564-2c3a2f964caa.png)
 
Après :
![Capture d’écran 2020-11-06 à 15 25 22](https://user-images.githubusercontent.com/1309612/98376823-515f5800-2044-11eb-9aff-9c940534521e.png)
