### PR TITLE
Mise à jour du code pour Rails 6.1

### DIFF
--- a/app/admin/comptes.rb
+++ b/app/admin/comptes.rb
@@ -34,7 +34,7 @@ ActiveAdmin.register Compte do
   controller do
     def update_resource(object, attributes)
       update_method = if attributes.first[:password].present?
-                        :update_attributes
+                        :update
                       else
                         :update_without_password
                       end


### PR DESCRIPTION
La méthode `update_attributes` a été suprimée