### PR TITLE
Ajoute un test pour le message d'accueil des comptes en attente de validation

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -38,6 +38,7 @@ group :red_green_refactor, halt_on_fail: true do
 
     # Turnip features and steps
     watch(%r{^spec/jobs/(.+)_spec\.rb$})
+    watch(%r{^spec/features/(.+)_spec\.rb$})
     watch(%r{^spec/acceptance/(.+)\.feature$})
     watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
       Dir[File.join("**/#{m[1]}.feature")][0] || 'spec/acceptance'

--- a/config/locales/views/dashboard.yml
+++ b/config/locales/views/dashboard.yml
@@ -41,4 +41,4 @@ fr:
 
             Si vous savez qui est cette personne, n'hésitez pas à vous rapprocher d'elle.
 
-            Vous pensez que cette personne est momentanément absente, merci de contacter %{prenom} au %{telephone} ou par mail [%{email}](mailto:%{email}).
+            Vous pensez que cette personne est momentanément absente ? Vous pouvez contacter %{prenom} au %{telephone} ou par mail à [%{email}](mailto:%{email}).

--- a/spec/features/inscription_conseiller_spec.rb
+++ b/spec/features/inscription_conseiller_spec.rb
@@ -4,6 +4,13 @@ require 'rails_helper'
 
 describe 'Création de compte conseiller', type: :feature do
   let!(:structure) { create :structure, :avec_admin, nom: 'Ma structure' }
+  let!(:compte_support) do
+    create :compte,
+           nom: 'Ma structure',
+           prenom: 'Véronique',
+           telephone: '06 01 02 03 04',
+           email: Eva::EMAIL_SUPPORT
+  end
 
   context 'sans structure précisée' do
     before do
@@ -31,6 +38,10 @@ describe 'Création de compte conseiller', type: :feature do
       nouveau_compte = Compte.find_by email: 'monemail@eva.fr'
       expect(nouveau_compte.validation_en_attente?).to be true
       expect(nouveau_compte.structure).to eq structure
+
+      infos_support =
+        'Vous pouvez contacter Véronique au 06 01 02 03 04 ou par mail à support@eva.beta.gouv.fr'
+      expect(page).to have_content infos_support
     end
   end
 end


### PR DESCRIPTION
Cette PR vérifie l'affichage des informations de contact du support pour comptes en attente de validation.

Le message en question a été aussi légèrement ajusté.

<img width="1233" alt="Capture d’écran 2021-07-28 à 11 14 16" src="https://user-images.githubusercontent.com/298214/127296915-1bbb10d6-a8a2-4440-a456-810561157d00.png">
