### PR TITLE
Renomme structure introuvable en structure non référencée

### DIFF
--- a/app/views/structures/index.html.erb
+++ b/app/views/structures/index.html.erb
@@ -15,7 +15,7 @@
 
   <% if params[:code_postal] %>
     <div class="actions">
-    <%= link_to t('.structure_introuvable'), nouvelle_structure_path, class: 'creer-structure' %>
+    <%= link_to t('.structure_non_referencee'), nouvelle_structure_path, class: 'creer-structure' %>
     </div>
   <% end %>
 

--- a/config/locales/views/structures.yml
+++ b/config/locales/views/structures.yml
@@ -6,7 +6,7 @@ fr:
         **Vous souhaitez créer un compte conseiller eva.**
         Dans un premier temps, vous devez retrouver votre structure.
       label_champ_recherche: 'Indiquez votre code postal ou votre ville :'
-      structure_introuvable: Structure introuvable ?
+      structure_non_referencee: Structure non référencée ?
     structure:
       code_postal: 'Code postal : '
       rejoindre_structure: Rejoindre


### PR DESCRIPTION
Pour : 
https://trello.com/c/4kkx7Zws/514-bouton-structure-introuvable-devient-structure-non-r%C3%A9f%C3%A9renc%C3%A9e


![Capture d’écran 2021-04-07 à 14 50 42](https://user-images.githubusercontent.com/1309612/113869204-bc0dee80-97b0-11eb-8680-74db4b8f84ae.png)

