### PR TITLE
Masque le temps de passation aux conseiller

### DIFF
--- a/app/views/admin/restitutions/_informations_generales_sidebar.html.arb
+++ b/app/views/admin/restitutions/_informations_generales_sidebar.html.arb
@@ -15,7 +15,9 @@ attributes_table_for resource do
       status_tag t('admin.restitutions.evaluation.en_cours')
     end
   end
-  row(t('admin.restitutions.evaluation.temps')) do |restitution|
-    formate_duree(restitution.temps_total)
+  if can?(:manage, Compte)
+    row(t('admin.restitutions.evaluation.temps')) do |restitution|
+      formate_duree(restitution.temps_total)
+    end
   end
 end


### PR DESCRIPTION
Pour le ticket : https://trello.com/c/Ebsn3jc8

Quand on regarde le rapport d'une MES, le temps n'est plus donné au conseiller·ères

En tant que conseiller·ère :
![Capture d’écran 2021-02-10 à 17 57 54](https://user-images.githubusercontent.com/298214/107543503-978b0100-6bc9-11eb-9979-c0857e6f9f6b.png)

En tant qu'administrateur·trice : 
![Capture d’écran 2021-02-10 à 17 57 00](https://user-images.githubusercontent.com/298214/107543588-a4a7f000-6bc9-11eb-9b2f-4c65ca3b0ff0.png)
