### PR TITLE
Permet de filtrer les structures inactives et abandonnistes

### DIFF
--- a/app/admin/structures.rb
+++ b/app/admin/structures.rb
@@ -20,6 +20,8 @@ ActiveAdmin.register Structure do
   scope :pas_vraiment_utilisatrices
   scope :non_activees
   scope :actives
+  scope :inactives
+  scope :abandonnistes
 
   action_item :nouvelle_structure, only: :index do
     link_to I18n.t('admin.structure.nouvelle_structure'), nouvelle_structure_path
@@ -31,11 +33,16 @@ ActiveAdmin.register Structure do
       traduction_type_structure(structure.type_structure)
     end
     column :code_postal
-    column :nombre_evaluations do |structure|
-      Evaluation.joins(campagne: :compte).where('comptes.structure_id' => structure).count
-    end
     column :created_at do |structure|
       l(structure.created_at, format: :court)
+    end
+    column :nombre_evaluations do |structure|
+      Evaluation.de_la_structure(structure).count
+    end
+    column :derniere_evaluation do |structure|
+      derniere_evaluation = Evaluation.de_la_structure(structure).order(:created_at).last
+
+      l(derniere_evaluation.created_at, format: :court) if derniere_evaluation.present?
     end
     actions
   end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -12,6 +12,10 @@ class Evaluation < ApplicationRecord
     nom
   end
 
+  scope :de_la_structure, lambda { |structure|
+    joins(campagne: :compte).where('comptes.structure_id' => structure)
+  }
+
   private
 
   def trouve_campagne_depuis_code

--- a/app/models/structure.rb
+++ b/app/models/structure.rb
@@ -19,15 +19,35 @@ class Structure < ApplicationRecord
 
   after_validation :geocode, if: ->(s) { s.code_postal.present? and s.code_postal_changed? }
 
-  scope :par_nombre_d_evaluations, lambda { |condition_nb_evaluations|
+  scope :joins_evaluations_et_groupe, lambda {
     joins('INNER JOIN comptes ON structures.id = comptes.structure_id')
       .joins('INNER JOIN campagnes ON comptes.id = campagnes.compte_id')
+      .joins('INNER JOIN evaluations ON campagnes.id = evaluations.campagne_id')
       .group('structures.id')
-      .having("SUM(campagnes.nombre_evaluations) #{condition_nb_evaluations}")
   }
-  scope :pas_vraiment_utilisatrices, -> { par_nombre_d_evaluations '= 0' }
+  scope :par_nombre_d_evaluations, lambda { |condition_nb_evaluations|
+    joins_evaluations_et_groupe
+      .having("COUNT(evaluations.id) #{condition_nb_evaluations}")
+  }
+  scope :par_derniere_evaluation, lambda { |*condition_date|
+    condition_date[0] = "MAX(evaluations.created_at) #{condition_date[0]}"
+    joins_evaluations_et_groupe
+      .having(*condition_date)
+  }
+
+  scope :pas_vraiment_utilisatrices, lambda {
+    ids = Evaluation.joins(campagne: { compte: :structure })
+                    .select('structures.id')
+    where.not(id: ids)
+  }
+
   scope :non_activees, -> { par_nombre_d_evaluations 'BETWEEN 1 AND 3' }
-  scope :actives, -> { par_nombre_d_evaluations '> 3' }
+  scope :activees, -> { par_nombre_d_evaluations '> 3' }
+  scope :actives, -> { activees.par_derniere_evaluation('> ?', 2.months.ago) }
+  scope :inactives, lambda {
+    activees.par_derniere_evaluation('BETWEEN ? AND ?', 6.months.ago, 2.months.ago)
+  }
+  scope :abandonnistes, -> { activees.par_derniere_evaluation('< ?', 6.months.ago) }
 
   def display_name
     nom

--- a/config/locales/activeadmin.yml
+++ b/config/locales/activeadmin.yml
@@ -16,6 +16,8 @@ fr:
     sidebars:
       filters: "Rechercher"
     scopes:
-      pas_vraiment_utilisatrices: Pas vraiment utilisatrices ☃️ 
-      non_activees: Non activées 🐤 
+      pas_vraiment_utilisatrices: Pas vraiment utilisatrices ☃️
+      non_activees: Non activées 🐤
       actives: Actives ❤️
+      inactives: Inactives 😴
+      abandonnistes : Abandonnistes 💔

--- a/config/locales/models/structure.yml
+++ b/config/locales/models/structure.yml
@@ -7,6 +7,8 @@ fr:
         nom: Nom de la structure
         code_postal: Code Postal
         region: Région
+        derniere_evaluation: Dernière évaluation
+        nombre_evaluations: Nombre d'évaluations
         type_structure:
           one: 'Type de structure'
           non_communique: Non communiqué


### PR DESCRIPTION
Et corrige la requête des pas vraiment utilisatrices
+ Affiche la dernière évaluation dans la liste des structures

Co-authored-by: Stéphane Hanser <shanser@captive.fr>

![Capture d’écran 2021-04-30 à 13 14 58](https://user-images.githubusercontent.com/28393/116687824-110ae200-a9b6-11eb-9ff4-0d1443166f04.png)

![Capture d’écran 2021-04-30 à 13 15 23](https://user-images.githubusercontent.com/28393/116687858-1ff19480-a9b6-11eb-8a99-36096592c65e.png)
