### PR TITLE
Tableau de bord : mise en avant des actualités

### DIFF
--- a/app/assets/stylesheets/admin/_actualites.scss
+++ b/app/assets/stylesheets/admin/_actualites.scss
@@ -13,9 +13,11 @@
 
 .actualites {
   position: relative;
+  margin-bottom: 2rem;
 
   h3 {
     @include titre-carte();
+    padding-bottom: 3rem;
   }
 
   > a {
@@ -26,58 +28,51 @@
   }
 
   &-liste {
-    .columns {
-      display: flex;
-    }
-
-    .column.derniere-actualite {
-      display: flex;
-
-      .actualite {
-        align-items: flex-start;
-        flex-direction: column;
-        flex: 1;
-        padding: 1rem;
-
-        .titre {
-          font-size: 1.25rem;
-          font-weight: 600;
-          margin: 1rem 0 0.5rem;
-        }
-        .action {
-          position: absolute;
-          bottom: 1rem;
-          right: 1rem;
-        }
-      }
-    }
-
     .actualite {
       @include carte;
-      padding: .75rem;
-      margin-bottom: .5rem;
       display: flex;
-      align-items: center;
+      margin-bottom: .5rem;
       font-size:0.875rem;
+      align-items: center;
+      padding: 0 1rem;
+      min-height: 3.5rem;
+
+      .action {
+        @include bouton-carte($couleur-legere-accent-validation, $couleur-texte-sombre);
+      }
 
       .status_tag {
         margin-right: 3.25rem;
       }
 
       .titre {
-        margin: 0;
         color: $couleur-texte-sombre;
         flex: 1;
-        margin-right: .75rem;
+        margin: 0 .75rem 0 0;
       }
 
       .date {
         color: $couleur-texte;
         margin-right: .75rem;
       }
+    }
 
-      .action {
-        @include bouton-carte($couleur-legere-accent-validation, $couleur-texte-sombre);
+    .derniere-actualite {
+      .actualite {
+        min-height: auto;
+        align-items: flex-start;
+        flex-direction: column;
+        padding: 1rem;
+        .titre {
+          font-size: 1.25rem;
+          font-weight: 600;
+          margin: 0.75rem 0 1.5rem;
+        }
+        .action {
+          position: absolute;
+          bottom: 1rem;
+          right: 1rem;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/admin/_actualites.scss
+++ b/app/assets/stylesheets/admin/_actualites.scss
@@ -22,7 +22,7 @@
 
   > a {
     position: absolute;
-    top: 1rem;
+    top: 0.75rem;
     right: 0;
     @include bouton()
   }

--- a/app/assets/stylesheets/admin/_evaluations.scss
+++ b/app/assets/stylesheets/admin/_evaluations.scss
@@ -1,5 +1,6 @@
 .evaluations h3 {
   @include titre-carte;
+  padding-bottom: 3rem;
 }
 
 .evaluation {

--- a/app/assets/stylesheets/admin/_mixins.scss
+++ b/app/assets/stylesheets/admin/_mixins.scss
@@ -17,7 +17,6 @@
   display: inline-flex;
   border-radius: 0.25rem;
   color: $color;
-  background-color: $couleur-legere-accent-validation;
   text-decoration: none;
   min-width: 3rem;
   justify-content: center;

--- a/app/views/admin/dashboard/_actualites.html.arb
+++ b/app/views/admin/dashboard/_actualites.html.arb
@@ -4,15 +4,11 @@ div class: 'actualites' do
   h3 t('.titre')
   text_node link_to 'Voir toutes les actualités', admin_actualites_path
   div class: 'actualites-liste' do
-    columns do
-      column class: 'column derniere-actualite' do
-        render 'actualite', actualite: actualites.first
-      end
-      column span: 2 do
-        actualites[1, 3].each do |actualite|
-          render 'actualite', actualite: actualite
-        end
-      end
+    div class: 'derniere-actualite' do
+      render 'actualite', actualite: actualites.first
+    end
+    actualites[1, 3].each do |actualite|
+      render 'actualite', actualite: actualite
     end
   end
 end

--- a/app/views/admin/dashboard/_dashboard.html.arb
+++ b/app/views/admin/dashboard/_dashboard.html.arb
@@ -6,25 +6,10 @@ columns do
   end
 
   column do
-    panel t('.contacts.titre') do
-      h4 class: 'mise-en-evidence' do
-        t('.contacts.intro')
-      end
-      render 'admin/contacts/form'
-      if contacts.present?
-        hr
-        h4 t('.contacts.deja_enregistres')
-        ul do
-          contacts.each do |contact|
-            li contact.display_name
-          end
-        end
-      end
-    end
+    render 'actualites', actualites: actualites if actualites.present?
+    render 'formulaire_contact', contacts: contacts
   end
 end
-
-render 'actualites', actualites: actualites if actualites.present?
 
 if can?(:manage, Compte)
   panel t('.statistiques.titre') do

--- a/app/views/admin/dashboard/_formulaire_contact.html.arb
+++ b/app/views/admin/dashboard/_formulaire_contact.html.arb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+panel t('.contacts.titre') do
+  h4 class: 'mise-en-evidence' do
+    t('.contacts.intro')
+  end
+  render 'admin/contacts/form'
+  if contacts.present?
+    hr
+    h4 t('.contacts.deja_enregistres')
+    ul do
+      contacts.each do |contact|
+        li contact.display_name
+      end
+    end
+  end
+end

--- a/config/locales/views/dashboard.yml
+++ b/config/locales/views/dashboard.yml
@@ -2,13 +2,14 @@ fr:
   admin:
     dashboard:
       dashboard:
-        contacts:
-          titre: Vos coordonnées
-          intro: "Pour que ce service puisse continuer à vous apporter son  aide, nous avons besoin de la vôtre. Merci de nous laisser vos coordonnées :"
-          deja_enregistres: "Les contacts que vous avez déjà enregistrés :"
         statistiques:
           titre: Statistiques
       actualites:
         titre: Les actualités sur eva
       evaluations:
         titre: Vos dernières évaluations
+      formulaire_contact:
+        contacts:
+          titre: Vos coordonnées
+          intro: "Pour que ce service puisse continuer à vous apporter son  aide, nous avons besoin de la vôtre. Merci de nous laisser vos coordonnées :"
+          deja_enregistres: "Les contacts que vous avez déjà enregistrés :"


### PR DESCRIPTION
![Capture d’écran 2020-12-02 à 16 19 31](https://user-images.githubusercontent.com/298214/100892079-3b657b80-34ba-11eb-9907-ed0791800349.png)

Et quand l'écran est trop petit, les actualités plus anciennes passent sur plusieurs lignes : 
![Capture d’écran 2020-12-02 à 16 10 22](https://user-images.githubusercontent.com/298214/100892154-50daa580-34ba-11eb-811e-9406d07b5e0e.png)
