### PR TITLE
Corrige le style des articles sur le back-office

### DIFF
--- a/app/assets/stylesheets/admin/_actualites.scss
+++ b/app/assets/stylesheets/admin/_actualites.scss
@@ -94,6 +94,13 @@
   .contenu {
     @include make-col(3, 5);
     @include make-col-offset(1, 5);
+    padding: 0 .625rem;
+
+    img, iframe, blockquote {
+      width: calc(100% + 2.5rem);
+      border-radius: .5rem;
+      margin: 0 -1.25rem;
+    }
   }
 
   .metadonnees {

--- a/app/views/admin/actualites/_show.html.arb
+++ b/app/views/admin/actualites/_show.html.arb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 div class: 'actualite-complete' do
-  h1 actualite.titre, class: 'titre'
+  div class: 'row' do
+    div class: 'col-5' do
+      h1 actualite.titre, class: 'titre'
+    end
+  end
 
   div class: 'row' do
     div class: 'col-5' do


### PR DESCRIPTION
On fait en sorte que les images soient plus large que le texte.
On revoit aussi la largeur général du contenu

Co-authored-by: Benjamin Bartholet <hello@trab.design>

![Capture d’écran 2021-05-10 à 11 36 06](https://user-images.githubusercontent.com/7428736/117639182-ed992180-b183-11eb-8c00-10f6d744c5e3.png)