### PR TITLE
Fixe la largeur du bloc statistiques sur le dashboard

### DIFF
--- a/app/assets/stylesheets/admin/composants/_panels.scss
+++ b/app/assets/stylesheets/admin/composants/_panels.scss
@@ -42,6 +42,7 @@ body.logged_out .sous-panel {
 
 .admin_dashboard {
   .panel {
+    padding: 1.5rem 0;
     box-shadow: unset;
     background-color: transparent;
     h3 {


### PR DESCRIPTION
Pour : https://trello.com/c/UhP8xvgJ/617-largeur-du-bloc-statistiques-cest-plus-%C3%A9troit-que-pr%C3%A9vu

![Capture d’écran 2021-05-19 à 17 51 38](https://user-images.githubusercontent.com/1309612/118844016-e59b5900-b8ca-11eb-861f-fdeb60524002.png)
