### PR TITLE
élargie les filtres pour que les boutons d'actions soient sur la même ligne

### DIFF
--- a/app/assets/stylesheets/admin/_panels.scss
+++ b/app/assets/stylesheets/admin/_panels.scss
@@ -13,6 +13,6 @@
     background: none;
   }
   .panel_contents {
-    padding: 0 1.5rem 1.5rem;
+    padding: 0 1.3rem 1.5rem;
   }
 }


### PR DESCRIPTION
Le problème n'est présent que sur firefox et safari

avant : 
<img width="302" alt="Capture d’écran 2020-11-10 à 14 37 41" src="https://user-images.githubusercontent.com/298214/98680907-51bc6380-2362-11eb-816e-1caa846e61a8.png">



après : 
<img width="299" alt="Capture d’écran 2020-11-10 à 14 37 25" src="https://user-images.githubusercontent.com/298214/98680889-4bc68280-2362-11eb-9b20-290b2d75e32a.png">
