### PR TITLE
Supprime la bordure du bouton onboarding

### DIFF
--- a/app/assets/stylesheets/admin/_dashboard.scss
+++ b/app/assets/stylesheets/admin/_dashboard.scss
@@ -98,6 +98,7 @@
         display: inline-block;
         font-size: 0.75rem;
         color: $eva_dark;
+        border: 0;
         background-color: $couleur-warning;
       }
     }


### PR DESCRIPTION
Pour : https://trello.com/c/k0B85LCc/593-le-bouton-de-la-page-daccueil-est-avec-une-bordure-bleue

![Capture d’écran 2021-05-12 à 11 21 21](https://user-images.githubusercontent.com/1309612/117951181-32ec5900-b314-11eb-9747-1e53e8b5a200.png)
