### PR TITLE
Restreins les temps moyens de campagnes aux administrateurs

### DIFF
--- a/app/views/admin/campagnes/_show.html.arb
+++ b/app/views/admin/campagnes/_show.html.arb
@@ -2,16 +2,23 @@
 
 panel 'Détails de la campagne' do
   attributes_table_for campagne do
-    row :id
     row :libelle
     row :code
     row :affiche_competences_fortes
-    row :questionnaire
-    row :compte if can?(:manage, Compte)
-    row :created_at
-    row(:temps_min) { formate_duree statistiques.temps_min }
-    row(:temps_max) { formate_duree statistiques.temps_max }
-    row(:temps_moyen) { formate_duree statistiques.temps_moyen }
+  end
+end
+
+if can?(:manage, Compte)
+  panel 'Administration' do
+    attributes_table_for campagne do
+      row :id
+      row :questionnaire
+      row :compte
+      row :created_at
+      row(:temps_min) { formate_duree statistiques.temps_min }
+      row(:temps_max) { formate_duree statistiques.temps_max }
+      row(:temps_moyen) { formate_duree statistiques.temps_moyen }
+    end
   end
 end
 


### PR DESCRIPTION
et autres informations techniques qui sont du bruit pour les structures

Co-authored-by: Étienne Charignon <etienne.charignon@beta.gouv.fr>

Vue Structure

![Capture d’écran 2021-01-25 à 15 54 59](https://user-images.githubusercontent.com/28393/105722276-c9436d00-5f25-11eb-824b-28c6df27646e.png)

Vue Admin

![Capture d’écran 2021-01-25 à 15 56 41](https://user-images.githubusercontent.com/28393/105722407-eb3cef80-5f25-11eb-8b91-8888fa43fc40.png)


Pour https://trello.com/c/qfO5C2eC/402-cacher-les-temps-moyens-des-campagnes-aux-structures
