### PR TITLE
ajuste la largeur des panels pour les boutons des filtres sur safari

### DIFF
--- a/app/assets/stylesheets/admin/_panels.scss
+++ b/app/assets/stylesheets/admin/_panels.scss
@@ -15,6 +15,6 @@ body.logged_out #content_wrapper #active_admin_content {
     background: none;
   }
   .panel_contents {
-    padding: 0 1.3rem 1.5rem;
+    padding: 0 1.2rem 1.5rem;
   }
 }


### PR DESCRIPTION
Corrige l'affichage suivant : 

<img width="317" alt="bug-affichage-boutons-filtres" src="https://user-images.githubusercontent.com/298214/100074496-1bd9ad80-2e3f-11eb-9383-72d03c24e38d.png">

Après : 
<img width="282" alt="Capture d’écran 2020-11-24 à 10 24 10" src="https://user-images.githubusercontent.com/298214/100074573-34e25e80-2e3f-11eb-86cd-a78b3eec7992.png">
