### PR TITLE
Corrige la configuration circle ci pour détecter les tests en erreur

### DIFF
--- a/lib/tasks/nettoyage.rake
+++ b/lib/tasks/nettoyage.rake
@@ -60,13 +60,13 @@ namespace :nettoyage do
     unless ENV.key?(arg_situation)
       logger.error "La variable d'environnement #{arg_situation} est marquante"
       logger.info 'Usage : rake nettoyage:recalcule_metriques SITUATION=<nom_technique>'
-      exit
+      next
     end
 
     situation = Situation.find_by(nom_technique: ENV[arg_situation])
     if situation.nil?
       logger.error "Situation \"#{ENV[arg_situation]}\" non trouvé"
-      exit
+      next
     end
 
     nombre_partie = Partie.where(situation: situation).count

--- a/spec/tasks/recalcule_metriques_spec.rb
+++ b/spec/tasks/recalcule_metriques_spec.rb
@@ -45,15 +45,17 @@ describe 'nettoyage:recalcule_metriques' do
     it do
       ENV['SITUATION'] = 'inconnue'
       expect(logger).to receive(:error).with('Situation "inconnue" non trouvé')
+      expect(logger).to receive(:info).exactly(0).times # ne doit pas recevoir le message de fin
       subject.invoke
     end
   end
 
   context 'appellé sans situation' do
     it do
+      ENV['SITUATION'] = nil
       expect(logger).to receive(:error)
         .with("La variable d'environnement SITUATION est marquante")
-      expect(logger).to receive(:error)
+      expect(logger).to receive(:info)
         .with('Usage : rake nettoyage:recalcule_metriques SITUATION=<nom_technique>')
       subject.invoke
     end

--- a/spec/tasks/supprime_controle_campagne_spec.rb
+++ b/spec/tasks/supprime_controle_campagne_spec.rb
@@ -10,7 +10,7 @@ describe 'nettoyage:supprime_controle_campagne' do
 
     it do
       subject.invoke
-      expect(campagne.situations.count).to eql(0)
+      expect(campagne.situations_configurations.count).to eql(0)
     end
   end
 
@@ -20,14 +20,14 @@ describe 'nettoyage:supprime_controle_campagne' do
     let(:situation_inventaire) { create :situation_inventaire }
 
     before do
-      campagne.situations << situation_controle
-      campagne.situations << situation_inventaire
+      campagne.situations_configurations.create situation: situation_controle
+      campagne.situations_configurations.create situation: situation_inventaire
     end
 
     it do
       subject.invoke
-      expect(campagne.reload.situations.count).to eql(1)
-      expect(campagne.reload.situations[0].nom_technique).to eql('inventaire')
+      expect(campagne.reload.situations_configurations.count).to eql(1)
+      expect(campagne.reload.situations_configurations[0].nom_technique).to eql('inventaire')
     end
   end
 
@@ -35,11 +35,11 @@ describe 'nettoyage:supprime_controle_campagne' do
     let(:campagne) { create :campagne }
     let(:situation) { create :situation_inventaire }
 
-    before { campagne.situations << situation }
+    before { campagne.situations_configurations.create situation: situation }
 
     it do
       subject.invoke
-      expect(campagne.reload.situations.count).to eql(1)
+      expect(campagne.reload.situations_configurations.count).to eql(1)
     end
   end
 end


### PR DESCRIPTION
Les `exit` tuait certains tests dont on ne voyait pas le résultat et empêchait rspec de retourner un code d'erreur différent quand la suite de test était KO.