### PR TITLE
Admin - Situations : n'affiche le bouton `parties` que si on a les droits

### DIFF
--- a/app/admin/situations.rb
+++ b/app/admin/situations.rb
@@ -20,7 +20,7 @@ ActiveAdmin.register Situation do
     column :questionnaire
     column :questionnaire_entrainement
     actions do |situation|
-      link_to 'Parties', admin_situation_parties_path(situation)
+      link_to 'Parties', admin_situation_parties_path(situation) if can?(:manage, Partie)
     end
   end
 end


### PR DESCRIPTION
pour le ticket https://trello.com/c/B8mrh7kE