### PR TITLE
Corrige une erreur lors de la création d'un compte sans email

### DIFF
--- a/app/models/compte.rb
+++ b/app/models/compte.rb
@@ -38,6 +38,7 @@ class Compte < ApplicationRecord
   private
 
   def verifie_dns_email
+    return if email.blank?
     return unless email_changed?
     return if Truemail.valid?(email)
 


### PR DESCRIPTION
Cette erreur apparait si on rempli entièrement le formulaire de création de compte, sauf le champs email.

Error Rollbar :
New Error: #218 Truemail::TypeError: email should be a String

Je n'ai malheureusement pas réussi à reproduire le problème dans mes tests, que ce soit dans le model ou dans les tests de feature .. pourtant la situation est similaire ! Il y a probablement quelque chose qui m'échappe