### PR TITLE
Ajout la traduction pour les valeurs des categories possibles d'actualités

### DIFF
--- a/config/locales/models/actualite.yml
+++ b/config/locales/models/actualite.yml
@@ -1,10 +1,11 @@
+
 fr:
   activerecord:
     attributes:
       actualite:
         created_at: Créée le
         categorie: Catégorie
-        categories:
+        categories: &traduction-categories
           blog: Newsletter
           assistance: Assistance
           evolution: Mise à jour
@@ -24,6 +25,4 @@ fr:
         new_model: Ajouter une nouvelle actualité
         edit_model: Modifier
     status_tag:
-      blog: Newsletter
-      assistance: Assistance
-      evolution: Mise à jour
+      <<: *traduction-categories

--- a/config/locales/models/actualite.yml
+++ b/config/locales/models/actualite.yml
@@ -4,6 +4,10 @@ fr:
       actualite:
         created_at: Créée le
         categorie: Catégorie
+        categories:
+          blog: Newsletter
+          assistance: Assistance
+          evolution: Mise à jour
     models:
       actualite:
         one: Actualité


### PR DESCRIPTION
Sans ces traductions, la liste des choix possibles à la modification
d'une actualité n'est pas pas traduite.

Ceci introduit une duplication avec la traduction des tags. Je ne sais pas si on peut factoriser des traductions.

Avant : 
![Capture d’écran 2020-11-27 à 14 51 56](https://user-images.githubusercontent.com/298214/100456303-6e75cc80-30c0-11eb-8fb6-82f61f69cb00.png)

Après :
![Capture d’écran 2020-11-27 à 14 52 16](https://user-images.githubusercontent.com/298214/100456336-7897cb00-30c0-11eb-988c-1ae92529292e.png)
