### PR TITLE
Design table - Ajoute un espace à droite des boutons pour firefox

### DIFF
--- a/app/assets/stylesheets/admin/_tables.scss
+++ b/app/assets/stylesheets/admin/_tables.scss
@@ -40,6 +40,9 @@ table.index_table {
         }
         &.col-actions {
           padding: 0;
+          @-moz-document url-prefix() {
+            padding-right: 0.75rem;
+          }
           .table_actions {
             display: flex;
             align-content: stretch;


### PR DESCRIPTION
Avant 

<img width="306" alt="Capture d’écran 2020-11-13 à 12 30 03" src="https://user-images.githubusercontent.com/1309612/99068171-45c3e200-25ac-11eb-8bd5-cb52cf2251f2.png">

Après 

<img width="339" alt="Capture d’écran 2020-11-13 à 12 29 46" src="https://user-images.githubusercontent.com/1309612/99068192-4ceaf000-25ac-11eb-99f7-7cde82fc2b21.png">
