### PR TITLE
Restitution - Repositionne les titres des blocs

### DIFF
--- a/app/assets/stylesheets/restitution_globale/_base.scss
+++ b/app/assets/stylesheets/restitution_globale/_base.scss
@@ -6,21 +6,19 @@
 
 .admin_restitution_globale {
   color: $couleur-texte;
-  font-size: 1rem;
+  font-size: 0.875rem;
   font-family: $font-texte;
 
   .en-tete-page, .pied-page {
     display: none;
   }
 
-  .page {
-    border-bottom: thin solid $eva_bluegrey;
-  }
-
   h2 {
     font-family: $font-titre;
     color: $eva_dark;
     font-weight: bold;
+    font-size: 1.5rem;
+    margin: 3rem 0 2rem;
   }
 
   h3 {
@@ -105,12 +103,6 @@
     }
   }
 
-  .legende-titre {
-    font-size: 1rem;
-    color: $couleur-texte;
-    font-weight: normal;
-  }
-
   .competences-transversales-vides {
     p:last-child {
       margin-bottom: 0;
@@ -171,6 +163,7 @@
     }
 
     .nom-competence {
+      margin: 0 0 0.75em;
       font-size: 1.3rem;
     }
 
@@ -313,6 +306,7 @@
   }
 
   .titre-redaction {
+    margin-top: 0;
     font-size: 1.7rem;
   }
 

--- a/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
+++ b/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
@@ -6,10 +6,12 @@ $grid-gutter-width: 1.25rem;
 
 .admin_restitution_globale {
   line-height: 1.3;
+  font-size: 1rem;
   width: 1100px;
 
   h2 {
     font-size: 1.80rem;
+    margin-bottom: 0.75rem;
   }
 
   h3 {

--- a/app/views/admin/evaluations/_autopositionnement.arb
+++ b/app/views/admin/evaluations/_autopositionnement.arb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 div class: 'autopositionnement' do
-  h2 class: 'text-center my-5' do
-    t('.titre')
-  end
   auto_positionnement.questions_et_reponses(:jauge).each do |question, reponse|
     div class: 'row' do
       div class: 'col intitule-question' do

--- a/app/views/admin/evaluations/_communication_ecrite.arb
+++ b/app/views/admin/evaluations/_communication_ecrite.arb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+mes_avec_redaction_de_notes = restitution_globale.restitutions.select do |restitution|
+  %w[questions livraison].include?(restitution.situation.nom_technique) &&
+    !restitution.questions_redaction.empty?
+end
+unless mes_avec_redaction_de_notes.empty?
+  div class: 'marges-page mt-4' do
+    mes_avec_redaction_de_notes.each do |restitution|
+      situation = restitution.situation
+
+      render 'questions', {
+        restitution: restitution,
+        situation_libelle: situation.libelle,
+        pdf: pdf
+      }
+    end
+  end
+end

--- a/app/views/admin/evaluations/_francais_mathematique.arb
+++ b/app/views/admin/evaluations/_francais_mathematique.arb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+div id: 'francais_mathematiques', class: 'marges-page' do
+  render 'litteratie_numeratie_synthese',
+         synthese: restitution_globale.synthese,
+         pdf: pdf
+
+  render 'litteratie_numeratie_niveau1',
+         interpretations: restitution_globale.interpretations_niveau1,
+         pdf: pdf
+
+  div class: 'row my-4' do
+    div class: 'col-auto badge' do
+      img # place holder
+    end
+    div class: 'col' do
+      render 'metacompetences', categorie: :litteratie
+    end
+    div class: 'col-auto badge' do
+      img # place holder
+    end
+    div class: 'col' do
+      render 'metacompetences', categorie: :numeratie
+    end
+  end
+end

--- a/app/views/admin/evaluations/_restitution_globale.arb
+++ b/app/views/admin/evaluations/_restitution_globale.arb
@@ -4,67 +4,76 @@ niveaux_competences = restitution_globale.niveaux_competences
 
 div class: 'admin_restitution_globale' do
   if auto_positionnement
-    div class: 'page panel' do
+    div id: 'auto_positionnement', class: 'page' do
       render 'entete_page', restitution_globale: restitution_globale
 
-      div id: 'auto_positionnement', class: 'marges-page' do
-        render partial: 'autopositionnement', locals: { auto_positionnement: auto_positionnement }
+      if pdf
+        h2 t('.autopositionnement_titre'), class: 'text-center my-5'
+      else
+        h2 t('.autopositionnement_titre')
       end
 
-      render 'pied_page'
+      div class: 'panel' do
+        div class: 'marges-page' do
+          render partial: 'autopositionnement', locals: { auto_positionnement: auto_positionnement }
+        end
+
+        render 'pied_page'
+      end
     end
   end
 
-  div class: 'page panel' do
+  div id: 'competences_transversales', class: 'page' do
     render 'entete_page', restitution_globale: restitution_globale
 
-    div id: 'competences_transversales', class: 'marges-page' do
-      div class: 'text-center my-5' do
-        h2 t('.competences_fortes_titre')
-        para class: 'legende-titre' do
-          t('.legende_titre')
-        end
-      end
+    if pdf
+      h2 t('.competences_fortes_titre'), class: 'text-center my-5'
+    else
+      h2 t('.competences_fortes_titre')
+    end
 
-      div class: 'row mb-5' do
-        div class: 'col' do
-          if niveaux_competences.blank?
-            div class: 'competences-transversales-vides' do
-              md t('.competences_fortes_vides')
+    div class: 'panel' do
+      div class: 'marges-page' do
+        div class: 'row my-5' do
+          div class: 'col' do
+            if niveaux_competences.blank?
+              div class: 'competences-transversales-vides' do
+                md t('.competences_fortes_vides')
+              end
             end
-          end
 
-          interpretations = restitution_globale.interpretations_competences_transversales
-          interpretations.each do |competence, interpretation|
-            div class: 'competence-transversale' do
-              div class: 'conteneur-jauge' do
-                div class: 'jauge'
-                div class: "jauge remplissage remplissage-#{interpretation}"
-              end
-              span class: 'image-competence' do
-                if pdf
-                  svg_tag_base64 "#{competence}.svg"
-                else
-                  image_tag "#{competence}.svg"
+            interpretations = restitution_globale.interpretations_competences_transversales
+            interpretations.each do |competence, interpretation|
+              div class: 'competence-transversale' do
+                div class: 'conteneur-jauge' do
+                  div class: 'jauge'
+                  div class: "jauge remplissage remplissage-#{interpretation}"
                 end
-              end
-              div class: 'informations-competence' do
-                h2 t("#{competence}.nom", scope: 'admin.evaluations.restitution_competence'),
-                   class: 'nom-competence'
-                div class: 'description-competence' do
-                  div md t("#{competence}.stanine#{interpretation}",
-                           scope: 'admin.evaluations.restitution_competence')
-                  div class: 'lien-metier' do
-                    if pdf
-                      text_node svg_tag_base64 'lien.svg', class: 'image-lien'
-                    else
-                      text_node image_tag 'lien.svg', class: 'image-lien'
-                    end
-                    span class: 'align-middle' do
-                      text_node t('.etiquette_lien_metiers')
-                      url_competence = "#{URL_COMPETENCES_SITE_VITRINE}#{competence}/"
-                      a href: url_competence, target: '_blank' do
-                        url_competence
+                span class: 'image-competence' do
+                  if pdf
+                    svg_tag_base64 "#{competence}.svg"
+                  else
+                    image_tag "#{competence}.svg"
+                  end
+                end
+                div class: 'informations-competence' do
+                  h2 t("#{competence}.nom", scope: 'admin.evaluations.restitution_competence'),
+                     class: 'nom-competence'
+                  div class: 'description-competence' do
+                    div md t("#{competence}.stanine#{interpretation}",
+                             scope: 'admin.evaluations.restitution_competence')
+                    div class: 'lien-metier' do
+                      if pdf
+                        text_node svg_tag_base64 'lien.svg', class: 'image-lien'
+                      else
+                        text_node image_tag 'lien.svg', class: 'image-lien'
+                      end
+                      span class: 'align-middle' do
+                        text_node t('.etiquette_lien_metiers')
+                        url_competence = "#{URL_COMPETENCES_SITE_VITRINE}#{competence}/"
+                        a href: url_competence, target: '_blank' do
+                          url_competence
+                        end
                       end
                     end
                   end
@@ -74,73 +83,42 @@ div class: 'admin_restitution_globale' do
           end
         end
       end
-    end
-
-    render 'pied_page'
-  end
-
-  div class: 'page panel' do
-    render 'entete_page', restitution_globale: restitution_globale
-
-    div id: 'francais_mathematiques', class: 'marges-page' do
-      h2 class: 'text-center my-4' do
-        span t('titre', scope: 'admin.restitutions.niveaux_illettrisme')
-      end
-
-      render 'litteratie_numeratie_synthese',
-             synthese: restitution_globale.synthese,
-             pdf: pdf
-
-      render 'litteratie_numeratie_niveau1',
-             interpretations: restitution_globale.interpretations_niveau1,
-             pdf: pdf
-
-      div class: 'row my-4' do
-        div class: 'col-auto badge' do
-          img # place holder
-        end
-        div class: 'col' do
-          render 'metacompetences', categorie: :litteratie
-        end
-        div class: 'col-auto badge' do
-          img # place holder
-        end
-        div class: 'col' do
-          render 'metacompetences', categorie: :numeratie
-        end
-      end
-    end
-
-    render 'references_restitution_illettrisme' unless pdf
-
-    render 'pied_page', avant_pied_page: 'references_restitution_illettrisme'
-  end
-
-  mes_avec_redaction_de_notes = restitution_globale.restitutions.select do |restitution|
-    %w[questions livraison].include?(restitution.situation.nom_technique) &&
-      !restitution.questions_redaction.empty?
-  end
-  unless mes_avec_redaction_de_notes.empty?
-    div class: 'page panel' do
-      render 'entete_page', restitution_globale: restitution_globale
-
-      h2 class: 'text-center my-5' do
-        span t('titre', scope: 'admin.restitutions.niveaux_illettrisme')
-      end
-
-      div id: 'communication_ecrite', class: 'marges-page mt-4' do
-        mes_avec_redaction_de_notes.each do |restitution|
-          situation = restitution.situation
-
-          render 'questions', {
-            restitution: restitution,
-            situation_libelle: situation.libelle,
-            pdf: pdf
-          }
-        end
-      end
 
       render 'pied_page'
+    end
+  end
+
+  if pdf
+    div class: 'page' do
+      render 'entete_page', restitution_globale: restitution_globale
+
+      h2 t('titre', scope: 'admin.restitutions.niveaux_illettrisme'), class: 'text-center my-5'
+
+      div class: 'panel' do
+        render 'francais_mathematique', pdf: pdf
+      end
+
+      render 'pied_page', avant_pied_page: 'references_restitution_illettrisme'
+    end
+
+    div class: 'page' do
+      render 'entete_page', restitution_globale: restitution_globale
+
+      render 'communication_ecrite', restitution_globale: restitution_globale, pdf: pdf
+
+      render 'pied_page'
+    end
+  else
+    div id: 'francais_mathematiques', class: 'page' do
+      h2 t('titre', scope: 'admin.restitutions.niveaux_illettrisme')
+
+      div class: 'panel' do
+        render 'francais_mathematique', pdf: pdf
+
+        render 'communication_ecrite', restitution_globale: restitution_globale, pdf: pdf
+
+        render 'references_restitution_illettrisme'
+      end
     end
   end
 end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -22,11 +22,11 @@ fr:
         <<: *commun
         reste_plateau: Reste plateau
       autopositionnement:
-        titre: Questionnaire d'auto-positionnement
         appareils: Appareils
         scolarite: Scolarité
         sante: Santé
       restitution_globale:
+        autopositionnement_titre: Questionnaire d'auto-positionnement
         competences_fortes_titre: 'Vos compétences transversales'
         legende_titre: 'Les compétences transversales sont des compétences que l’on retrouve dans de nombreux métiers'
         competences_fortes_vides: |


### PR DESCRIPTION
Co-authored-by: Marine Sourin <msourin@captive.fr>

Le bloc communication écrite est maintenant inclus dans le bloc français et mathématique ( mais pas dans le pdf )

Pour : https://trello.com/c/1sQX3HYN/544-restitution-s%C3%A9parer-les-sections-dans-des-panels-diff%C3%A9rents 

![Capture d’écran 2021-06-25 à 12 37 16](https://user-images.githubusercontent.com/1309612/123412622-177e9a00-d5b2-11eb-8054-b10e74a22ede.png)
