### PR TITLE
Actualité : Augmentation de la taille du titre des actus à 100 caractères max

### DIFF
--- a/app/models/actualite.rb
+++ b/app/models/actualite.rb
@@ -5,7 +5,7 @@ class Actualite < ApplicationRecord
   enum categorie: %i[blog assistance evolution]
 
   validates :titre, :contenu, :categorie, presence: true
-  validates :titre, length: { maximum: 60 }
+  validates :titre, length: { maximum: 100 }
 
   def display_name
     titre

--- a/spec/models/actualite_spec.rb
+++ b/spec/models/actualite_spec.rb
@@ -9,7 +9,7 @@ describe Actualite do
   it { is_expected.to have_one(:illustration_attachment) }
 
   describe 'limite la taille du titre pour le tableau de bord' do
-    it { should validate_length_of(:titre).is_at_most(60) }
+    it { should validate_length_of(:titre).is_at_most(100) }
   end
 
   describe '#recentes_sauf_moi' do


### PR DESCRIPTION
Pour le ticket https://trello.com/c/tdY1WPNT

Est-ce que 100 c'est suffisant ?

Sur le tableau de bord ça fait ça : 
![Capture d’écran 2020-12-22 à 17 15 51](https://user-images.githubusercontent.com/298214/102909539-6c155100-4479-11eb-923e-1efdadcfcd83.png)

Dans une actu : 

![Capture d’écran 2020-12-22 à 17 16 43](https://user-images.githubusercontent.com/298214/102909589-7d5e5d80-4479-11eb-9441-18d7f9b67f8f.png)

