### PR TITLE
Retire le filtre partie des événements

### DIFF
--- a/app/admin/evenements.rb
+++ b/app/admin/evenements.rb
@@ -5,7 +5,6 @@ ActiveAdmin.register Evenement do
   belongs_to :campagne
   includes partie: %i[situation evaluation]
 
-  filter :partie, collection: proc { Partie.pluck(:session_id) }
   filter :partie_situation_nom_technique, label: 'Situation',
                                           as: :select,
                                           collection: proc { Situation.pluck(:nom_technique) }


### PR DESCRIPTION
Il fait ramer la page et me semble inutile en l'état.

https://trello.com/c/Rbe3cbK0/380-retirer-le-filtre-de-partie-dans-la-page-des-%C3%A9v%C3%A9nements

![Capture d’écran 2021-01-12 à 09 28 31](https://user-images.githubusercontent.com/28393/104288817-9aa2ac80-54b8-11eb-9d8a-41e61c25bf26.png)
