### PR TITLE
Restitution situation : Utilise les valeurs figés du niveau 3

### DIFF
--- a/app/models/restitution/base.rb
+++ b/app/models/restitution/base.rb
@@ -124,7 +124,8 @@ module Restitution
     def standardisateur
       @standardisateur ||= Restitution::StandardisateurGlissant.new(
         partie.metriques_numeriques,
-        proc { Partie.where(situation: partie.situation) }
+        proc { Partie.where(situation: partie.situation) },
+        Restitution::StandardisateurFige::STANDARDS[partie.situation.nom_technique.to_sym]
       )
     end
   end

--- a/app/models/restitution/standardisateur_fige.rb
+++ b/app/models/restitution/standardisateur_fige.rb
@@ -4,25 +4,28 @@ module Restitution
   class StandardisateurFige < Standardisateur
     STANDARDS = {
       livraison: {
-        score_syntaxe_orthographe: { moyenne: 0.49, ecart_type: 0.24 },
-        score_numeratie: { moyenne: 0.09, ecart_type: 0.04 },
-        score_ccf: { moyenne: 0.71, ecart_type: 0.23 }
+        score_syntaxe_orthographe: { average: 0.49, stddev_pop: 0.24 },
+        score_numeratie: { average: 0.09, stddev_pop: 0.04 },
+        score_ccf: { average: 0.71, stddev_pop: 0.23 }
       },
       objets_trouves: {
-        score_numeratie: { moyenne: 0.09, ecart_type: 0.04 },
-        score_ccf: { moyenne: 0.28, ecart_type: 0.09 },
-        score_memorisation: { moyenne: 0.22, ecart_type: 0.11 }
+        score_numeratie: { average: 0.09, stddev_pop: 0.04 },
+        score_ccf: { average: 0.28, stddev_pop: 0.09 },
+        score_memorisation: { average: 0.22, stddev_pop: 0.11 }
       },
       maintenance: {
-        score_ccf: { moyenne: 425.04, ecart_type: 245.78 }
+        score_ccf: { average: 425.04, stddev_pop: 245.78 }
+      },
+      securite: {
+        temps_moyen_recherche_zones_dangers: { average: 17.83, stddev_pop: 9.46 }
       },
       plus_haut_niveau: {
-        score_ccf: { moyenne: 0.16, ecart_type: 0.61 },
-        score_syntaxe_orthographe: { moyenne: 0.09, ecart_type: 0.83 },
-        score_memorisation: { moyenne: 0.23, ecart_type: 0.93 },
-        score_numeratie: { moyenne: 0, ecart_type: 1 },
-        litteratie: { moyenne: 0.16, ecart_type: 0.65 },
-        numeratie: { moyenne: 0, ecart_type: 1 }
+        score_ccf: { average: 0.16, stddev_pop: 0.61 },
+        score_syntaxe_orthographe: { average: 0.09, stddev_pop: 0.83 },
+        score_memorisation: { average: 0.23, stddev_pop: 0.93 },
+        score_numeratie: { average: 0, stddev_pop: 1 },
+        litteratie: { average: 0.16, stddev_pop: 0.65 },
+        numeratie: { average: 0, stddev_pop: 1 }
       }
     }.freeze
 
@@ -33,8 +36,8 @@ module Restitution
     attr_reader :moyennes_metriques, :ecarts_types_metriques
 
     def initialize(standards)
-      @moyennes_metriques = standards&.transform_values { |references| references[:moyenne] }
-      @ecarts_types_metriques = standards&.transform_values { |references| references[:ecart_type] }
+      @moyennes_metriques = standards&.transform_values { |references| references[:average] }
+      @ecarts_types_metriques = standards&.transform_values { |references| references[:stddev_pop] }
     end
   end
 end

--- a/app/models/restitution/standardisateur_glissant.rb
+++ b/app/models/restitution/standardisateur_glissant.rb
@@ -2,11 +2,7 @@
 
 module Restitution
   class StandardisateurGlissant < Standardisateur
-    STANDARDS = {
-      temps_moyen_recherche_zones_dangers: { average: 17.83, stddev_pop: 9.46 }
-    }.freeze
-
-    def initialize(metriques, collect_metriques, standards_figes = STANDARDS)
+    def initialize(metriques, collect_metriques, standards_figes = nil)
       @metriques = metriques
       @collect_metriques = collect_metriques
       @standards_figes = standards_figes
@@ -35,7 +31,7 @@ module Restitution
     end
 
     def aggrege_metrique(fonction, metrique)
-      return @standards_figes[metrique.to_sym][fonction] if @standards_figes.key?(metrique.to_sym)
+      return @standards_figes[metrique.to_sym][fonction] if @standards_figes&.key?(metrique.to_sym)
 
       @collect_metriques
         .call

--- a/spec/integrations/restitution/maintenance_spec.rb
+++ b/spec/integrations/restitution/maintenance_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Restitution::Maintenance, type: :integration do
+  context 'Calcule le score de deux parties et attend deux résultats différents' do
+    let(:situation) { create :situation_maintenance }
+
+    let(:partie1) { create :partie, situation: situation }
+    let(:restitution1) { FabriqueRestitution.instancie partie1.id }
+
+    before do
+      create(:evenement_demarrage,
+             partie: partie1,
+             date: Time.local(2019, 10, 9, 10, 1, 20))
+      create(:evenement_apparition_mot,
+             partie: partie1,
+             donnees: { 'mot' => 'revu', 'type' => 'neutre' },
+             date: Time.local(2019, 10, 9, 10, 1, 21))
+    end
+
+    it do
+      expect(restitution1.score_ccf).to eq(0)
+    end
+  end
+end

--- a/spec/integrations/standardisateur_spec.rb
+++ b/spec/integrations/standardisateur_spec.rb
@@ -36,6 +36,14 @@ describe Restitution::Standardisateur do
              test_chaine: 'test2'
            }
   end
+  let(:partie4) do
+    create :partie,
+           situation: situation,
+           evaluation: evaluation,
+           metriques: {
+             temps_moyen_recherche_zones_dangers: 0
+           }
+  end
 
   let(:restitution) { FabriqueRestitution.instancie(partie1.id) }
 
@@ -50,6 +58,17 @@ describe Restitution::Standardisateur do
 
       it do
         expect(restitution.moyennes_metriques).to eql('test_metrique' => 1.0)
+      end
+    end
+
+    context 'retourne la moyennes figée si elle existe' do
+      let(:restitution) { FabriqueRestitution.instancie(partie4.id) }
+      before do
+        create(:evenement_demarrage, partie: partie4)
+      end
+
+      it do
+        expect(restitution.moyennes_metriques).to eq('temps_moyen_recherche_zones_dangers' => 17.83)
       end
     end
   end

--- a/spec/models/restitution/standardisateur_fige_spec.rb
+++ b/spec/models/restitution/standardisateur_fige_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 describe Restitution::StandardisateurFige do
   let(:standards) do
     {
-      ccf: { moyenne: 12, ecart_type: 3 },
-      syntaxe: { moyenne: 2, ecart_type: 0.5 }
+      ccf: { average: 12, stddev_pop: 3 },
+      syntaxe: { average: 2, stddev_pop: 0.5 }
     }
   end
   let(:subject) { described_class.new standards }

--- a/spec/models/restitution/standardisateur_glissant_spec.rb
+++ b/spec/models/restitution/standardisateur_glissant_spec.rb
@@ -16,4 +16,16 @@ describe Restitution::StandardisateurGlissant do
     it { expect(subject.moyennes_metriques).to eq('temps_moyen_recherche_zones_dangers' => 12) }
     it { expect(subject.ecarts_types_metriques).to eq('temps_moyen_recherche_zones_dangers' => 3) }
   end
+
+  context 'peut ne pas recevoir de standards figés' do
+    let(:subject) do
+      described_class.new(
+        ['temps_moyen_recherche_zones_dangers'],
+        proc { Partie.where(situation: Situation.where(nom_technique: 'securite')) }
+      )
+    end
+
+    it { expect(subject.moyennes_metriques).to eq('temps_moyen_recherche_zones_dangers' => 0) }
+    it { expect(subject.ecarts_types_metriques).to eq('temps_moyen_recherche_zones_dangers' => 0) }
+  end
 end


### PR DESCRIPTION
Utilise les standards figés aussi dans la restitution des situation. Par exemple dans la copie d'écran suivante, la moyenne et l'écart type du score ccf de la maintenance sont les valeurs figées : 
<img width="1105" alt="Capture d’écran 2020-11-23 à 17 39 27" src="https://user-images.githubusercontent.com/298214/99989497-fbfca800-2db2-11eb-9b48-b77baf4a18ff.png">
