### PR TITLE
Bascule les batch_action en mode 'opt-in'

### DIFF
--- a/app/admin/campagnes.rb
+++ b/app/admin/campagnes.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Campagne do
-  config.batch_actions = false
   permit_params :libelle, :code, :questionnaire_id, :compte,
                 :compte_id, :affiche_competences_fortes,
                 situations_configurations_attributes: %i[id situation_id _destroy]

--- a/app/admin/stats.rb
+++ b/app/admin/stats.rb
@@ -2,7 +2,6 @@
 
 ActiveAdmin.register Evaluation, as: 'Stats' do
   belongs_to :campagne
-  config.batch_actions = false
   config.sort_order = 'created_at_desc'
 
   filter :nom

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -138,7 +138,7 @@ ActiveAdmin.setup do |config|
   #
   # Enable and disable Batch Actions
   #
-  config.batch_actions = true
+  config.batch_actions = false
 
   # == Controller Filters
   #

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -223,6 +223,3 @@ fr:
       index:
         rapport: Rapport
         evenements: Évenements
-    batch_actions:
-      labels:
-        restitution_globale_pour: Restitution globale pour


### PR DESCRIPTION
Par exemple, sur les comptes les actions groupées ne sont plus affichées.

<img width="945" alt="Capture d’écran 2020-11-16 à 17 32 29" src="https://user-images.githubusercontent.com/298214/99280558-c3e4ea80-2831-11eb-80f8-a0448d9030a9.png">
