### PR TITLE
Permet d'utiliser la gem foreman pour lancer le serveur

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec rails server
-postdeploy: bundle exec rake db:migrate
+postdeploy: bin/postdeploy.sh

--- a/bin/postdeploy.sh
+++ b/bin/postdeploy.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ -z "$RAILS_ENV" || "$RAILS_ENV" = "development" ]] ; then
+  cat
+else
+  bundle exec rake db:migrate
+fi


### PR DESCRIPTION
Utilise un script pour déterminer si le Procfile doit executer ou non les migrations. Dans le cas de l'environnement de Development, on ne lance pas les migrations.
Cela permet ainsi d'utiliser Foreman car ce dernier utilise le fichier Procfile pour déterminer les processus à lancer. Sans ce changement, lancer foreman s'arrete après l'execution des migrations car elle se quitte (avec un exit)