### PR TITLE
N'autorise pas les comtes en attente de validation a consulter la structure

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -103,7 +103,7 @@ class Ability # rubocop:disable Metrics/ClassLength
   end
 
   def droit_structure(compte)
-    can :read, Structure, id: compte.structure_id
+    can :read, Structure, id: compte.structure_id if compte.validation_acceptee?
     can :update, Structure, id: compte.structure_id if compte.admin?
     cannot(:destroy, Structure) { |s| Compte.where(structure: s).exists? }
   end

--- a/spec/integrations/ability_spec.rb
+++ b/spec/integrations/ability_spec.rb
@@ -248,5 +248,9 @@ describe Ability do
       is_expected.to_not be_able_to(:read, autre_evaluation)
       is_expected.to_not be_able_to(:destroy, autre_evaluation)
     end
+
+    it 'ne peut pas consulter la page de la structure' do
+      is_expected.to_not be_able_to(:read, compte.structure)
+    end
   end
 end


### PR DESCRIPTION
Quand l'utilisateur essaye de consulter la page d'une structure alors qu'il est en attente de validation, on lui indique qu'il n'a pas le droit. Par exemple en cliquant sur le lien dans le cartouche blanc en haut à droite (ce cartouche qui est en fait un menu ! damned !).

<img width="1254" alt="Capture d’écran 2021-07-30 à 11 41 08" src="https://user-images.githubusercontent.com/298214/127634607-beab9f4f-9aae-4dbd-bbfe-2ec3b1c0c889.png">

C'est aussi le cas du coup quand on clique sur le lien de la structure dans le fiche de l'utilisateur.