### PR TITLE
Corrige le style du texte pour les utilisateurs avec le rôle  organisation

### DIFF
--- a/app/assets/stylesheets/admin/_header.scss
+++ b/app/assets/stylesheets/admin/_header.scss
@@ -82,7 +82,8 @@
       }
     }
     #current_user {
-      a {
+      span, a {
+        color: $couleur-texte-sombre;
         margin-right: 3.1rem;
         padding: 0.38rem 0;
       }


### PR DESCRIPTION
Pour le ticket : https://trello.com/c/O7WoOu86

Avant :

<img width="222" alt="Capture d’écran 2020-11-18 à 16 08 56" src="https://user-images.githubusercontent.com/298214/99547924-662eda80-29b8-11eb-81e5-651cd48ed4b9.png">

après : 

<img width="282" alt="Capture d’écran 2020-11-18 à 16 09 06" src="https://user-images.githubusercontent.com/298214/99547967-7050d900-29b8-11eb-94a2-19d43cbf9594.png">
