### PR TITLE
Généralise le prénom du support dans le message d'accueil attente validation

### DIFF
--- a/app/views/admin/dashboard/_validation_necessaire.html.arb
+++ b/app/views/admin/dashboard/_validation_necessaire.html.arb
@@ -3,5 +3,8 @@
 h3 t('.titre'), class: 'titre'
 
 div class: 'panel' do
-  md t('.description', telephone: support&.telephone, email: support&.email)
+  md t('.description',
+       prenom: support&.prenom,
+       telephone: support&.telephone,
+       email: support&.email)
 end

--- a/config/locales/views/dashboard.yml
+++ b/config/locales/views/dashboard.yml
@@ -41,4 +41,4 @@ fr:
 
             Si vous savez qui est cette personne, n'hésitez pas à vous rapprocher d'elle.
 
-            Vous pensez que cette personne est momentanément absente, merci de contacter Véronique %{telephone} ou par mail [%{email}](mailto:%{email}).
+            Vous pensez que cette personne est momentanément absente, merci de contacter %{prenom} au %{telephone} ou par mail [%{email}](mailto:%{email}).


### PR DESCRIPTION
Le prénom du support est aussi extrait du compte "support". Si on donne à ce compte le prenom "le support" ça marche pas mal.

<img width="947" alt="Capture d’écran 2021-07-28 à 10 20 29" src="https://user-images.githubusercontent.com/298214/127289212-41b3021c-60a1-4b39-bb23-b57ad38aa00c.png">
