### PR TITLE
Supprimer les espaces inutiles dans les champs de saisies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'activeadmin_reorderable'
 gem 'activeadmin-xls'
 gem 'acts_as_list'
 gem 'addressable'
+gem 'auto_strip_attributes', '~> 2.6'
 gem 'aws-sdk-s3', require: false
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'bootstrap', '~> 4.3', '>= 4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,8 @@ GEM
       activesupport (>= 3.0.0, < 6.2)
       ruby2_keywords (>= 0.0.2, < 1.0)
     ast (2.4.2)
+    auto_strip_attributes (2.6.0)
+      activerecord (>= 4.0)
     autoprefixer-rails (10.2.4.0)
       execjs
     aws-eventstream (1.1.1)
@@ -468,6 +470,7 @@ DEPENDENCIES
   activeadmin_reorderable
   acts_as_list
   addressable
+  auto_strip_attributes (~> 2.6)
   aws-sdk-s3
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3, >= 4.3.1)

--- a/app/models/campagne.rb
+++ b/app/models/campagne.rb
@@ -10,6 +10,8 @@ class Campagne < ApplicationRecord
   validates :libelle, presence: true
   validates :code, presence: true, uniqueness: true
 
+  auto_strip_attributes :libelle, :code, squish: true
+
   accepts_nested_attributes_for :situations_configurations, allow_destroy: true
 
   before_create :initialise_situations, if: :parcours_type_id

--- a/app/models/compte.rb
+++ b/app/models/compte.rb
@@ -13,6 +13,8 @@ class Compte < ApplicationRecord
   validates_presence_of :nom, :prenom, on: :create
   validate :verifie_dns_email
 
+  auto_strip_attributes :email, :nom, :prenom, :telephone, squish: true
+
   enum statut_validation: %i[en_attente acceptee refusee], _prefix: :validation
 
   belongs_to :structure

--- a/app/models/structure.rb
+++ b/app/models/structure.rb
@@ -9,6 +9,8 @@ class Structure < ApplicationRecord
   validates :nom, :code_postal, :type_structure, presence: true
   validates :type_structure, inclusion: { in: (TYPES_STRUCTURES + ['non_communique']) }
 
+  auto_strip_attributes :nom, :code_postal, squish: true
+
   geocoded_by :code_postal, state: :region, params: { countrycodes: 'fr' } do |obj, resultats|
     if (resultat = resultats.first)
       obj.region = resultat.state

--- a/lib/tasks/nettoyage.rake
+++ b/lib/tasks/nettoyage.rake
@@ -132,6 +132,32 @@ namespace :nettoyage do
   task supprime_controle_campagne: :environment do
     SituationConfiguration.where(situation: Situation.where(nom_technique: 'controle')).destroy_all
   end
+
+  def supprime_espace_inutile(objet, attributs)
+    changements = attributs.each_with_object({}) do |str, hsh|
+      hsh[str] = objet.send(str)&.squish
+    end
+    objet.update(changements)
+  end
+
+  desc 'Supprime les espaces inutiles pour les campagnes, comptes et structures'
+  task supprime_espaces_inutiles: :environment do
+    puts "\n-- campagnes --"
+    Campagne.find_each do |campagne|
+      supprime_espace_inutile(campagne, %i[libelle code])
+      print '.'
+    end
+    puts "\n-- comptes --"
+    Compte.find_each do |compte|
+      supprime_espace_inutile(compte, %i[email nom prenom telephone])
+      print '.'
+    end
+    puts "\n-- structures --"
+    Structure.find_each do |structure|
+      supprime_espace_inutile(structure, %i[nom code_postal])
+      print '.'
+    end
+  end
 end
 
 class RakeLogger


### PR DESCRIPTION
Commande à lancer en preprod et production pour supprimer les espaces inutiles dans les données existantes : `rails nettoyage:supprime_espaces_inutiles`

J'ai fait le choix de ne pas le faire dans une migration car si la base de donnée est importante, cela bloque la mise en production