### PR TITLE
Ajoute le style du status tag oui

### DIFF
--- a/app/assets/stylesheets/admin/_status_tag.scss
+++ b/app/assets/stylesheets/admin/_status_tag.scss
@@ -22,4 +22,9 @@
       color: $darkgreen;
       border-color: $couleur-legere-accent-validation;
     }
+
+    &.no, &.yes {
+      background-color: transparent;
+      border-color: $couleur-texte
+    }
   }


### PR DESCRIPTION
Pour : https://trello.com/c/vh58UsQA/331-bug-affichage-il-manque-le-style-pour-le-tag-oui

# Avant : 
![Capture d’écran 2020-12-15 à 12 17 33](https://user-images.githubusercontent.com/298214/102208306-8a0a1100-3ecf-11eb-9d34-b770526694f3.png)

# Après : utilise un style neutre en attendant un meilleur design :
![Capture d’écran 2020-12-15 à 12 16 28](https://user-images.githubusercontent.com/298214/102208178-5fb85380-3ecf-11eb-92a6-65988861c58d.png)
![Capture d’écran 2020-12-15 à 12 16 15](https://user-images.githubusercontent.com/298214/102208197-634bda80-3ecf-11eb-99de-37f4e4365c1a.png)
