### PR TITLE
Tente de mettre les actions en sidebar

### DIFF
--- a/config/initializers/actions_items_sidebar.rb
+++ b/config/initializers/actions_items_sidebar.rb
@@ -1,0 +1,1 @@
+require 'active_admin/actions_items_sidebar'

--- a/lib/active_admin/actions_items_sidebar.rb
+++ b/lib/active_admin/actions_items_sidebar.rb
@@ -1,0 +1,3 @@
+require 'active_admin/actions_items_sidebar/resource_extension'
+
+ActiveAdmin::Resource.send :include, ActiveAdmin::ActionsItemsSidebar::ResourceExtension

--- a/lib/active_admin/actions_items_sidebar/resource_extension.rb
+++ b/lib/active_admin/actions_items_sidebar/resource_extension.rb
@@ -1,0 +1,20 @@
+module ActiveAdmin
+  module ActionsItemsSidebar
+    module ResourceExtension
+      def initialize(*)
+        super
+        add_action_items_sidebar
+      end
+
+      def actions_items_sidebar_section
+        ActiveAdmin::SidebarSection.new :action_items, if: -> { active_admin_config.action_items_for(params[:action], self).any? } do
+          insert_tag(view_factory.action_items, active_admin_config.action_items_for(params[:action], self))
+        end
+      end
+
+      def add_action_items_sidebar
+        self.sidebar_sections.prepend actions_items_sidebar_section
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ Cette PR ne devrait pas être mergée dans l'état.

Je la crée pour partager le résultat d'un spike pour afficher les actions en sidebar. La prochaine action serait de décider si on continue dans cette voie ou non.

En fouillant le code d'activeadmin j'ai trouvé un moyen de le faire, et c'est ce code qui est poussé.

### Ce qui marche bien : cela met les actions dans la sidebar 🎉 

![Capture d’écran 2021-05-10 à 16 27 16](https://user-images.githubusercontent.com/28393/117678384-a163d680-b1af-11eb-9ebf-0c1b1f7cbf91.png)


Voilà c'est cool, maintenant ce qui ne marche pas pour l'instant.

### 1. Ca affiche le bloc même s'il n'y a pas d'action.
![Capture d’écran 2021-05-10 à 16 44 31](https://user-images.githubusercontent.com/28393/117678507-c22c2c00-b1af-11eb-87df-f9667fb04f25.png)

C'est lié au fait qu'ActiveAdmin crée des éléments HTML vides. En fait ActiveAdmin liste toutes les actions puis ensuite vérifie si l'utilisateur courant peut utiliser l'action ou non. Ce problème existe déjà mais on ne le voit pas car cela n'a pas d'impact dans notre design.

### **2. Du coup cela utilise la sidebar, alors qu'on a parfois décidé de la créer différemment.**
![Capture d’écran 2021-05-10 à 16 45 45](https://user-images.githubusercontent.com/28393/117678940-264ef000-b1b0-11eb-874f-22c3d1b90c45.png)
![Capture d’écran 2021-05-10 à 16 27 22](https://user-images.githubusercontent.com/28393/117679102-454d8200-b1b0-11eb-8c3f-73312f13f93c.png)


C'est lié à l'hétérogénéité de notre design, en soit ça pourrait être une bonne idée de le traiter.
