### PR TITLE
Corrige erreur pour accéder à l'application lors de l'entrée du code

### DIFF
--- a/app/views/api/evaluations/_evaluation.jbuilder
+++ b/app/views/api/evaluations/_evaluation.jbuilder
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+json.id evaluation.id
 json.nom evaluation.nom
 json.campagne_id evaluation.campagne_id
 json.email evaluation.email

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -16,6 +16,10 @@ describe 'Evaluation API', type: :request do
         evaluation = Evaluation.last
         expect(evaluation.campagne).to eq campagne_ete19
         expect(evaluation.nom).to eq 'Roger'
+
+        expect(response).to have_http_status(201)
+        reponse = JSON.parse(response.body)
+        expect(reponse['id']).to eq evaluation.id
       end
     end
 


### PR DESCRIPTION
L'API de création d'évaluation ne renvoyer pas d'ID et donc le js ne changer pas de page après la création de l'évaluation

Ce bug fait suite à un refactoring de l'api evaluations lors de la mise en place de Bullet :
https://github.com/betagouv/eva-serveur/pull/860

J'ai ajouté un test couvrir ce cas