### PR TITLE
Ajoute `nowrap` au style des status_tag

### DIFF
--- a/app/assets/stylesheets/admin/_status_tag.scss
+++ b/app/assets/stylesheets/admin/_status_tag.scss
@@ -7,6 +7,7 @@
     text-transform: unset;
     letter-spacing: unset;
     font-size: 0.8rem;
+    white-space: nowrap;
 
     &.assistance, &.red {
       color: $couleur-accent-erreur;


### PR DESCRIPTION
Pour corriger https://trello.com/c/7AQxbaq9

Avant : 
![Capture d’écran 2020-11-30 à 11 39 57](https://user-images.githubusercontent.com/298214/100599843-d0247980-3300-11eb-9345-ca7842946a64.png)

Après : 
![Capture d’écran 2020-11-30 à 11 39 45](https://user-images.githubusercontent.com/298214/100599858-d74b8780-3300-11eb-8f2f-cfe21efabb6c.png)
