### PR TITLE
Design : met le fond des lignes des tableaux en blanc

### DIFF
--- a/app/assets/stylesheets/admin/composants/_tables.scss
+++ b/app/assets/stylesheets/admin/composants/_tables.scss
@@ -30,7 +30,7 @@ table.index_table {
 
       &.even {
         td {
-          background: none;
+          background-color: #FFF;
         }
       }
 
@@ -42,6 +42,7 @@ table.index_table {
         border-top: 1px solid $bluegrey;
         border-bottom: 1px solid $bluegrey;
         color: $couleur-texte-sombre;
+        background-color: #FFF;
         &:first-child {
           font-weight: 600;
           padding-left: 1.375rem;
@@ -59,6 +60,7 @@ table.index_table {
         }
         &.col-actions {
           background: image-url('roue-dentee.svg') right 1rem center no-repeat;
+          background-color: #FFF;
 
           .table_actions {
             opacity: 0;


### PR DESCRIPTION
Avant : 
<img width="1495" alt="Capture d’écran 2021-01-04 à 13 57 26" src="https://user-images.githubusercontent.com/298214/103537489-cc05f180-4e94-11eb-8524-8db27f60a0f3.png">

Après :
<img width="1496" alt="Capture d’écran 2021-01-04 à 13 57 13" src="https://user-images.githubusercontent.com/298214/103537485-ca3c2e00-4e94-11eb-9530-4c9159c7d793.png">
