### PR TITLE
Utilise la dernière version de activeadmin-xls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,7 @@ gem 'activeadmin'
 gem 'activeadmin_addons'
 gem 'active_admin-humanized_enum'
 gem 'activeadmin_reorderable'
-# Utilisation d'un fork en attendant que le correctif soit mergé : https://github.com/thambley/activeadmin-xls/pull/21
-gem 'activeadmin-xls', git: 'https://github.com/cprodhomme/activeadmin-xls', branch: 'dist'
+gem 'activeadmin-xls'
 gem 'acts_as_list'
 gem 'aws-sdk-s3', require: false
 gem 'bootsnap', '>= 1.1.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/cprodhomme/activeadmin-xls
-  revision: bcd58bdf9e95e8725cc828ce2477708681fafa8c
-  branch: dist
-  specs:
-    activeadmin-xls (2.0.3)
-      activeadmin (>= 1.0.0)
-      spreadsheet (~> 1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -66,6 +57,9 @@ GEM
       kaminari (~> 1.0, >= 1.2.1)
       railties (>= 5.2, < 6.2)
       ransack (~> 2.1, >= 2.1.1)
+    activeadmin-xls (2.0.3)
+      activeadmin (>= 1.0.0)
+      spreadsheet (~> 1.0)
     activeadmin_addons (1.7.1)
       active_material
       railties
@@ -449,7 +443,7 @@ PLATFORMS
 DEPENDENCIES
   active_admin-humanized_enum
   activeadmin
-  activeadmin-xls!
+  activeadmin-xls
   activeadmin_addons
   activeadmin_reorderable
   acts_as_list


### PR DESCRIPTION
L'auteur de la gem à merger ma PR qui permet de supprimer le deprecation warning

Si jamais vous avez encore l'erreur en local, il faut supprimer les versions (cache) que vous avez sur votre poste avec :

`gem uninstall activeadmin-xls`