### PR TITLE
Le compte generique est un compte admin de structure

### DIFF
--- a/app/models/compte.rb
+++ b/app/models/compte.rb
@@ -7,7 +7,7 @@ class Compte < ApplicationRecord
   devise :database_authenticatable, :trackable,
          :recoverable, :rememberable, :validatable, :registerable
   ROLES = %w[superadmin admin conseiller compte_generique].freeze
-  ADMIN_ROLES = %w[superadmin admin].freeze
+  ADMIN_ROLES = %w[superadmin admin compte_generique].freeze
   validates :role, inclusion: { in: ROLES }
   enum role: ROLES.zip(ROLES).to_h
   validates :statut_validation, presence: true

--- a/spec/models/compte_spec.rb
+++ b/spec/models/compte_spec.rb
@@ -64,6 +64,13 @@ describe Compte do
     end
   end
 
+  describe '#au_moins_admin?' do
+    it { expect(Compte.new(role: 'superadmin').au_moins_admin?).to eql(true) }
+    it { expect(Compte.new(role: 'admin').au_moins_admin?).to eql(true) }
+    it { expect(Compte.new(role: 'compte_generique').au_moins_admin?).to eql(true) }
+    it { expect(Compte.new(role: 'conseiller').au_moins_admin?).to eql(false) }
+  end
+
   describe 'structure a un admin' do
     let(:structure) { Structure.new }
     let(:compte) { Compte.new role: 'admin' }


### PR DESCRIPTION
Sinon, un conseiller ne peux pas se créer de compte (qui à un rôle conseiller) à partir du compte
générique.