### PR TITLE
Revert "utilise un domaine en eva.gouv.fr pour récupérer les images stockées chez OVH"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'activeadmin'
 gem 'activeadmin-xls'
 gem 'activeadmin_addons'
 gem 'activeadmin_reorderable'
-gem 'activestorage-openstack', '>= 1.5.1'
+gem 'activestorage-openstack'
 gem 'acts_as_list'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'bootstrap', '~> 4.3', '>= 4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,9 +74,10 @@ GEM
       activejob (= 6.0.3.3)
       activerecord (= 6.0.3.3)
       marcel (~> 0.3.1)
-    activestorage-openstack (1.5.1)
+    activestorage-openstack (1.4.1)
       fog-openstack (~> 1.0)
       marcel
+      mime-types
       rails (>= 5.2.2)
     activesupport (6.0.3.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -134,7 +135,7 @@ GEM
       devise (>= 4.7.1)
     diff-lcs (1.4.2)
     erubi (1.9.0)
-    excon (0.78.1)
+    excon (0.75.0)
     execjs (2.7.0)
     factory_bot (6.0.2)
       activesupport (>= 5.0.0)
@@ -142,7 +143,7 @@ GEM
       factory_bot (~> 6.0.0)
       railties (>= 5.0.0)
     ffi (1.13.1)
-    fog-core (2.2.3)
+    fog-core (2.2.0)
       builder
       excon (~> 0.71)
       formatador (~> 0.2)
@@ -224,7 +225,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.1104)
+    mime-types-data (3.2020.0512)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
@@ -232,7 +233,7 @@ GEM
       libv8 (> 7.3)
     minitest (5.14.2)
     msgpack (1.3.3)
-    multi_json (1.15.0)
+    multi_json (1.14.1)
     nenv (0.3.0)
     nio4r (2.5.3)
     nokogiri (1.11.1)
@@ -425,7 +426,7 @@ DEPENDENCIES
   activeadmin-xls
   activeadmin_addons
   activeadmin_reorderable
-  activestorage-openstack (>= 1.5.1)
+  activestorage-openstack
   acts_as_list
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3, >= 4.3.1)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,13 +33,4 @@ module ApplicationHelper
     image_src64 = "data:image/svg+xml;base64,#{encodage}"
     image_tag image_src64, options
   end
-
-  def public_static_url_pour(resource)
-    if ENV.key?('HOTE_STOCKAGE')
-      blob = resource.blob
-      "http://#{ENV['HOTE_STOCKAGE']}/#{blob['key']}?filename=#{blob['filename']}"
-    else
-      Rails.application.routes.url_helpers.url_for(resource)
-    end
-  end
 end

--- a/app/models/question_qcm.rb
+++ b/app/models/question_qcm.rb
@@ -11,7 +11,7 @@ class QuestionQcm < Question
     json = slice(:id, :intitule, :metacompetence, :type_qcm, :description, :choix)
     json['type'] = 'qcm'
     if illustration.attached?
-      json['illustration'] = ApplicationController.helpers.public_static_url_pour(illustration)
+      json['illustration'] = Rails.application.routes.url_helpers.url_for(illustration)
     end
     json
   end

--- a/app/models/question_redaction_note.rb
+++ b/app/models/question_redaction_note.rb
@@ -5,7 +5,7 @@ class QuestionRedactionNote < Question
     json = slice(:id, :intitule, :entete_reponse, :expediteur, :message, :objet_reponse)
     json['type'] = 'redaction_note'
     if illustration.attached?
-      json['illustration'] = ApplicationController.helpers.public_static_url_pour(illustration)
+      json['illustration'] = Rails.application.routes.url_helpers.url_for(illustration)
     end
     json
   end

--- a/app/views/admin/actualites/_show.html.arb
+++ b/app/views/admin/actualites/_show.html.arb
@@ -6,7 +6,7 @@ div class: 'actualite-complete' do
   div class: 'row' do
     div class: 'col-5' do
       div class: 'illustration' do
-        image_tag public_static_url_pour(actualite.illustration) if actualite.illustration.attached?
+        image_tag url_for(actualite.illustration) if actualite.illustration.attached?
       end
 
       div class: 'row' do

--- a/app/views/admin/dashboard/_actualite.html.arb
+++ b/app/views/admin/dashboard/_actualite.html.arb
@@ -2,9 +2,7 @@
 
 div class: 'carte-actualite' do
   div class: 'illustration' do
-    if actualite.illustration.attached? && affiche_image
-      image_tag public_static_url_pour(actualite.illustration)
-    end
+    image_tag url_for(actualite.illustration) if actualite.illustration.attached? && affiche_image
   end
   div class: 'texte' do
     status_tag actualite.categorie

--- a/app/views/admin/question_qcms/_show.html.arb
+++ b/app/views/admin/question_qcms/_show.html.arb
@@ -9,7 +9,7 @@ panel 'Détails de la question' do
     row :type_qcm
     row :description
     row :illustration do |question|
-      image_tag public_static_url_pour(question.illustration) if question.illustration.attached?
+      image_tag url_for(question.illustration) if question.illustration.attached?
     end
     row :created_at
   end

--- a/app/views/admin/question_redaction_notes/_show.html.arb
+++ b/app/views/admin/question_redaction_notes/_show.html.arb
@@ -6,7 +6,7 @@ panel 'Détails de la question' do
     row :libelle
     row :intitule
     row :illustration do |question|
-      image_tag public_static_url_pour(question.illustration) if question.illustration.attached?
+      image_tag url_for(question.illustration) if question.illustration.attached?
     end
     row :entete_reponse
     row :expediteur

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -35,7 +35,6 @@ local:
 
 openstack:
   service: OpenStack
-  public: true # important ; to tell rails that this is a public container
   container: <%= ENV['OS_CONTAINER'] %> # Container name for your OpenStack provider
   credentials:
     openstack_auth_url: <%= ENV['OS_AUTH_URL'] %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -40,34 +40,4 @@ describe ApplicationHelper do
       expect(helper.formate_duree('')).to eql(nil)
     end
   end
-
-  describe '#public_static_url_pour' do
-    let(:resource) { double }
-
-    context "si la variable d'env est définie" do
-      before { ENV['HOTE_STOCKAGE'] = 'host' }
-
-      it "retourne l'url static, avec nom de fichier pour que l'app puis precharger la ressource" do
-        expect(resource).to receive(:blob)
-          .and_return({ 'key' => 'unique_blob_id', 'filename' => 'blob.jpg' })
-
-        expect(helper.public_static_url_pour(resource))
-          .to eql('http://host/unique_blob_id?filename=blob.jpg')
-      end
-    end
-
-    context "si la variable d'env n'est pas définie (developpement)" do
-      let(:routes) { double }
-      let(:url_helpers) { double }
-
-      before { ENV.delete('HOTE_STOCKAGE') }
-
-      it 'retourne une url rails' do
-        expect(Rails.application).to receive(:routes).and_return(routes)
-        expect(routes).to receive(:url_helpers).and_return(url_helpers)
-        expect(url_helpers).to receive(:url_for)
-        helper.public_static_url_pour(resource)
-      end
-    end
-  end
 end


### PR DESCRIPTION
Reverts betagouv/eva-serveur#637

Comme mis dans le commentaire de la carte trello, ça ne fonctionne pas en preprod. Le navigateur cherche à charger les images en https alors que ça n'est pas possible ici.