### PR TITLE
Ajoute une bordure pour safari

### DIFF
--- a/app/assets/stylesheets/admin/_tables.scss
+++ b/app/assets/stylesheets/admin/_tables.scss
@@ -31,11 +31,6 @@ table.index_table {
       &.even {
         td {
           background: none;
-          &:last-child {
-            @supports not (-moz-appearance:none) {
-              background-color: $bluegrey;
-            }
-          }
         }
       }
 
@@ -58,51 +53,31 @@ table.index_table {
           border-right: 1px solid $bluegrey;
           border-top-right-radius: 0.5rem;
           border-bottom-right-radius: 0.5rem;
-          @supports not (-moz-appearance:none) {
-            background-color: $bluegrey;
-          }
         }
         a {
           color: $couleur-principale;
         }
         &.col-actions {
-          padding: 0;
           .table_actions {
             display: flex;
-            align-content: stretch;
-            height: 100%;
-            @supports not (-moz-appearance:none) {
-              border-top-right-radius: 0.4rem;
-              border-bottom-right-radius: 0.4rem;
-            }
-            overflow: hidden;
             a {
               display: flex;
               align-items: center;
               justify-content: center;
-              margin-right: 0;
-              padding: 0 0.5rem;
-              color: #fff;
-              background-color: $couleur-texte;
-              @supports (-moz-appearance:none) {
-                margin: 0.2rem;
-                border-radius: 1rem;
-                text-decoration:none;
+              padding: 0.25rem 0.5rem;
+              color: $couleur-blanc;
+              margin: 0.2rem;
+              border-radius: 1rem;
+              text-decoration: none;
 
-                &:last-child {
-                  margin-right: 0.7rem;
-                }
-              }
               &.view_link {
                 background-color: $couleur-legere-accent-validation;
                 min-width: 3rem;
               }
               &.edit_link {
-                min-width: 3.5rem;
                 background-color: $couleur-principale;
               }
               &.delete_link {
-                min-width: 4.5rem;
                 background-color: $couleur-accent-erreur;
               }
             }

--- a/app/assets/stylesheets/admin/_tables.scss
+++ b/app/assets/stylesheets/admin/_tables.scss
@@ -32,11 +32,24 @@ table.index_table {
         line-height: 1.2;
         border-bottom: 0;
         vertical-align: middle;
+        border-top: 1px solid $bluegrey;
+        border-bottom: 1px solid $bluegrey;
         color: $couleur-texte-sombre;
-        a { color: $couleur-principale; }
         &:first-child {
           font-weight: 600;
           padding-left: 1.375rem;
+          border-left: 1px solid $bluegrey;
+          border-top-left-radius: 0.5rem;
+          border-bottom-left-radius: 0.5rem;
+        }
+        &:last-child {
+          border-right: 1px solid $bluegrey;
+          border-top-right-radius: 0.5rem;
+          border-bottom-right-radius: 0.5rem;
+
+        }
+        a {
+          color: $couleur-principale;
         }
         &.col-actions {
           padding: 0;

--- a/app/assets/stylesheets/admin/_tables.scss
+++ b/app/assets/stylesheets/admin/_tables.scss
@@ -27,6 +27,18 @@ table.index_table {
     tr {
       border-radius: 0.5rem;
       box-shadow: 0px 0px 0.5rem rgba(30, 65, 106, 0.5);
+
+      &.even {
+        td {
+          background: none;
+          &:last-child {
+            @supports not (-moz-appearance:none) {
+              background-color: $bluegrey;
+            }
+          }
+        }
+      }
+
       td {
         height: 1.875rem;
         line-height: 1.2;
@@ -46,24 +58,24 @@ table.index_table {
           border-right: 1px solid $bluegrey;
           border-top-right-radius: 0.5rem;
           border-bottom-right-radius: 0.5rem;
-
+          @supports not (-moz-appearance:none) {
+            background-color: $bluegrey;
+          }
         }
         a {
           color: $couleur-principale;
         }
         &.col-actions {
           padding: 0;
-          @-moz-document url-prefix() {
-            padding-right: 0.75rem;
-          }
           .table_actions {
             display: flex;
             align-content: stretch;
             height: 100%;
+            @supports not (-moz-appearance:none) {
+              border-top-right-radius: 0.4rem;
+              border-bottom-right-radius: 0.4rem;
+            }
             overflow: hidden;
-            border-top-right-radius: 0.5rem;
-            border-bottom-right-radius: 0.5rem;
-            background-color: $bluegrey;
             a {
               display: flex;
               align-items: center;
@@ -72,6 +84,15 @@ table.index_table {
               padding: 0 0.5rem;
               color: #fff;
               background-color: $couleur-texte;
+              @supports (-moz-appearance:none) {
+                margin: 0.2rem;
+                border-radius: 1rem;
+                text-decoration:none;
+
+                &:last-child {
+                  margin-right: 0.7rem;
+                }
+              }
               &.view_link {
                 background-color: $couleur-legere-accent-validation;
                 min-width: 3rem;
@@ -86,11 +107,6 @@ table.index_table {
               }
             }
           }
-        }
-      }
-      &.even {
-        td {
-          background: none;
         }
       }
     }


### PR DESCRIPTION
<img width="1102" alt="Capture d’écran 2020-11-13 à 16 09 57" src="https://user-images.githubusercontent.com/1309612/99087128-b24dd980-25ca-11eb-8381-b96de59d3389.png">

Cet ajout laisse une bordure visible sur Chrome :

<img width="1051" alt="Capture d’écran 2020-11-13 à 16 11 18" src="https://user-images.githubusercontent.com/1309612/99087297-e32e0e80-25ca-11eb-862c-bae8d1e22c34.png">
