### PR TITLE
Ajout le calcul du temps moyen de recherche des zone de danger

### DIFF
--- a/app/models/restitution/metriques/map_to_list.rb
+++ b/app/models/restitution/metriques/map_to_list.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Restitution
+  module Metriques
+    class MapToList < Restitution::Metriques::Base
+      def initialize(metrique_a_moyenner)
+        @metrique_a_moyenner = metrique_a_moyenner
+      end
+
+      def calcule(premier_parametre, deuxieme_parametre)
+        @metrique_a_moyenner.calcule(premier_parametre, deuxieme_parametre).values
+      end
+    end
+  end
+end

--- a/app/models/restitution/securite.rb
+++ b/app/models/restitution/securite.rb
@@ -38,6 +38,12 @@ module Restitution
         'type' => :map,
         'instance' => Securite::TempsRechercheZonesDangers.new
       },
+      'temps_moyen_recherche_zones_dangers' => {
+        'type' => :nombre,
+        'instance' => Metriques::Moyenne.new(
+          Metriques::MapToList.new(Securite::TempsRechercheZonesDangers.new)
+        )
+      },
       'temps_total_ouverture_zones_dangers' => {
         'type' => :map,
         'instance' => Securite::TempsTotalOuvertureZonesDangers.new

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -176,6 +176,7 @@ fr:
         nombre_reouverture_zones_sans_danger: Retours sur les zones sans danger
         temps_bonnes_qualifications_dangers: Temps ouverture de la première bonne qualification
         temps_recherche_zones_dangers: Temps de recherche des zones de dangers
+        temps_moyen_recherche_zones_dangers: Temps moyen de recherche des zones de dangers
         temps_total_ouverture_zones_dangers: Temps total d'ouverture des zones de dangers
         nombre_dangers_mal_identifies: Dangers mal identifiés
         nombre_dangers_bien_identifies_avant_aide_1: Dangers bien identifiés avant activation de l'aide N°1

--- a/spec/models/restitution/metriques/map_to_list_spec.rb
+++ b/spec/models/restitution/metriques/map_to_list_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Restitution::Metriques::MapToList do
+  let(:mock_metrique_a_moyenner) { double }
+  let(:metrique_moyenne) do
+    described_class.new(mock_metrique_a_moyenner)
+  end
+
+  describe '#moyenne' do
+    it "quand il n'y a pas de valeur" do
+      expect(mock_metrique_a_moyenner).to receive(:calcule).and_return({})
+      expect(metrique_moyenne.calcule([], [])).to eql([])
+    end
+
+    it 'rend une liste des valeurs quand il y en a' do
+      expect(mock_metrique_a_moyenner).to receive(:calcule).and_return({ mesure: 1, mesure2: 1.1 })
+      expect(metrique_moyenne.calcule([], [])).to eql([1, 1.1])
+    end
+  end
+end


### PR DESCRIPTION
Attention à bien recalculer les métriques de sécurité pour profiter de cette
nouvelle métrique.