### PR TITLE
Permet de filtrer les comptes selon la région et l'activation de leur structure

### DIFF
--- a/app/admin/comptes.rb
+++ b/app/admin/comptes.rb
@@ -6,20 +6,6 @@ ActiveAdmin.register Compte do
 
   includes :structure
 
-  index do
-    column :prenom
-    column :nom
-    column :email
-    column :telephone
-    column :statut_validation
-    if can? :manage, Compte
-      column :role
-      column :structure
-      column :created_at
-    end
-    actions
-  end
-
   filter :email
   filter :statut_validation,
          as: :select,
@@ -40,6 +26,33 @@ ActiveAdmin.register Compte do
          as: :select,
          collection: ApplicationController.helpers.collection_types_structures,
          label: I18n.t('type_structure', count: 1, scope: 'activerecord.attributes.structure')
+
+  def filtrer_par_activation_structure(statut_activation)
+    scope statut_activation, if: proc { can? :manage, Compte } do |scope|
+      scope.where(structure: Structure.send(statut_activation))
+    end
+  end
+
+  filtrer_par_activation_structure(:all)
+  filtrer_par_activation_structure(:pas_vraiment_utilisatrices)
+  filtrer_par_activation_structure(:non_activees)
+  filtrer_par_activation_structure(:actives)
+  filtrer_par_activation_structure(:inactives)
+  filtrer_par_activation_structure(:abandonnistes)
+
+  index do
+    column :prenom
+    column :nom
+    column :email
+    column :telephone
+    column :statut_validation
+    if can? :manage, Compte
+      column :role
+      column :structure
+      column :created_at
+    end
+    actions
+  end
 
   form do |f|
     f.inputs do

--- a/app/admin/comptes.rb
+++ b/app/admin/comptes.rb
@@ -28,6 +28,12 @@ ActiveAdmin.register Compte do
          label: I18n.t('type_structure', count: 1, scope: 'activerecord.attributes.structure'),
          if: proc { can? :manage, Compte }
 
+  filter :structure_region_eq,
+         as: :select,
+         collection: proc { Structure.distinct.order(:region).pluck(:region) },
+         label: I18n.t('region', scope: 'activerecord.attributes.structure'),
+         if: proc { can? :manage, Compte }
+
   def filtrer_par_activation_structure(statut_activation)
     scope statut_activation, if: -> { can? :manage, Compte } do |scope|
       scope.where(structure: Structure.send(statut_activation))

--- a/app/admin/comptes.rb
+++ b/app/admin/comptes.rb
@@ -25,10 +25,11 @@ ActiveAdmin.register Compte do
   filter :structure_type_structure_eq,
          as: :select,
          collection: ApplicationController.helpers.collection_types_structures,
-         label: I18n.t('type_structure', count: 1, scope: 'activerecord.attributes.structure')
+         label: I18n.t('type_structure', count: 1, scope: 'activerecord.attributes.structure'),
+         if: proc { can? :manage, Compte }
 
   def filtrer_par_activation_structure(statut_activation)
-    scope statut_activation, if: proc { can? :manage, Compte } do |scope|
+    scope statut_activation, if: -> { can? :manage, Compte } do |scope|
       scope.where(structure: Structure.send(statut_activation))
     end
   end
@@ -74,6 +75,11 @@ ActiveAdmin.register Compte do
     end
     f.actions
   end
+
+  sidebar :aide_filtres,
+          partial: 'admin/structures/aide_filtres_sidebar',
+          only: :index,
+          if: -> { can? :manage, Compte }
 
   controller do
     helper_method :peut_modifier_mot_de_passe?, :collection_roles

--- a/app/views/admin/structures/_aide_filtres_sidebar.html.erb
+++ b/app/views/admin/structures/_aide_filtres_sidebar.html.erb
@@ -1,3 +1,4 @@
+<p>ℹ️ Ces filtres s'appliquent à la structure</p>
 <ul>
   <li><strong>Pas vraiment utilisatrices ☃️</strong> : Aucune évaluation</li>
   <li><strong>Non activées 🐤</strong> : Entre 1 et 3 évaluations</li>


### PR DESCRIPTION
Par exemple, dans cette capture on cherche les comptes qui sont dans des structures 
- Pas vraiment utilisatrices
- En Bourgogne-Franche-Comté
- Dans des structures de type SIAE

![Capture d’écran 2021-06-04 à 11 46 21](https://user-images.githubusercontent.com/28393/120782712-90964e80-c52a-11eb-8d8e-ab7cac26a47d.png)

Ce qui permet de les exporter en CSV et d'importer leur coordonnées dans Mailchimp (ou autre) pour les relancer