### PR TITLE
Export Stats : on ne peut pas utiliser `.find_each` quand on veut aussi trier

### DIFF
--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -52,7 +52,8 @@ namespace :stats do
       session_id: sessions_ids(situation)
     )
              .order(:date)
-             .find_each.with_object({}) do |evenement, map|
+             .each_with_object({}) do |evenement, map|
+      # attention, find_each ne fonctionne pas avec order
       map[evenement.session_id] ||= []
       map[evenement.session_id] << evenement
     end


### PR DESCRIPTION
https://guides.rubyonrails.org/active_record_querying.html#find-each

> …as long as they have no ordering, …