### PR TITLE
Enlève le terme campagne du bouton de création d'une structure

### DIFF
--- a/config/locales/views/structures.yml
+++ b/config/locales/views/structures.yml
@@ -13,7 +13,7 @@ fr:
       rejoindre_structure: Rejoindre
   admin:
     structure:
-      nouvelle_structure: Créer une nouvelle structure (avec compte et campagne)
+      nouvelle_structure: Créer une nouvelle structure (avec compte)
   nouvelles_structures:
     show:
       titre: Rejoindre eva


### PR DESCRIPTION
Petite correction décidée hier avec @shanser

![image](https://user-images.githubusercontent.com/26568502/127982613-6d2c1d12-ccc6-414f-9500-ac06f8216565.png)
