### PR TITLE
Anonymisation : force la re-génération du code campagne

### DIFF
--- a/app/models/anonymisation/campagne.rb
+++ b/app/models/anonymisation/campagne.rb
@@ -5,6 +5,7 @@ module Anonymisation
     def anonymise
       super do |campagne|
         campagne.libelle = FFaker::Product.product_name
+        campagne.code = nil
       end
     end
   end


### PR DESCRIPTION
Ceci afin de s'assurer que la base ne contient que des codes campagne valides.