### PR TITLE
Change le lien matomo avec un `/` à la fin pour corriger l'erreur de …

### DIFF
--- a/app/assets/javascripts/matomo.js
+++ b/app/assets/javascripts/matomo.js
@@ -1,4 +1,4 @@
 // Matomo Tracking Code for https://api.app.eva.beta.gouv.fr
-tarteaucitron.user.matomoHost = 'https://stats.data.gouv.fr';
+tarteaucitron.user.matomoHost = 'https://stats.data.gouv.fr/';
 tarteaucitron.user.matomoId = 149;
 (tarteaucitron.job = tarteaucitron.job || []).push('matomohightrack');


### PR DESCRIPTION
…chargement

pour https://trello.com/c/tE5dk1to/344-admin-eva-je-peux-connaitre-les-stats-de-consultation-des-pages

ça fonctionne, mais le problème c'est que ça marche aussi en local et en du coup en preprod. Je pense que ça serait bien de pouvoir activer/désactiver avec une variable d'environnement par la suite.