### PR TITLE
Utilise flex-start qui semble mieux supportée

### DIFF
--- a/app/assets/stylesheets/admin/composants/_panels.scss
+++ b/app/assets/stylesheets/admin/composants/_panels.scss
@@ -14,7 +14,7 @@ body.logged_out .sous-panel {
   @include sous-carte;
   display: flex;
   flex-direction: row;
-  align-items: start;
+  align-items: flex-start;
 
   .infos {
     h4 {


### PR DESCRIPTION
Voici le warning quand on lançait les tests:

```
autoprefixer: /Users/shanser/Projects/eva/serveur/app/assets/stylesheets/active_admin.scss:5585:3: start value has mixed support, consider using flex-start instead
```