### PR TITLE
Mailing création de compte: prévenir les admins

### DIFF
--- a/app/controllers/nouvelles_structures_controller.rb
+++ b/app/controllers/nouvelles_structures_controller.rb
@@ -28,7 +28,6 @@ class NouvellesStructuresController < ApplicationController
   end
 
   def envoie_emails
-    CompteMailer.with(compte: @compte).nouveau_compte.deliver_later
     StructureMailer.with(compte: @compte, structure: @compte.structure)
                    .nouvelle_structure
                    .deliver_later

--- a/app/mailers/compte_mailer.rb
+++ b/app/mailers/compte_mailer.rb
@@ -7,6 +7,13 @@ class CompteMailer < ApplicationMailer
          subject: t('.objet', structure: @compte.structure.nom))
   end
 
+  def alerte_admin
+    @compte = params[:compte]
+    @compte_admin = params[:compte_admin]
+    mail(to: @compte_admin.email,
+         subject: t('.objet', structure: @compte.structure.nom))
+  end
+
   def relance
     @compte = params[:compte]
     structure = @compte.structure

--- a/app/views/compte_mailer/alerte_admin.html.erb
+++ b/app/views/compte_mailer/alerte_admin.html.erb
@@ -1,0 +1,7 @@
+<%= md t('.corps',
+         prenom_admin: @compte_admin.prenom,
+         prenom: @compte.prenom,
+         nom: @compte.nom,
+         structure: @compte.structure.nom,
+         url_validation: "#{root_url}admin/comptes?q\\[statut_validation_eq\\]=en_attente"
+        ) %>

--- a/config/locales/views/compte_mailer.yml
+++ b/config/locales/views/compte_mailer.yml
@@ -16,6 +16,27 @@ fr:
 
         - Mot de passe : c'est le mot de passe que vous avez choisi précédemment.
           Il est personnel, ne le communiquez pas à vos collègues.
+    alerte_admin:
+      objet: Validez l'accès eva à « %{structure} » de vos collègues
+      corps: |
+        ### Bonjour %{prenom_admin},
+
+        Votre collègues %{prenom} %{nom} souhaite utiliser eva pour ses
+        prochains accompagnements.
+
+        Pour des raisons de sécurité, vous devez confirmer qu'il s'agit bien
+        d'une personne de « %{structure} ».
+
+        Pour valider ce compte :
+          - cliquez sur le lien suivant,
+          - utilisez le bouton [modifier] de la ligne à valider,
+          - choisissez l'accès "authorisé" ou "refusé",
+          - et enfin, cliquer sur le bouton [modifier]
+
+        -> [Valider ce compte](%{url_validation})
+
+        Vous avez reçu ce message parce que vous avez actuellement le rôle
+        d’administrateur de cette structure.
     relance:
       objet: "%{prenom}, quelques ressources pour vous aider à réaliser vos premières évaluations"
       intro: |

--- a/spec/factories/compte.rb
+++ b/spec/factories/compte.rb
@@ -25,6 +25,6 @@ FactoryBot.define do
   end
 
   sequence :email do |n|
-    "superadmin-#{n}@exemple.fr"
+    "toto-#{n}@exemple.fr"
   end
 end

--- a/spec/integrations/compte_spec.rb
+++ b/spec/integrations/compte_spec.rb
@@ -12,11 +12,43 @@ describe Compte, type: :integration do
       end.to have_enqueued_job(RelanceUtilisateurPourNonActivationJob)
     end
 
+    it 'programme un mail de bienvenue' do
+      expect do
+        create :compte_conseiller
+      end.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+    end
+
     context 'quand le compte est superadmin' do
-      it 'ne programme pas de mail de relance' do
+      it 'ne programme pas de mail de relance pour éviter le pb dans le seed par exemple' do
         expect do
           create :compte_superadmin
         end.not_to have_enqueued_job(RelanceUtilisateurPourNonActivationJob)
+      end
+      it 'ne programme pas de mail de bienvenue' do
+        expect do
+          create :compte_superadmin
+        end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+      end
+    end
+  end
+
+  describe '#find_admins' do
+    let(:structure) { create :structure }
+    let(:compte) { create :compte_conseiller, structure: structure }
+
+    it "ne trouve aucun admins d'un compte quand il n'y en a pas" do
+      expect(compte.find_admins.empty?).to eql(true)
+    end
+
+    describe 'avec des admins' do
+      let!(:compte_admin) { create :compte_admin, structure: structure }
+      let!(:compte_admin2) { create :compte_admin, structure: structure }
+      let!(:compte_superadmin) { create :compte_superadmin, structure: structure }
+      let(:autre_structure) { create :structure }
+      let!(:autre_admin) { create :compte_admin, structure: autre_structure }
+
+      it "trouve les admins d'un compte" do
+        expect(compte.find_admins.count).to eql(3)
       end
     end
   end

--- a/spec/mailers/compte_mailer_spec.rb
+++ b/spec/mailers/compte_mailer_spec.rb
@@ -26,6 +26,35 @@ describe CompteMailer, type: :mailer do
     end
   end
 
+  describe '#alerte_admin' do
+    it "envoie un email de demande de validation d'un nouveau compte à l'admin" do
+      structure = Structure.new nom: 'Ma Super Structure'
+      admin = Compte.new prenom: 'Admin',
+                         email: 'debut@test.com',
+                         role: :admin,
+                         structure: structure
+      compte = Compte.new prenom: 'Paule',
+                          nom: 'Delaporte',
+                          email: 'debut@test.com',
+                          structure: structure
+
+      email = CompteMailer.with(compte: compte, compte_admin: admin)
+                          .alerte_admin
+
+      assert_emails 1 do
+        email.deliver_now
+      end
+
+      expect(email.from).to eql([Eva::EMAIL_CONTACT])
+      expect(email.to).to eql(['debut@test.com'])
+      expect(email.subject).to eql("Validez l'accès eva à « Ma Super Structure » de vos collègues")
+      expect(email.multipart?).to be(false)
+      expect(email.body).to include('Admin')
+      expect(email.body).to include('Paule Delaporte')
+      expect(email.body).to include('Ma Super Structure')
+    end
+  end
+
   describe 'relance' do
     let(:structure) { Structure.new nom: 'Ma Super Structure' }
     let(:compte) { Compte.new prenom: 'Paule', email: 'debut@test.com', structure: structure }

--- a/spec/mailers/previews/compte_mailer_preview.rb
+++ b/spec/mailers/previews/compte_mailer_preview.rb
@@ -8,6 +8,19 @@ class CompteMailerPreview < ActionMailer::Preview
     CompteMailer.with(compte: compte).nouveau_compte
   end
 
+  def alerte_admin
+    structure = Structure.new nom: 'Ma Super Structure'
+    admin = Compte.new prenom: 'Admin',
+                       email: 'admin@test.com',
+                       structure: structure,
+                       role: 'admin'
+    compte = Compte.new prenom: 'Paule',
+                        nom: 'Delaporte',
+                        email: 'debut@test.com',
+                        structure: structure
+    CompteMailer.with(compte: compte, compte_admin: admin).alerte_admin
+  end
+
   def relance
     structure = Structure.new type_structure: 'mission_locale'
     compte = Compte.new prenom: 'Lucas', structure: structure, email: 'lucas.dupont@example.com'


### PR DESCRIPTION
Pour le ticket https://trello.com/c/MqUQ7XF2

Cette PR modifie deux choses.

- Elle envoie un mail de bienvenu pour toutes les création de compte
- Elle envoie un mail à tous les comptes admin (ou superadmin) de la structure

<img width="607" alt="Capture d’écran 2021-06-22 à 17 00 16" src="https://user-images.githubusercontent.com/298214/122948619-55de4400-d37b-11eb-85af-f94420538428.png">
