### PR TITLE
Le menu transversal des evaluations bug quand la campagne n a pas d auto positionnement

### DIFF
--- a/app/assets/javascripts/aide.js
+++ b/app/assets/javascripts/aide.js
@@ -23,7 +23,10 @@ const onIntersection = (entries) => {
 document.addEventListener("DOMContentLoaded", () => {
   const observer = new IntersectionObserver(onIntersection);
   document.querySelectorAll('.menu-transverse ul li a').forEach(el => {
-    observer.observe(document.querySelector(el.hash));
-    sections.push(el.hash);
+    section = document.querySelector(el.hash);
+    if(section) {
+      observer.observe(section);
+      sections.push(el.hash);
+    }
   });
 });

--- a/app/assets/javascripts/aide.js
+++ b/app/assets/javascripts/aide.js
@@ -28,5 +28,8 @@ document.addEventListener("DOMContentLoaded", () => {
       observer.observe(section);
       sections.push(el.hash);
     }
+    else {
+      el.parentNode.removeChild(el);
+    }
   });
 });


### PR DESCRIPTION
Cette PR supprime du menu les sections absentes :

<img width="1364" alt="Capture d’écran 2021-05-18 à 16 57 31" src="https://user-images.githubusercontent.com/298214/118674589-2f683e80-b7fa-11eb-8c1e-3f70fd08deba.png">
