### PR TITLE
Utilise un verts plus clair pour le bord des status tag verts

### DIFF
--- a/app/assets/stylesheets/admin/_status_tag.scss
+++ b/app/assets/stylesheets/admin/_status_tag.scss
@@ -19,5 +19,6 @@
 
     &.evolution, &.green {
       color: $darkgreen;
+      border-color: $couleur-legere-accent-validation;
     }
   }


### PR DESCRIPTION
![Capture d’écran 2020-11-30 à 15 36 21](https://user-images.githubusercontent.com/298214/100622982-d37c2d00-3321-11eb-818b-7d7907c0c2a7.png)
