### PR TITLE
Admin : élargit la colonne action pour éviter que la molette ne soit tronquée

### DIFF
--- a/app/assets/stylesheets/admin/composants/_tables.scss
+++ b/app/assets/stylesheets/admin/composants/_tables.scss
@@ -59,7 +59,7 @@ table.index_table {
           color: $eva_main_blue;
         }
         &.col-actions {
-          width: 20px;
+          width: 40px;
           position: relative;
           background: image-url('roue-dentee.svg') right 1rem center no-repeat;
           background-color: #FFF;


### PR DESCRIPTION
avant : 
<img width="476" alt="Capture d’écran 2021-03-29 à 14 02 17" src="https://user-images.githubusercontent.com/298214/112833725-6b531300-9097-11eb-8c1d-f33b1df147e5.png">

après : 
<img width="563" alt="Capture d’écran 2021-03-29 à 14 02 25" src="https://user-images.githubusercontent.com/298214/112833746-727a2100-9097-11eb-8522-9e1d9b62699f.png">
