### PR TITLE
Donne une couleur et une taille minimum par défaut pour les boutons d'actions

### DIFF
--- a/app/assets/stylesheets/admin/_tables.scss
+++ b/app/assets/stylesheets/admin/_tables.scss
@@ -69,10 +69,11 @@ table.index_table {
               margin: 0.2rem;
               border-radius: 1rem;
               text-decoration: none;
+              background-color: $couleur-texte;
+              min-width: 3rem;
 
               &.view_link {
                 background-color: $couleur-legere-accent-validation;
-                min-width: 3rem;
               }
               &.edit_link {
                 background-color: $couleur-principale;


### PR DESCRIPTION
Ici par exemple pour le bouton "Parties"

<img width="557" alt="Capture d’écran 2020-11-16 à 16 49 16" src="https://user-images.githubusercontent.com/298214/99275378-b4fb3980-282b-11eb-8e25-872623b6e52a.png">
