### PR TITLE
Simplifie le message d'au revoir dans la signature des mails

### DIFF
--- a/config/locales/views/mailer.yml
+++ b/config/locales/views/mailer.yml
@@ -17,8 +17,6 @@ fr:
 
         Merci et à très bientôt !
 
-        Bien cordialement,
-
         L'équipe eva
 
         <img src="https://eva.beta.gouv.fr/illustration_email/signature.png"/>


### PR DESCRIPTION
Le "bien cordialement" n'est pas en phase avec le ton de "à très bientôt"