### PR TITLE
Actualités : navigation vers les autres actualités depuis une actualité

### DIFF
--- a/app/admin/actualites.rb
+++ b/app/admin/actualites.rb
@@ -30,6 +30,6 @@ ActiveAdmin.register Actualite do
   end
 
   show do
-    render partial: 'show'
+    render partial: 'show', locals: { autres_actualites: actualite.recentes_sauf_moi(3) }
   end
 end

--- a/app/assets/stylesheets/admin/_actualites.scss
+++ b/app/assets/stylesheets/admin/_actualites.scss
@@ -81,7 +81,7 @@
   }
 }
 
-.actualite {
+.actualite-complete {
   $grid-columns:      8;
   $grid-gutter-width: 1.25rem;
   $largeur-conteneur: 1220px;
@@ -116,6 +116,7 @@
   .metadonnees {
     @include carte;
     padding: 1.5rem;
+    margin-bottom: 1.5rem;
     display: flex;
 
     .donnee {
@@ -128,6 +129,36 @@
     .label {
       font-weight: bold;
       margin-bottom: .5rem;
+    }
+  }
+
+  .autres-actualites {
+    display: flex;
+    flex-direction: column;
+
+    &-titre {
+      @include titre();
+      margin-bottom: 1.5rem;
+      font-size: 1.5rem;
+    }
+
+    .actualite {
+      display: flex;
+      align-items: center;
+      margin-bottom: 1rem;
+
+      .categorie {
+        margin-right: 1rem;
+      }
+
+      .lien {
+        color: $couleur-principale;
+        text-decoration: underline;
+
+        &:hover {
+          text-decoration: none;
+        }
+      }
     }
   }
 }

--- a/app/models/actualite.rb
+++ b/app/models/actualite.rb
@@ -10,4 +10,8 @@ class Actualite < ApplicationRecord
   def display_name
     titre
   end
+
+  def recentes_sauf_moi(nombre)
+    Actualite.order(created_at: :desc).where.not(id: id).first(nombre)
+  end
 end

--- a/app/views/admin/actualites/_show.html.arb
+++ b/app/views/admin/actualites/_show.html.arb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-div class: 'actualite' do
+div class: 'actualite-complete' do
   h1 actualite.titre, class: 'titre'
 
   div class: 'row' do
@@ -30,6 +30,16 @@ div class: 'actualite' do
           span 'Date :', class: 'label'
           span class: 'date' do
             l actualite.created_at, format: :point
+          end
+        end
+      end
+
+      h3 t('.autres_actualites'), class: 'autres-actualites-titre'
+      div class: 'autres-actualites' do
+        autres_actualites.each do |actualite|
+          div class: 'actualite' do
+            status_tag actualite.categorie, class: 'categorie'
+            text_node link_to actualite.titre, [:admin, actualite], class: 'lien'
           end
         end
       end

--- a/config/locales/views/actualites.yml
+++ b/config/locales/views/actualites.yml
@@ -1,0 +1,5 @@
+fr:
+  admin:
+    actualites:
+      show:
+        autres_actualites: Les autres actualités sur eva

--- a/spec/factories/actualite.rb
+++ b/spec/factories/actualite.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :actualite do
+    titre { 'contenu' }
+    categorie { 'blog' }
+    contenu { 'contenu' }
+  end
+end

--- a/spec/models/actualite_spec.rb
+++ b/spec/models/actualite_spec.rb
@@ -8,7 +8,17 @@ describe Actualite do
   it { should validate_presence_of(:categorie) }
   it { is_expected.to have_one(:illustration_attachment) }
 
-  context 'limite la taille du titre pour le tableau de bord' do
+  describe 'limite la taille du titre pour le tableau de bord' do
     it { should validate_length_of(:titre).is_at_most(60) }
+  end
+
+  describe '#recentes_sauf_moi' do
+    let!(:actualite3) { create :actualite, titre: 'titre3' }
+    let!(:actualite2) { create :actualite, titre: 'titre2' }
+    let!(:actualite1) { create :actualite, titre: 'titre1' }
+
+    it { expect(actualite1.recentes_sauf_moi(1)).to eql([actualite2]) }
+    it { expect(actualite1.recentes_sauf_moi(3)).to eql([actualite2, actualite3]) }
+    it { expect(actualite2.recentes_sauf_moi(3)).to eql([actualite1, actualite3]) }
   end
 end


### PR DESCRIPTION
Pour le ticket https://trello.com/c/NZxjEeWT

Ajout de la navigation vers 3 autres activités depuis la page d'une actualité.

![Capture d’écran 2020-12-15 à 16 43 48](https://user-images.githubusercontent.com/298214/102237296-d1ef5f00-3ef4-11eb-93db-9ffb01a02ae0.png)
