### PR TITLE
Envoie le nom des fichiers au bout de l'url quand on charge un assert

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,6 +37,7 @@ module ApplicationHelper
   def cdn_for(fichier)
     return Rails.application.routes.url_helpers.url_for(fichier) unless Rails.env.production?
 
-    "#{ENV['PROTOCOLE_SERVEUR']}://#{ENV['HOTE_STOCKAGE']}/#{fichier.key}"
+    param = "filename=#{fichier.filename}"
+    "#{ENV['PROTOCOLE_SERVEUR']}://#{ENV['HOTE_STOCKAGE']}/#{fichier.key}?#{param}"
   end
 end


### PR DESCRIPTION
C'est necessaire pour l'application (via l'api) pour que cette dernière
sache comment charger cette ressource à partir de l'extention