### PR TITLE
Ne cache pas le header verticalement pour que les sous menus puissent s'afficher

### DIFF
--- a/app/assets/stylesheets/admin/_header.scss
+++ b/app/assets/stylesheets/admin/_header.scss
@@ -3,7 +3,7 @@
   display: table;
   height: 64px;
   padding: 0.6rem 1.9rem;
-  overflow: hidden;
+  overflow-x: hidden;
   text-shadow: none;
   border-bottom: 0;
   box-shadow: none;


### PR DESCRIPTION
Avant : 
![menu-caché](https://user-images.githubusercontent.com/298214/98700568-9bb04400-2378-11eb-9d04-5a56bc021316.png)

Après : 
![menu-pas-caché](https://user-images.githubusercontent.com/298214/98700562-99e68080-2378-11eb-86ce-f7a115e8c874.png)
