### PR TITLE
Création de campagne - Intégration des textes explicatifs et ne sélectionne pas de parcours par défaut

### DIFF
--- a/app/admin/campagnes.rb
+++ b/app/admin/campagnes.rb
@@ -55,7 +55,6 @@ ActiveAdmin.register Campagne do
     def assigne_valeurs_par_defaut
       params[:campagne] ||= {}
       params[:campagne][:compte_id] ||= current_compte.id
-      params[:campagne][:parcours_type_id] ||= ParcoursType.par_defaut&.id
     end
 
     def parcours_type

--- a/app/admin/parcours_type.rb
+++ b/app/admin/parcours_type.rb
@@ -3,7 +3,7 @@
 ActiveAdmin.register ParcoursType do
   menu parent: 'Parcours', if: proc { can? :manage, Compte }
 
-  permit_params :libelle, :nom_technique, :duree_moyenne,
+  permit_params :libelle, :nom_technique, :duree_moyenne, :description,
                 situations_configurations_attributes: %i[id situation_id questionnaire_id _destroy]
 
   form partial: 'form'

--- a/app/assets/stylesheets/admin/composants/_input_choix_parcours.scss
+++ b/app/assets/stylesheets/admin/composants/_input_choix_parcours.scss
@@ -1,13 +1,25 @@
 .input-choix-parcours {
   /* reset style */
-  li.radio fieldset ol {
-    padding: 0;
-    margin: 0;
-    width: 100%;
+  li.radio {
+    fieldset ol {
+      padding: 0;
+      margin: 0;
+      width: 100%;
+    }
+    &.error {
+      .choix-parcours-item {
+        border-color: $eva_red;
+      }
+    }
   }
   /* fin reset style */
 
   input { display: none; }
+
+  > ol > li {
+    display: flex;
+    flex-direction: column;
+  }
 
   .choices-group {
     display: flex;
@@ -41,28 +53,45 @@
       margin-bottom: .625rem;
     }
 
-    .choix-parcours-intro-situations, .choix-parcours-situation, .choix-parcours-duree-moyenne {
+    .choix-parcours-description, .choix-parcours-duree-moyenne {
       color: $couleur-texte;
       font-size: .75rem;
-      font-style: italic;
       line-height: .875rem;
       margin: 0;
     }
 
-    .choix-parcours-situations {
+    .choix-parcours-duree-moyenne {
+      font-style: italic;
+    }
+
+    .choix-parcours-description {
       flex: 1;
       margin-bottom: 1rem;
+      ul {
+        padding-left: 1.5em;
+        list-style-type: disc;
+      }
     }
 
     input:checked + div {
       border-color: $couleur-texte;
       background: $eva_main_blue;
 
-      &, h4, p, ul li {
+      .choix-parcours-titre {
+        color: $eva_dark
+      }
+
+      &, p, ul li {
         color: $eva_light;
       }
     }
 
+  }
+
+  .inline-errors {
+    width: 100%;
+    margin: 1rem auto;
+    text-align: center;
   }
 
 }

--- a/app/assets/stylesheets/admin/pages/_campagne.scss
+++ b/app/assets/stylesheets/admin/pages/_campagne.scss
@@ -8,17 +8,20 @@
   .titre {
     @include titre;
     font-size: 1.5rem;
-    margin-bottom: 1.5rem;
+    margin-bottom: 0.5rem;
     &--medium {
       font-size: 1.25rem;
     }
   }
 
   .description {
-    padding-right: $largeur-colonne + $largeur-goutiere;
     font-size: 0.875rem;
     font-style: italic;
     line-height: 1rem;
+    &--secondaire {
+      margin-bottom: 1rem;
+      color: $eva_dark_blue_grey;
+    }
     p:last-child {
       margin-bottom: 0;
     }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,6 +21,8 @@ module ApplicationHelper
   end
 
   def md(contenu)
+    return '' if contenu.nil?
+
     @markdown ||= Redcarpet::Markdown.new(
       Redcarpet::Render::HTML.new(hard_wrap: true)
     )

--- a/app/models/campagne.rb
+++ b/app/models/campagne.rb
@@ -6,6 +6,7 @@ class Campagne < ApplicationRecord
   belongs_to :compte
   belongs_to :parcours_type, optional: true
 
+  validates :parcours_type, presence: true, on: :create
   validates :libelle, presence: true
   validates :code, presence: true, uniqueness: true
 

--- a/app/models/parcours_type.rb
+++ b/app/models/parcours_type.rb
@@ -12,8 +12,4 @@ class ParcoursType < ApplicationRecord
   def display_name
     libelle
   end
-
-  def self.par_defaut
-    find_by nom_technique: :complet
-  end
 end

--- a/app/views/admin/campagnes/_form.html.arb
+++ b/app/views/admin/campagnes/_form.html.arb
@@ -24,10 +24,10 @@ div class: 'nouvelle-campagne' do
             h2 t('.choix_parcours'), class: 'titre titre--medium'
             para t('.explication_choix_parcours'), class: 'description description--secondaire'
             f.inputs class: 'input-choix-parcours' do
-              f.input :parcours_type_id, as: :radio,
-                                         collection: collection_parcours_type(parcours_type),
-                                         required: true,
-                                         label: false
+              f.input :parcours_type, as: :radio,
+                                      collection: collection_parcours_type(parcours_type),
+                                      required: true,
+                                      label: false
             end
           end
         end

--- a/app/views/admin/campagnes/_form.html.arb
+++ b/app/views/admin/campagnes/_form.html.arb
@@ -12,6 +12,7 @@ div class: 'nouvelle-campagne' do
         f.semantic_errors
         div class: 'panel' do
           h2 t('.titre_informations'), class: 'titre titre--medium'
+          para t('.explication_informations_campagne'), class: 'description description--secondaire'
           f.inputs do
             f.input :libelle
             f.input :code
@@ -21,6 +22,7 @@ div class: 'nouvelle-campagne' do
         if resource.new_record?
           div class: 'panel' do
             h2 t('.choix_parcours'), class: 'titre titre--medium'
+            para t('.explication_choix_parcours'), class: 'description description--secondaire'
             f.inputs class: 'input-choix-parcours' do
               f.input :parcours_type_id, as: :radio,
                                          collection: collection_parcours_type(parcours_type),

--- a/app/views/admin/parcours_type/_form.html.arb
+++ b/app/views/admin/parcours_type/_form.html.arb
@@ -5,6 +5,7 @@ active_admin_form_for [:admin, resource] do |f|
     f.input :libelle
     f.input :nom_technique
     f.input :duree_moyenne
+    f.input :description, as: :text
     render partial: 'admin/situations_configurations/input_situations_configurations',
            locals: { f: f }
   end

--- a/app/views/admin/parcours_type/_show.html.arb
+++ b/app/views/admin/parcours_type/_show.html.arb
@@ -5,6 +5,7 @@ panel 'Détails du parcours type' do
     row :libelle
     row :nom_technique
     row :duree_moyenne
+    row(:description) { md(parcours_type.description) }
     row :created_at
     row :updated_at
   end

--- a/app/views/components/_input_choix_parcours.html.erb
+++ b/app/views/components/_input_choix_parcours.html.erb
@@ -3,7 +3,7 @@
     <%= parcours_type.libelle %>
   </h4>
 
-  <div class="choix-parcours-situations">
+  <div class="choix-parcours-description">
     <%= md(parcours_type.description) %>
   </div>
 

--- a/app/views/components/_input_choix_parcours.html.erb
+++ b/app/views/components/_input_choix_parcours.html.erb
@@ -3,13 +3,9 @@
     <%= parcours_type.libelle %>
   </h4>
 
-  <p class="choix-parcours-intro-situations">Contient :</p>
-
-  <ul class="choix-parcours-situations">
-    <% parcours_type.situations_configurations.each do |situation_configuration| %>
-      <li class='choix-parcours-situation'><%= situation_configuration.libelle %></li>
-    <% end %>
-  </ul>
+  <div class="choix-parcours-situations">
+    <%= md(parcours_type.description) %>
+  </div>
 
   <p class="choix-parcours-duree-moyenne">
     Durée moyenne : <%= parcours_type.duree_moyenne %>

--- a/config/locales/models/campagne.yml
+++ b/config/locales/models/campagne.yml
@@ -12,6 +12,12 @@ fr:
       situation_configuration:
         one: Situation
         other: Situations
+    errors:
+      models:
+        campagne:
+          attributes:
+            parcours_type:
+              blank: 'Vous devez choisir un parcours.'
   formtastic:
     actions:
       campagne:

--- a/config/locales/views/campagnes.yml
+++ b/config/locales/views/campagnes.yml
@@ -5,7 +5,9 @@ fr:
         explication_campagne: Une campagne permet de regrouper vos passations. Vous pouvez ainsi par exemple les regrouper selon leurs objectifs, leurs publics cibles ou les dispositifs mobilisés.
         explication_code: Le code est communiqué aux bénéficiaires pour démarrer le parcours. Nous vous conseillons de le choisir simple et personnalisé.
         titre_informations: Informations de la campagne
+        explication_informations_campagne: Le libellé est le nom utilisé pour designer la campagne dans votre espace conseiller. Le code campagne est le code saisi par les bénéficiaires pour être rattachés à votre compte.
         choix_parcours: Choix du parcours
+        explication_choix_parcours: Une campagne eva est constituée de jeux sérieux appelés “mise en situation”. Ci-dessous, il est possible de choisir entre deux séries de mises en situation. Vous pouvez en consulter le descriptif pour sélectionner le parcours correspondant aux compétences que vous souhaitez évaluer.
         configuration_avancee: Configuration avancée
       show:
         titre_panel_parcours: Parcours

--- a/db/migrate/20210609134800_ajoute_description_pour_parcours_type.rb
+++ b/db/migrate/20210609134800_ajoute_description_pour_parcours_type.rb
@@ -1,0 +1,5 @@
+class AjouteDescriptionPourParcoursType < ActiveRecord::Migration[6.1]
+  def change
+    add_column :parcours_type, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_04_104236) do
+ActiveRecord::Schema.define(version: 2021_06_09_134800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -166,6 +166,7 @@ ActiveRecord::Schema.define(version: 2021_06_04_104236) do
     t.string "duree_moyenne"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "description"
   end
 
   create_table "parties", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/campagne.rb
+++ b/spec/factories/campagne.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     libelle { 'Ma campagne' }
     sequence(:code) { |n| "CODE-#{n}" }
     association :compte, factory: :compte_conseiller
+    parcours_type
   end
 end

--- a/spec/features/admin/campagne_spec.rb
+++ b/spec/features/admin/campagne_spec.rb
@@ -79,6 +79,7 @@ describe 'Admin - Campagne', type: :feature do
       context 'crée la campagne, associé au compte courant et initialise les situations' do
         before do
           fill_in :campagne_code, with: 'EUROCKS'
+          choose "campagne_parcours_type_id_#{parcours_type_complet.id}"
           click_on 'Créer'
         end
         it do

--- a/spec/features/admin/parcours_type_spec.rb
+++ b/spec/features/admin/parcours_type_spec.rb
@@ -23,10 +23,12 @@ describe 'Admin - Parcours type', type: :feature do
       fill_in :parcours_type_libelle, with: 'Parcours complet'
       fill_in :parcours_type_nom_technique, with: 'complet'
       fill_in :parcours_type_duree_moyenne, with: '1 heure'
+      fill_in :parcours_type_description, with: 'Ma description'
     end
 
     it do
       expect { click_on 'Créer' }.to(change { ParcoursType.count })
+      expect(ParcoursType.last.description).to eq('Ma description')
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -65,4 +65,14 @@ describe ApplicationHelper do
       end
     end
   end
+
+  describe '#md' do
+    context "quand il n'y a pas de contenu" do
+      let(:contenu) { nil }
+
+      it 'retourne une chaine vide' do
+        expect(helper.md(contenu)).to eq ''
+      end
+    end
+  end
 end

--- a/spec/models/campagne_spec.rb
+++ b/spec/models/campagne_spec.rb
@@ -26,35 +26,20 @@ describe Campagne, type: :model do
     end
 
     describe 'initialisation de la campagne' do
-      context "n'ajoute aucune situation quand ce n'est pas demandé" do
-        let(:campagne) do
-          Campagne.new libelle: 'ma campagne',
-                       code: 'moncode',
-                       compte: compte
-        end
-        before { expect(campagne.valid?).to be(true) }
-        it do
-          campagne.save
-          expect(campagne.situations_configurations.count).to eq 0
-        end
+      let(:campagne) do
+        Campagne.new libelle: 'ma campagne',
+                     code: 'moncode',
+                     compte: compte,
+                     parcours_type: parcours_type
       end
-
-      context "ajoute les situations par defaut quand c'est demandé" do
-        let(:campagne) do
-          Campagne.new libelle: 'ma campagne',
-                       code: 'moncode',
-                       compte: compte,
-                       parcours_type: parcours_type
-        end
-        before do
-          allow(campagne)
-            .to receive(:parcours_type).and_return parcours_type
-          expect(campagne.valid?).to be(true)
-        end
-        it do
-          campagne.save
-          expect(campagne.situations_configurations.count).to eq 1
-        end
+      before do
+        allow(campagne)
+          .to receive(:parcours_type).and_return parcours_type
+        expect(campagne.valid?).to be(true)
+      end
+      it do
+        campagne.save
+        expect(campagne.situations_configurations.count).to eq 1
       end
     end
   end


### PR DESCRIPTION
Pour : https://trello.com/c/BI8x1DXX/645-page-de-choix-du-parcours-int%C3%A9gration-des-textes-explicatifs

Par défaut, aucun parcours n'est sélectionné. Si on crée une campagne sans parcours, un message d'erreur apparaît.

![Capture d’écran 2021-06-09 à 17 51 26](https://user-images.githubusercontent.com/1309612/121387963-60481900-c94b-11eb-87ef-37de71071ea1.png)
