### PR TITLE
Corrige erreur JS FAQ

### DIFF
--- a/app/assets/javascripts/faq.js
+++ b/app/assets/javascripts/faq.js
@@ -1,6 +1,8 @@
 document.addEventListener("DOMContentLoaded", () => {
   const questions = document.querySelectorAll('.faq .question');
 
+  if (!questions.length) return
+
   document.querySelector('.faq .question').classList.add('active');
   document.querySelector('.faq .reponse').classList.add('active');
 


### PR DESCRIPTION
Sur les pages de l'admin autre que la page aide, on a une erreur JS car la faq n'existe pas.
J'ai modifié le JS pour ne cibler que la page aide.