### PR TITLE
Supprime deprecation warning lié à activeadmin-xls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'activeadmin_addons'
 gem 'active_admin-humanized_enum'
 gem 'activeadmin_reorderable'
 # Utilisation d'un fork en attendant que le correctif soit mergé : https://github.com/thambley/activeadmin-xls/pull/21
-gem 'activeadmin-xls', git: 'https://github.com/cprodhomme/activeadmin-xls'
+gem 'activeadmin-xls', git: 'https://github.com/cprodhomme/activeadmin-xls', branch: 'dist'
 gem 'acts_as_list'
 gem 'aws-sdk-s3', require: false
 gem 'bootsnap', '>= 1.1.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 GIT
   remote: https://github.com/cprodhomme/activeadmin-xls
-  revision: 78bdaf000b3c75ed9cfa58f5889761a573d8de15
+  revision: bcd58bdf9e95e8725cc828ce2477708681fafa8c
+  branch: dist
   specs:
-    activeadmin-xls (2.0.2)
+    activeadmin-xls (2.0.3)
       activeadmin (>= 1.0.0)
       spreadsheet (~> 1.0)
 


### PR DESCRIPTION
sur mon fork (branche `dist`), j'ai supprimé le repertoire `spec/` et j'ai créé une nouvelle version pour la gem.