### PR TITLE
Conseiller, je ne peux pas m'enregistrer avec une mauvaise adresse email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'redcarpet'
 gem 'redis'
 gem 'rollbar'
 gem 'sidekiq'
+gem 'truemail'
 gem 'wicked_pdf'
 gem 'wkhtmltopdf-binary', '~> 0.12.3.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,6 +399,8 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    simpleidn (0.2.1)
+      unf (~> 0.1.4)
     spreadsheet (1.2.8)
       ruby-ole
     spring (2.1.1)
@@ -416,9 +418,14 @@ GEM
       geoip
     thor (1.1.0)
     tilt (2.0.10)
+    truemail (2.3.4)
+      simpleidn (~> 0.2.1)
     ttfunk (1.7.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
     unicode-display_width (2.0.0)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -484,6 +491,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   tarteaucitron
+  truemail
   wicked_pdf
   wkhtmltopdf-binary (~> 0.12.3.1)
 

--- a/app/models/compte.rb
+++ b/app/models/compte.rb
@@ -8,6 +8,7 @@ class Compte < ApplicationRecord
   validates :role, inclusion: { in: %w[administrateur organisation] }
   validates :statut_validation, presence: true
   validates_presence_of :nom, :prenom, on: :create
+  validate :verifie_dns_email
   default_scope { order(created_at: :asc) }
 
   enum statut_validation: %i[en_attente acceptee refusee], _prefix: :validation
@@ -26,5 +27,14 @@ class Compte < ApplicationRecord
 
   def administrateur?
     role == 'administrateur'
+  end
+
+  private
+
+  def verifie_dns_email
+    return unless email_changed?
+    return if Truemail.valid?(email)
+
+    errors.add(:email, :invalid)
   end
 end

--- a/config/initializers/truemail.rb
+++ b/config/initializers/truemail.rb
@@ -1,0 +1,6 @@
+Truemail.configure do |config|
+  config.verifier_email = 'contact@eva.beta.gouv.fr'
+
+  config.default_validation_type = :mx
+  config.not_rfc_mx_lookup_flow = true
+end

--- a/spec/models/compte_spec.rb
+++ b/spec/models/compte_spec.rb
@@ -28,4 +28,30 @@ describe Compte do
     expect(described_class.new(prenom: 'Pepa', nom: 'Pig', email: 'pepa@france5.fr').display_name)
       .to eql('Pepa Pig - pepa@france5.fr')
   end
+
+  describe "validation DNS de l'email" do
+    let(:compte) { Compte.new email: 'email@example.com' }
+
+    before do
+      allow(compte).to receive(:email_changed?).and_return(true)
+      allow(Truemail).to receive(:valid?).and_return(true)
+    end
+
+    context "quand l'email est valide" do
+      before { compte.valid? }
+      it { expect(compte.errors[:email]).to be_blank }
+    end
+
+    context "quand l'email est invalide" do
+      before { allow(Truemail).to receive(:valid?).with('email@example.com').and_return(false) }
+      before { compte.valid? }
+      it { expect(compte.errors[:email]).to include(I18n.t('errors.messages.invalid')) }
+    end
+
+    context "quand l'email du compte n'est pas modifié" do
+      before { allow(compte).to receive(:email_changed?).and_return(false) }
+      before { compte.valid? }
+      it { expect(Truemail).not_to have_received(:valid?).with('email@example.com') }
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,8 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.before { allow(Truemail).to receive(:valid?).and_return(true) }
+
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
   # have no way to turn it off -- the option exists only for backwards
   # compatibility in RSpec 3). It causes shared context metadata to be


### PR DESCRIPTION
Utilisation de la gem truemail pour vérifier les DNS de l'email et donc la validité du nom de domaine utilisé.
Cela permet ainsi d'éviter de faire des fautes de frappe du style : exemple@gmail.co

ou encore d'écrire une adresse email fausse : exemple@fake.com