### PR TITLE
Met à jour ruby en 2.7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     parallelism: 1
     docker:
-      - image: circleci/ruby:2.6.6-node
+      - image: circleci/ruby:2.7.1-node
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ruby '2.6.6'
+ruby '2.7.1'
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -492,7 +492,7 @@ DEPENDENCIES
   wkhtmltopdf-binary (~> 0.12.3.1)
 
 RUBY VERSION
-   ruby 2.6.6p146
+   ruby 2.7.1p83
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
Scalingo et docker me réclament une mise à jours de 2.6.6 à 2.6.7
Je propose de passer directement à 2.7.1 car rbenv ne connait pas 2.6.7