### PR TITLE
Structure infos utilisateurs & campagnes - Tableaux pleine largeur

### DIFF
--- a/app/views/admin/structures/_show.html.arb
+++ b/app/views/admin/structures/_show.html.arb
@@ -23,33 +23,28 @@ if can?(:manage, Compte)
   end
 end
 
-columns do
-  column do
-    h3 'Utilisateurs'
-    table_for comptes, class: 'index_table' do
-      column(:nom_complet) do |compte|
-        compte.nom_complet.blank? ? 'Nom inconnu' : compte.nom_complet
-      end
-      column :email
-      column :statut_validation
-      column :actions do |compte|
-        div class: 'table_actions' do
-          link_to t('.voir'), admin_compte_path(compte), class: 'view_link'
-        end
-      end
+h3 'Utilisateurs'
+table_for comptes, class: 'index_table' do
+  column(:nom_complet) do |compte|
+    compte.nom_complet.blank? ? 'Nom inconnu' : compte.nom_complet
+  end
+  column :email
+  column :statut_validation
+  column :actions do |compte|
+    div class: 'table_actions' do
+      link_to t('.voir'), admin_compte_path(compte), class: 'view_link'
     end
   end
-  column do
-    h3 'Campagnes'
-    table_for campagnes, class: 'index_table' do
-      column :libelle
-      column :code
-      column :nombre_evaluations
-      column :actions do |campagne|
-        div class: 'table_actions' do
-          link_to t('.voir'), admin_campagne_path(campagne), class: 'view_link'
-        end
-      end
+end
+
+h3 'Campagnes'
+table_for campagnes, class: 'index_table' do
+  column :libelle
+  column :code
+  column :nombre_evaluations
+  column :actions do |campagne|
+    div class: 'table_actions' do
+      link_to t('.voir'), admin_campagne_path(campagne), class: 'view_link'
     end
   end
 end


### PR DESCRIPTION
Pour : https://trello.com/c/nUswy3hG/614-probl%C3%A8me-daffichage-de-la-page-structures-quand-les-adresse-emails-sont-trop-longues

![Capture d’écran 2021-06-04 à 11 06 15](https://user-images.githubusercontent.com/1309612/120776820-e7008e80-c524-11eb-9100-1d48e3cbc34f.png)
