### PR TITLE
1/3 Ne génère plus automatiquement un code campagne s'il n'est pas donné

### DIFF
--- a/app/models/campagne.rb
+++ b/app/models/campagne.rb
@@ -19,7 +19,6 @@ class Campagne < ApplicationRecord
 
   validates :libelle, presence: true
   validates :code, presence: true, uniqueness: true
-  before_validation :genere_code_unique
 
   accepts_nested_attributes_for :situations_configurations, allow_destroy: true
   accepts_nested_attributes_for :compte
@@ -42,15 +41,6 @@ class Campagne < ApplicationRecord
     SITUATIONS_PAR_DEFAUT.each do |nom_technique|
       situation = Situation.find_by nom_technique: nom_technique
       situations_configurations.build situation: situation unless situation.nil?
-    end
-  end
-
-  def genere_code_unique
-    return if self[:code].present?
-
-    loop do
-      self[:code] = SecureRandom.hex 3
-      break if Campagne.where(code: self[:code]).none?
     end
   end
 end

--- a/config/locales/models/campagne.yml
+++ b/config/locales/models/campagne.yml
@@ -18,11 +18,11 @@ fr:
         update: Enregistrer
     placeholders:
       campagne:
-        libelle: "Ma campagne du 12 avril"
-        code: 1A2B3
+        libelle: ML Caraces, PE Marita, Garantie Jeunes
+        code: milo21160, Capinsertion92270
     hints:
       campagne:
-        code: Laissez vide pour en générer un, ou choisissez vous-même
+        code: Le code campagne est le code qu'il faudra fournir aux bénéficiaires.
         situation_configuration:
           questionnaire: Laissez vide pour utiliser le questionnaire par défaut
   active_admin:

--- a/spec/features/admin/campagne_spec.rb
+++ b/spec/features/admin/campagne_spec.rb
@@ -70,24 +70,13 @@ describe 'Admin - Campagne', type: :feature do
         select 'orga@eva.fr'
       end
 
-      context 'génère un code si on en saisit pas' do
-        before do
-          fill_in :campagne_code, with: ''
-        end
-
-        it do
-          expect { click_on 'Créer' }.to(change { Campagne.count })
-          expect(Campagne.last.code).to be_present
-          expect(Campagne.last.compte).to eq compte_organisation
-          expect(page).to have_content 'Mon QCM'
-        end
-      end
-
-      context 'conserve le code saisi si précisé' do
+      context 'crée la campagne avec le code donné, associé au compte courant' do
         before { fill_in :campagne_code, with: 'EUROCKS' }
         it do
           expect { click_on 'Créer' }.to(change { Campagne.count })
           expect(Campagne.last.code).to eq 'EUROCKS'
+          expect(Campagne.last.compte).to eq compte_organisation
+          expect(page).to have_content 'Mon QCM'
         end
       end
     end

--- a/spec/models/campagne_spec.rb
+++ b/spec/models/campagne_spec.rb
@@ -7,25 +7,6 @@ RSpec.describe Campagne, type: :model do
   it { should validate_uniqueness_of :code }
   it { should belong_to(:questionnaire).optional }
 
-  describe 'validation du code' do
-    context 'garde le code initial' do
-      let(:campagne) { Campagne.new code: 'mon code' }
-      before { campagne.valid? }
-      it { expect(campagne.code).to eq 'mon code' }
-    end
-
-    context 'sans code initial génère un code unique' do
-      let(:campagne) { Campagne.new code: nil }
-      before do
-        allow(SecureRandom).to receive(:hex).with(3).and_return('abcde', '12345')
-        allow(Campagne).to receive(:where).with(code: 'abcde').and_return(double(none?: false))
-        allow(Campagne).to receive(:where).with(code: '12345').and_return(double(none?: true))
-        campagne.valid?
-      end
-      it { expect(campagne.code).to eq '12345' }
-    end
-  end
-
   context 'avec des situations' do
     let(:compte) { Compte.new email: 'accompagnant@email.com', password: 'secret' }
     before do


### PR DESCRIPTION
Cette PR supprime le code qui permettait de généré automatiquement un code campagne.
https://trello.com/c/iwCYmCIc


En voulant faire une copie d'écran, je me rend compte que le design de ce formulaire est cassé… a voir dans une PR à venir.

<img width="1024" alt="Capture d’écran 2021-03-23 à 11 59 29" src="https://user-images.githubusercontent.com/298214/112136435-3d6d5a80-8bcf-11eb-89f5-7713375cf087.png">
