### PR TITLE
Optimise les requêtes pour les droits

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -66,18 +66,18 @@ class Ability
   def droit_questionnaire
     can :read, Questionnaire
     cannot :destroy, Questionnaire do |q|
-      Campagne.where(questionnaire: q).present? ||
+      Campagne.where(questionnaire: q).exists? ||
         Situation.where(questionnaire: q)
                  .or(Situation.where(questionnaire_entrainement: q))
-                 .present?
+                 .exists?
     end
   end
 
   def droit_question
     can :read, Question
     cannot :destroy, Question do |q|
-      QuestionnaireQuestion.where(question: q).present? ||
-        Evenement.where("donnees->>'question' = ?", q.id.to_s).present?
+      QuestionnaireQuestion.where(question: q).exists? ||
+        Evenement.where("donnees->>'question' = ?", q.id.to_s).exists?
     end
   end
 
@@ -85,19 +85,19 @@ class Ability
     can :create, Compte
     can %i[read update], Compte, structure_id: compte.structure_id
     cannot :destroy, Compte do |q|
-      Campagne.where(compte: q).present?
+      Campagne.where(compte: q).exists?
     end
   end
 
   def droit_choix
     cannot :destroy, Choix do |c|
-      Evenement.where("donnees->>'reponse' = ?", c.id.to_s).present?
+      Evenement.where("donnees->>'reponse' = ?", c.id.to_s).exists?
     end
   end
 
   def droit_structure
     cannot :destroy, Structure do |s|
-      Compte.where(structure: s).present?
+      Compte.where(structure: s).exists?
     end
   end
 


### PR DESCRIPTION
L'utilisation de la méthode `.exists?` est plus efficace que la méthode `.present?`

- .exists? : C'est la base de donnée qui renvoie true/false
- .present? : la base de donnée renvoit toutes les infos, puis Ruby instancie l'objet pour ensuite dire qu'il existe

```
irb(main):003:0> Compte.where(structure: s).present?
  Compte Load (0.9ms)  SELECT "comptes".* FROM "comptes" WHERE "comptes"."structure_id" = $1 ORDER BY "comptes"."created_at" ASC  [["structure_id", "10a85469-a970-415d-bf3d-51556d28d257"]]
=> true
irb(main):004:0> Compte.where(structure: s).exists?
  Compte Exists? (0.5ms)  SELECT 1 AS one FROM "comptes" WHERE "comptes"."structure_id" = $1 LIMIT $2  [["structure_id", "10a85469-a970-415d-bf3d-51556d28d257"], ["LIMIT", 1]]
=> true
```