### PR TITLE
Conseiller, je peux trouver une structure avec le code postal 45300

### DIFF
--- a/app/controllers/structures_controller.rb
+++ b/app/controllers/structures_controller.rb
@@ -5,6 +5,6 @@ class StructuresController < ApplicationController
   helper ::ActiveAdmin::ViewHelpers
 
   def index
-    @structures = Structure.near(params[:code_postal])
+    @structures = Structure.near("#{params[:code_postal]}, FRANCE")
   end
 end

--- a/spec/controllers/structures_controller_spec.rb
+++ b/spec/controllers/structures_controller_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe StructuresController, type: :controller do
+  describe 'GET index' do
+    it 'recherche un code postal en France' do
+      expect(Structure).to receive(:near).with('75001, FRANCE')
+      get :index, params: { code_postal: '75001' }
+    end
+  end
+end


### PR DESCRIPTION
On précise que l'on recherche en France car si on fait juste une recherche de 45300, Geocoder ne trouve pas de résultat. En précisant France, on affine ainsi le résultat