### PR TITLE
Renvoie une seule erreur quand une évaluation est créée sans campagne

### DIFF
--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Evaluation < ApplicationRecord
-  validates :nom, :campagne, presence: true
+  validates :nom, presence: true
   belongs_to :campagne, counter_cache: :nombre_evaluations
 
   def display_name

--- a/config/locales/models/evaluation.yml
+++ b/config/locales/models/evaluation.yml
@@ -7,7 +7,7 @@ fr:
             nom:
               blank: doit être rempli
             campagne:
-              required: code inexistant
+              required: code inconnu
     models:
       evaluation:
         one: Évaluation

--- a/spec/models/evaluation_spec.rb
+++ b/spec/models/evaluation_spec.rb
@@ -4,6 +4,5 @@ require 'rails_helper'
 
 describe Evaluation do
   it { should validate_presence_of :nom }
-  it { should validate_presence_of :campagne }
   it { should belong_to :campagne }
 end


### PR DESCRIPTION
pour https://trello.com/c/Gfb8kkOv/432-corrige-le-message-derreur-en-cas-de-code-campagne-inconnu

Proposition alternative à #650

Explication : le `belongs_to` n'est pas `optional` ici, donc il vérifie la présence de `campagne`.
Et comme on avait un validateur de presence de `campagne`, on avait 2 validations qui vérifiait la même chose.
Le client affichait uniquement la première erreur, une erreur `blank`, traduite par `doit être rempli(e)`.

J'ai retiré ce premier validateur, il n'y a plus que le 2eme, qui envoie une erreur `required`, que nous avons traduit par `code inexistant`