### PR TITLE
Réduit la marge sur la carte actu du tableau de bord pour que le titr…

### DIFF
--- a/app/assets/stylesheets/admin/_actualites.scss
+++ b/app/assets/stylesheets/admin/_actualites.scss
@@ -44,7 +44,7 @@
     }
 
     .status_tag {
-      margin-right: 3.25rem;
+      margin-right: 1rem;
     }
 
     .titre {


### PR DESCRIPTION
…e reste sur 2 lignes`

Avant:

<img width="708" alt="Capture d’écran 2020-12-28 à 15 12 27" src="https://user-images.githubusercontent.com/28393/103219967-5becee00-491f-11eb-94ec-9a87898cbe36.png">

Après:

<img width="694" alt="Capture d’écran 2020-12-28 à 15 13 22" src="https://user-images.githubusercontent.com/28393/103220001-732bdb80-491f-11eb-9130-f05f5789a235.png">
