### PR TITLE
Ajoute un index sur les événements pour optimiser le temps des requêtes

### DIFF
--- a/db/migrate/20201228154851_add_index_on_evenements_session_id.rb
+++ b/db/migrate/20201228154851_add_index_on_evenements_session_id.rb
@@ -1,0 +1,5 @@
+class AddIndexOnEvenementsSessionId < ActiveRecord::Migration[6.0]
+  def change
+    add_index :evenements, :session_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_09_151700) do
+ActiveRecord::Schema.define(version: 2020_12_28_154851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -126,6 +126,7 @@ ActiveRecord::Schema.define(version: 2020_12_09_151700) do
     t.string "session_id"
     t.integer "position"
     t.index ["position"], name: "index_evenements_on_position"
+    t.index ["session_id"], name: "index_evenements_on_session_id"
   end
 
   create_table "parties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
Co-authored-by: Marine Dominé <marine.domine@beta.gouv.fr>

Pour https://trello.com/c/zJm0yVYk/356-certaines-structures-constatent-un-blocage-sur-laccueil-pendant-les-%C3%A9valuations

Contexte:

On charge les événements pour chaque partie ( probablement pour les compétences fortes ). La table événements est la plus grosse, et la recherche prend ~ 150ms sur mon poste ( quasi 200ms sur le serveur ).

Cette PR ajoute un index qui accélère considérablement cette requête SQL.
Sur mon poste, cette modification a fait passé la requête de 2000ms à 250ms.

Je pense que ça peut valoir le coup d'aller plus loin mais ça fait déjà un beau gain pour une seule PR ;-)