### PR TITLE
Corrige la couleur du texte des select et fixe le padding d'un select…

### DIFF
--- a/app/assets/stylesheets/admin/composants/_forms.scss
+++ b/app/assets/stylesheets/admin/composants/_forms.scss
@@ -99,6 +99,8 @@ form {
       border-width: 1px;
       height: 2rem;
       position: relative;
+      padding-left: .5rem;
+      padding-right: 2rem;
 
       &:focus {
         outline: none;
@@ -215,6 +217,6 @@ form:not(.filter_form) .select2-container {
     border-color: $eva_main_blue transparent transparent transparent;
   }
   .select2-selection__rendered {
-    color: $couleur-texte;
+    color: $eva_dark;
   }
 }


### PR DESCRIPTION
… natif

Pour : https://trello.com/c/SwnwQQVK/595-il-y-a-un-probl%C3%A8me-avec-la-couleur-du-texte-dans-le-champ-r%C3%B4le

Problème padding select natif : 
![Capture d’écran 2021-05-12 à 13 05 26](https://user-images.githubusercontent.com/1309612/117965192-c62c8b00-b322-11eb-8937-1f6223ca7a9d.png)
