### PR TITLE
Ne plus permettre d'accéder à la page /sign_up sans structure

### DIFF
--- a/app/controllers/eva/devise/registrations_controller.rb
+++ b/app/controllers/eva/devise/registrations_controller.rb
@@ -4,6 +4,8 @@ module Eva
   module Devise
     class RegistrationsController < ActiveAdmin::Devise::RegistrationsController
       def new
+        return redirect_to structures_path if params[:structure_id].blank?
+
         super do |resource|
           resource.structure = Structure.find_by id: params[:structure_id]
         end

--- a/app/views/active_admin/devise/registrations/new.html.erb
+++ b/app/views/active_admin/devise/registrations/new.html.erb
@@ -2,7 +2,7 @@
   <%= t('.title') -%>
 <% end %>
 <% content_for :sous_titre do %>
-  <%= resource.structure&.nom || active_admin_application.site_title(self) -%>
+  <%= resource.structure.nom -%>
 <% end %>
 
 <div id="login">
@@ -20,14 +20,7 @@
       f.input :telephone
       f.input :password
       f.input :password_confirmation, required:true, wrapper_html: { class: 'libelle-long' }
-
-      if resource.structure.blank?
-        f.input :structure,
-                hint: t('.nouvelle_structure_html', lien: nouvelle_structure_path),
-                collection: Hash[Structure.order(:code_postal).map{|s| ["#{s.code_postal} - #{s.nom}",s.id]}]
-      else
-        f.input :structure_id, as: :hidden
-      end
+      f.input :structure_id, as: :hidden
     end
     f.actions do
       f.action :submit, label: t('active_admin.devise.login.submit'), button_html: { value: t('active_admin.devise.sign_up.submit') }

--- a/spec/features/inscription_conseiller_spec.rb
+++ b/spec/features/inscription_conseiller_spec.rb
@@ -8,22 +8,10 @@ describe 'Création de compte conseiller', type: :feature do
   context 'sans structure précisée' do
     before do
       visit new_compte_registration_path
-      fill_in :compte_prenom, with: 'Julia'
-      fill_in :compte_nom, with: 'Robert'
-      fill_in :compte_email, with: 'monemail@eva.fr'
-      fill_in :compte_telephone, with: '01 02 03 04 05'
-      fill_in :compte_password, with: 'Pass123'
-      fill_in :compte_password_confirmation, with: 'Pass123'
-      select 'Ma structure'
     end
 
-    it do
-      expect { click_on "S'inscrire" }.to change(Compte, :count).by 1
-
-      nouveau_compte = Compte.find_by email: 'monemail@eva.fr'
-      expect(nouveau_compte.validation_en_attente?).to be true
-      expect(nouveau_compte.structure).to eq structure
-      expect(nouveau_compte.telephone).to eq '01 02 03 04 05'
+    it "redirige l'utilisateur vers la page pour trouver une structure" do
+      expect(page).to have_current_path(structures_path)
     end
   end
 


### PR DESCRIPTION
Si on tente d'accéder à la page /admin/sign_up sans paramètre `structure_id`, on est redirigé vers /structures afin de trouver d'abbord une structure ici.