### PR TITLE
Fait passer une grande partie des règles du linter rubocop-rails

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -16,7 +16,7 @@ ActiveAdmin.register_page 'Dashboard' do
 
   controller do
     before_action do
-      flash.now[:annonce_generale] = "<span>#{annonce.texte}</span>".html_safe unless annonce.blank?
+      flash.now[:annonce_generale] = "<span>#{annonce.texte}</span>".html_safe if annonce.present?
       if comptes_en_attente? && current_compte.au_moins_admin?
         lien = admin_comptes_url(q: { statut_validation_eq: 'en_attente' })
         flash.now[:comptes_en_attente] =
@@ -35,8 +35,7 @@ ActiveAdmin.register_page 'Dashboard' do
 
     def comptes_en_attente?
       @comptes_en_attente ||= Compte.where(statut_validation: :en_attente)
-                                    .where(structure_id: current_compte.structure_id)
-                                    .exists?
+                                    .exists?(structure_id: current_compte.structure_id)
     end
 
     def message_incitation_compte_personnel

--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -23,7 +23,7 @@ ActiveAdmin.register Evaluation do
               parties_selectionnees: params[:parties_selectionnees],
               format: :pdf
             },
-            target: '_blank')
+            target: '_blank', rel: 'noopener')
   end
 
   index download_links: lambda {

--- a/app/admin/source_aides.rb
+++ b/app/admin/source_aides.rb
@@ -12,7 +12,7 @@ ActiveAdmin.register SourceAide do
     column :titre
     column :description
     column :url do |a|
-      link_to a.url, a.url, target: '_blank'
+      link_to a.url, a.url, target: '_blank', rel: 'noopener'
     end
     actions
   end

--- a/app/helpers/campagne_helper.rb
+++ b/app/helpers/campagne_helper.rb
@@ -21,6 +21,6 @@ module CampagneHelper
 
   def lien_campagne(campagne)
     url = url_campagne(campagne.code)
-    link_to url, url, target: '_blank'
+    link_to url, url, target: '_blank', rel: 'noopener'
   end
 end

--- a/app/jobs/anonymisation_evaluations_job.rb
+++ b/app/jobs/anonymisation_evaluations_job.rb
@@ -13,6 +13,6 @@ class AnonymisationEvaluationsJob < ApplicationJob
 
   def evaluations_de_plus_1_an
     Evaluation.where(anonymise_le: nil)
-              .where('created_at < ?', 1.years.ago)
+              .where('created_at < ?', 1.year.ago)
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -76,7 +76,7 @@ class Ability # rubocop:disable Metrics/ClassLength
   def droit_questionnaire
     can :read, Questionnaire
     cannot :destroy, Questionnaire do |q|
-      Campagne.where(questionnaire: q).exists? ||
+      Campagne.exists?(questionnaire: q) ||
         Situation.where(questionnaire: q)
                  .or(Situation.where(questionnaire_entrainement: q))
                  .exists?
@@ -86,8 +86,8 @@ class Ability # rubocop:disable Metrics/ClassLength
   def droit_question
     can :read, Question
     cannot :destroy, Question do |q|
-      QuestionnaireQuestion.where(question: q).exists? ||
-        Evenement.where("donnees->>'question' = ?", q.id.to_s).exists?
+      QuestionnaireQuestion.exists?(question: q) ||
+        Evenement.exists?(["donnees->>'question' = ?", q.id.to_s])
     end
   end
 
@@ -97,19 +97,19 @@ class Ability # rubocop:disable Metrics/ClassLength
     can :update, compte
     comptes_generiques_ou_comptes_admin(compte)
     cannot :edit_role, compte if compte.compte_generique?
-    cannot(:destroy, Compte) { |c| Campagne.where(compte: c).exists? }
+    cannot(:destroy, Compte) { |c| Campagne.exists?(compte: c) }
   end
 
   def droit_choix
     cannot :destroy, Choix do |c|
-      Evenement.where("donnees->>'reponse' = ?", c.id.to_s).exists?
+      Evenement.exists?(["donnees->>'reponse' = ?", c.id.to_s])
     end
   end
 
   def droit_structure(compte)
     can :read, Structure, id: compte.structure_id if compte.validation_acceptee?
     can :update, Structure, id: compte.structure_id if compte.admin?
-    cannot(:destroy, Structure) { |s| Compte.where(structure: s).exists? }
+    cannot(:destroy, Structure) { |s| Compte.exists?(structure: s) }
   end
 
   def droit_actualite

--- a/app/models/actualite.rb
+++ b/app/models/actualite.rb
@@ -2,7 +2,7 @@
 
 class Actualite < ApplicationRecord
   has_one_attached :illustration
-  enum categorie: %i[blog assistance evolution]
+  enum categorie: { blog: 0, assistance: 1, evolution: 2 }
 
   validates :titre, :contenu, :categorie, presence: true
   validates :titre, length: { maximum: 100 }

--- a/app/models/campagne.rb
+++ b/app/models/campagne.rb
@@ -19,9 +19,8 @@ class Campagne < ApplicationRecord
 
   accepts_nested_attributes_for :situations_configurations, allow_destroy: true
 
-  before_create :initialise_situations, if: :parcours_type_id
-
   before_validation :genere_code_unique
+  before_create :initialise_situations, if: :parcours_type_id
 
   scope :de_la_structure, lambda { |structure|
     joins(:compte).where('comptes.structure_id' => structure)

--- a/app/models/choix.rb
+++ b/app/models/choix.rb
@@ -2,7 +2,7 @@
 
 class Choix < ApplicationRecord
   validates :intitule, :type_choix, presence: true
-  enum type_choix: %i[bon mauvais abstention]
+  enum type_choix: { bon: 0, mauvais: 1, abstention: 2 }
 
   acts_as_list scope: :question_id
 

--- a/app/models/compte.rb
+++ b/app/models/compte.rb
@@ -11,7 +11,7 @@ class Compte < ApplicationRecord
   validates :role, inclusion: { in: ROLES }
   enum role: ROLES.zip(ROLES).to_h
   validates :statut_validation, presence: true
-  validates_presence_of :nom, :prenom, on: :create
+  validates :nom, :prenom, presence: { on: :create }
   validate :verifie_dns_email, :structure_a_un_admin
   validates :role, inclusion: { in: %w[conseiller compte_generique],
                                 message: 'Ce compte ne peut pas avoir le rôle %<value>s en étant' \
@@ -20,7 +20,7 @@ class Compte < ApplicationRecord
 
   auto_strip_attributes :email, :nom, :prenom, :telephone, squish: true
 
-  enum statut_validation: %i[en_attente acceptee refusee], _prefix: :validation
+  enum statut_validation: { en_attente: 0, acceptee: 1, refusee: 2 }, _prefix: :validation
 
   delegate :code_postal, to: :structure, prefix: true
 

--- a/app/models/question_qcm.rb
+++ b/app/models/question_qcm.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class QuestionQcm < Question
-  enum metacompetence: %i[numeratie ccf syntaxe-orthographe]
-  enum type_qcm: %i[standard jauge]
+  enum metacompetence: { numeratie: 0, ccf: 1, "syntaxe-orthographe": 2 }
+  enum type_qcm: { standard: 0, jauge: 1 }
   has_many :choix, -> { order(position: :asc) }, foreign_key: :question_id
 
   accepts_nested_attributes_for :choix, allow_destroy: true

--- a/app/models/restitution/base.rb
+++ b/app/models/restitution/base.rb
@@ -35,8 +35,8 @@ module Restitution
       return unless nom_restitution.constantize.const_defined?('METRIQUES')
 
       dictionnaire_metriques = "#{nom_restitution}::METRIQUES".constantize
-      metriques = dictionnaire_metriques.keys.each_with_object({}) do |nom_metrique, memo|
-        memo[nom_metrique] = public_send(nom_metrique)
+      metriques = dictionnaire_metriques.keys.index_with do |nom_metrique|
+        public_send(nom_metrique)
       end
       partie.update(metriques: metriques)
     end

--- a/app/models/restitution/globale.rb
+++ b/app/models/restitution/globale.rb
@@ -49,9 +49,7 @@ module Restitution
       @scores_niveau1_standardises ||= Restitution::ScoresStandardises.new(scores_niveau1)
     end
 
-    def synthese
-      interpreteur_niveau1.synthese
-    end
+    delegate :synthese, to: :interpreteur_niveau1
 
     def interpretations_niveau1_cefr
       interpreteur_niveau1.interpretations_cefr

--- a/app/models/restitution/inventaire.rb
+++ b/app/models/restitution/inventaire.rb
@@ -23,7 +23,7 @@ module Restitution
       end
 
       def nombre_de_non_remplissage
-        compte_reponse { |reponse| !reponse['quantite'].present? }
+        compte_reponse { |reponse| reponse['quantite'].blank? }
       end
 
       def nombre_erreurs_sauf_de_non_remplissage

--- a/app/models/restitution/maintenance/score_vocabulaire.rb
+++ b/app/models/restitution/maintenance/score_vocabulaire.rb
@@ -39,7 +39,7 @@ module Restitution
         return 0 if nombre.zero?
 
         temps_moyen_normalise = temps_moyen_normalise(nom_moyenne, metrique_des_temps)
-        return 0 unless temps_moyen_normalise.present?
+        return 0 if temps_moyen_normalise.blank?
 
         nombre / temps_moyen_normalise
       end

--- a/app/models/restitution/standardisateur_glissant.rb
+++ b/app/models/restitution/standardisateur_glissant.rb
@@ -10,14 +10,14 @@ module Restitution
     end
 
     def moyennes_metriques
-      @moyennes_metriques ||= @metriques.each_with_object({}) do |metrique, memo|
-        memo[metrique] = moyenne_metrique(metrique)
+      @moyennes_metriques ||= @metriques.index_with do |metrique|
+        moyenne_metrique(metrique)
       end
     end
 
     def ecarts_types_metriques
-      @ecarts_types_metriques ||= @metriques.each_with_object({}) do |metrique, memo|
-        memo[metrique] = ecart_type_metrique(metrique)
+      @ecarts_types_metriques ||= @metriques.index_with do |metrique|
+        ecart_type_metrique(metrique)
       end
     end
 

--- a/app/models/source_aide.rb
+++ b/app/models/source_aide.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class SourceAide < ApplicationRecord
-  enum categorie: %i[prise_en_main animer_restituer presenter_eva]
-  enum type_document: %i[video pdf repertoire web_doc]
+  enum categorie: { prise_en_main: 0, animer_restituer: 1, presenter_eva: 2 }
+  enum type_document: { video: 0, pdf: 1, repertoire: 2, web_doc: 3 }
 
   validates :titre, :description, :url, :categorie, :type_document, presence: true
 

--- a/app/views/admin/evaluations/_demande_aide_illettrisme.arb
+++ b/app/views/admin/evaluations/_demande_aide_illettrisme.arb
@@ -9,6 +9,6 @@ div class: 'demande-aide' do
   end
   div class: 'aide-cta' do
     text_node link_to t('.aide_cta'), Eva::LIEN_DEMANDE_ACCOMPAGNEMENT_ILLETTRISME,
-                      target: '_blank', class: 'action'
+                      target: '_blank', class: 'action', rel: 'noopener'
   end
 end

--- a/app/views/admin/structures/_show.html.arb
+++ b/app/views/admin/structures/_show.html.arb
@@ -26,7 +26,7 @@ end
 h3 'Utilisateurs'
 table_for comptes, class: 'index_table' do
   column(:nom_complet) do |compte|
-    compte.nom_complet.blank? ? 'Nom inconnu' : compte.nom_complet
+    compte.nom_complet.presence || 'Nom inconnu'
   end
   column :email
   column :statut_validation

--- a/lib/tasks/nettoyage.rake
+++ b/lib/tasks/nettoyage.rake
@@ -53,7 +53,7 @@ namespace :nettoyage do
     return if Rails.env.production?
 
     Question.find_each do |question|
-      fichier_illustration = File.open(File.join(Rails.root, 'lib/assets/illustration.jpg'))
+      fichier_illustration = File.open(Rails.root.join('lib/assets/illustration.jpg'))
       question.illustration.attach(
         io: fichier_illustration,
         filename: 'illustration.jpg',
@@ -95,7 +95,7 @@ namespace :nettoyage do
   task ajoute_evenements_termines: :environment do
     Partie.find_each do |partie|
       evenements = Evenement.where(partie: partie)
-      next if evenements.where(nom: 'finSituation').exists?
+      next if evenements.exists?(nom: 'finSituation')
 
       restitution = FabriqueRestitution.instancie partie
       next unless restitution.termine?
@@ -150,8 +150,8 @@ namespace :nettoyage do
   end
 
   def supprime_espace_inutile(objet, attributs)
-    changements = attributs.each_with_object({}) do |str, hsh|
-      hsh[str] = objet.send(str)&.squish
+    changements = attributs.index_with do |str|
+      objet.send(str)&.squish
     end
     objet.update(changements)
   end

--- a/spec/features/admin/evenement_spec.rb
+++ b/spec/features/admin/evenement_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'Admin - Evenement', type: :feature do
-  let(:chemin) { "#{Rails.root}/spec/support/evenement/donnees.json" }
+  let(:chemin) { Rails.root.join('spec/support/evenement/donnees.json') }
   let(:donnees) { JSON.parse(File.read(chemin)) }
   let(:situation) { create :situation_inventaire, libelle: 'Inventaire' }
   let(:campagne) { create :campagne }

--- a/spec/integrations/anonymisation/structure_spec.rb
+++ b/spec/integrations/anonymisation/structure_spec.rb
@@ -27,7 +27,8 @@ describe Anonymisation::Structure, type: :integration do
     end
 
     before do
-      structure.update_attribute :code_postal, nil
+      structure.code_postal = nil
+      structure.save(validate: false)
     end
 
     it 'anonymise une structure' do

--- a/spec/integrations/restitution/livraison_spec.rb
+++ b/spec/integrations/restitution/livraison_spec.rb
@@ -19,15 +19,15 @@ describe Restitution::Livraison, type: :integration do
     before do
       create(:evenement_demarrage,
              partie: partie1,
-             date: Time.local(2019, 10, 9, 10, 1, 20))
+             date: Time.zone.local(2019, 10, 9, 10, 1, 20))
       create(:evenement_affichage_question_qcm,
              partie: partie1,
              donnees: { question: question_numeratie.id },
-             date: Time.local(2019, 10, 9, 10, 1, 21))
+             date: Time.zone.local(2019, 10, 9, 10, 1, 21))
       create(:evenement_reponse,
              partie: partie1,
              donnees: { question: question_numeratie.id, reponse: bon_choix.id },
-             date: Time.local(2019, 10, 9, 10, 1, 22))
+             date: Time.zone.local(2019, 10, 9, 10, 1, 22))
     end
 
     it do

--- a/spec/integrations/restitution/maintenance_spec.rb
+++ b/spec/integrations/restitution/maintenance_spec.rb
@@ -12,11 +12,11 @@ describe Restitution::Maintenance, type: :integration do
     before do
       create(:evenement_demarrage,
              partie: partie1,
-             date: Time.local(2019, 10, 9, 10, 1, 20))
+             date: Time.zone.local(2019, 10, 9, 10, 1, 20))
       create(:evenement_apparition_mot,
              partie: partie1,
              donnees: { 'mot' => 'revu', 'type' => 'neutre' },
-             date: Time.local(2019, 10, 9, 10, 1, 21))
+             date: Time.zone.local(2019, 10, 9, 10, 1, 21))
     end
 
     it do

--- a/spec/jobs/anonymisation_evaluations_job_spec.rb
+++ b/spec/jobs/anonymisation_evaluations_job_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe AnonymisationEvaluationsJob, type: :job do
   it "anonymise les évaluations de plus d'un an" do
     ancienne_evaluation = create :evaluation, created_at: 2.years.ago
-    evaluation_recente = create :evaluation, created_at: 11.month.ago
+    evaluation_recente = create :evaluation, created_at: 11.months.ago
     evaluation_deja_anonymise = create :evaluation, anonymise_le: 1.month.ago,
                                                     created_at: 2.years.ago,
                                                     nom: 'deja anonymise'

--- a/spec/models/restitution/avec_entrainement/temps_entrainement_spec.rb
+++ b/spec/models/restitution/avec_entrainement/temps_entrainement_spec.rb
@@ -16,7 +16,7 @@ describe Restitution::AvecEntrainement::TempsEntrainement do
 
     context 'avec un seul événement' do
       let(:evenements) do
-        [build(:evenement_demarrage_entrainement, date: Time.local(2019, 10, 9, 10, 2))]
+        [build(:evenement_demarrage_entrainement, date: Time.zone.local(2019, 10, 9, 10, 2))]
       end
 
       it { expect(metrique_temps_entrainement).to eq 0.minutes }
@@ -24,11 +24,11 @@ describe Restitution::AvecEntrainement::TempsEntrainement do
 
     context "d'un entrainement complet" do
       let(:evenements) do
-        [build(:evenement_demarrage_entrainement, date: Time.local(2019, 10, 9, 10, 2)),
+        [build(:evenement_demarrage_entrainement, date: Time.zone.local(2019, 10, 9, 10, 2)),
          build(:evenement_identification_danger,
                donnees: { reponse: 'oui', danger: 'danger' },
-               date: Time.local(2019, 10, 9, 10, 3)),
-         build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 7))]
+               date: Time.zone.local(2019, 10, 9, 10, 3)),
+         build(:evenement_qualification_danger, date: Time.zone.local(2019, 10, 9, 10, 7))]
       end
 
       it { expect(metrique_temps_entrainement).to eq 5.minutes }

--- a/spec/models/restitution/avec_entrainement_spec.rb
+++ b/spec/models/restitution/avec_entrainement_spec.rb
@@ -10,9 +10,9 @@ describe Restitution::AvecEntrainement do
     context "ignore les évenements d'entrainement même s'ils ont la même date" do
       let(:demarrage_entrainement) do
         build(:evenement_demarrage_entrainement,
-              date: Time.local(2019, 10, 9, 10, 0))
+              date: Time.zone.local(2019, 10, 9, 10, 0))
       end
-      let(:demarrage) { build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)) }
+      let(:demarrage) { build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)) }
       let(:evenements) { [demarrage_entrainement, demarrage] }
 
       it { expect(restitution.evenements_entrainement).to eq [demarrage_entrainement] }

--- a/spec/models/restitution/base/temps_total_spec.rb
+++ b/spec/models/restitution/base/temps_total_spec.rb
@@ -19,24 +19,24 @@ describe Restitution::Base::TempsTotal do
       let(:evenements_entrainement) { [] }
       let(:evenements_situation) do
         [
-          build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-          build(:evenement_fin_situation, date: Time.local(2019, 10, 9, 10, 1))
+          build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
+          build(:evenement_fin_situation, date: Time.zone.local(2019, 10, 9, 10, 1))
         ]
       end
 
-      it { expect(metrique_temps_total).to eq 1.minutes }
+      it { expect(metrique_temps_total).to eq 1.minute }
     end
 
     context 'situation complete' do
       let(:evenements_entrainement) do
         [
-          build(:evenement_demarrage_entrainement, date: Time.local(2019, 10, 9, 10, 0))
+          build(:evenement_demarrage_entrainement, date: Time.zone.local(2019, 10, 9, 10, 0))
         ]
       end
       let(:evenements_situation) do
         [
-          build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 1)),
-          build(:evenement_fin_situation, date: Time.local(2019, 10, 9, 10, 2))
+          build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 1)),
+          build(:evenement_fin_situation, date: Time.zone.local(2019, 10, 9, 10, 2))
         ]
       end
 

--- a/spec/models/restitution/illettrisme/temps_bonnes_reponses_spec.rb
+++ b/spec/models/restitution/illettrisme/temps_bonnes_reponses_spec.rb
@@ -25,10 +25,10 @@ describe Restitution::Illettrisme::TempsBonnesReponses do
       let(:evenements_reponses) do
         [
           build(:evenement_affichage_question_qcm, donnees: { question: question_numeratie.id },
-                                                   date: Time.local(2019, 10, 9, 10, 1, 21)),
+                                                   date: Time.zone.local(2019, 10, 9, 10, 1, 21)),
           build(:evenement_reponse, donnees: { question: question_numeratie.id,
                                                reponse: bon_choix.id },
-                                    date: Time.local(2019, 10, 9, 10, 1, 22))
+                                    date: Time.zone.local(2019, 10, 9, 10, 1, 22))
         ]
       end
       it { expect(temps_bonnes_reponses_numeratie).to eq([1]) }
@@ -38,10 +38,10 @@ describe Restitution::Illettrisme::TempsBonnesReponses do
       let(:evenements_reponses) do
         [
           build(:evenement_affichage_question_qcm, donnees: { question: question_numeratie.id },
-                                                   date: Time.local(2019, 10, 9, 10, 1, 21)),
+                                                   date: Time.zone.local(2019, 10, 9, 10, 1, 21)),
           build(:evenement_reponse, donnees: { question: question_numeratie.id,
                                                reponse: mauvais_choix.id },
-                                    date: Time.local(2019, 10, 9, 10, 1, 22))
+                                    date: Time.zone.local(2019, 10, 9, 10, 1, 22))
         ]
       end
       it { expect(temps_bonnes_reponses_numeratie).to eq([]) }
@@ -55,10 +55,10 @@ describe Restitution::Illettrisme::TempsBonnesReponses do
       let(:evenements_reponses) do
         [
           build(:evenement_affichage_question_qcm, donnees: { question: question_ccf.id },
-                                                   date: Time.local(2019, 10, 9, 10, 1, 21)),
+                                                   date: Time.zone.local(2019, 10, 9, 10, 1, 21)),
           build(:evenement_reponse, donnees: { question: question_ccf.id,
                                                reponse: bon_choix_ccf.id },
-                                    date: Time.local(2019, 10, 9, 10, 1, 22))
+                                    date: Time.zone.local(2019, 10, 9, 10, 1, 22))
         ]
       end
       it { expect(temps_bonnes_reponses_numeratie).to eq([]) }
@@ -68,7 +68,7 @@ describe Restitution::Illettrisme::TempsBonnesReponses do
       let(:evenements_reponses) do
         [
           build(:evenement_affichage_question_qcm, donnees: { question: question_numeratie.id },
-                                                   date: Time.local(2019, 10, 9, 10, 1, 21))
+                                                   date: Time.zone.local(2019, 10, 9, 10, 1, 21))
         ]
       end
       it { expect(temps_bonnes_reponses_numeratie).to eq([]) }

--- a/spec/models/restitution/inventaire_spec.rb
+++ b/spec/models/restitution/inventaire_spec.rb
@@ -8,10 +8,10 @@ describe Restitution::Inventaire do
   describe Restitution::Inventaire::Essai do
     it 'retourne le temps depuis le début de la situation' do
       evenements = [
-        build(:evenement_ouverture_contenant, date: 2.minute.ago),
+        build(:evenement_ouverture_contenant, date: 2.minutes.ago),
         build(:evenement_ouverture_contenant, date: 1.minute.ago)
       ]
-      restitution = described_class.new(campagne, evenements, 5.minute.ago)
+      restitution = described_class.new(campagne, evenements, 5.minutes.ago)
       expect(restitution.temps_total).to be_within(0.1).of(240)
     end
 
@@ -27,7 +27,7 @@ describe Restitution::Inventaire do
                   }
                 })
         ]
-        restitution = described_class.new(campagne, evenements, 5.minute.ago)
+        restitution = described_class.new(campagne, evenements, 5.minutes.ago)
         expect(restitution.nombre_erreurs).to eql(0)
         expect(restitution.nombre_de_non_remplissage).to eql(0)
         expect(restitution.nombre_erreurs_sauf_de_non_remplissage).to eql(0)
@@ -44,7 +44,7 @@ describe Restitution::Inventaire do
                   }
                 })
         ]
-        restitution = described_class.new(campagne, evenements, 5.minute.ago)
+        restitution = described_class.new(campagne, evenements, 5.minutes.ago)
         expect(restitution.nombre_erreurs).to eql(2)
         expect(restitution.nombre_de_non_remplissage).to eql(0)
         expect(restitution.nombre_erreurs_sauf_de_non_remplissage).to eql(2)
@@ -54,7 +54,7 @@ describe Restitution::Inventaire do
         evenements = [
           build(:evenement_ouverture_contenant)
         ]
-        restitution = described_class.new(campagne, evenements, 5.minute.ago)
+        restitution = described_class.new(campagne, evenements, 5.minutes.ago)
         expect(restitution.nombre_erreurs).to be_nil
         expect(restitution.nombre_de_non_remplissage).to be_nil
         expect(restitution.nombre_erreurs_sauf_de_non_remplissage).to be_nil
@@ -71,7 +71,7 @@ describe Restitution::Inventaire do
                   }
                 })
         ]
-        restitution = described_class.new(campagne, evenements, 5.minute.ago)
+        restitution = described_class.new(campagne, evenements, 5.minutes.ago)
         expect(restitution.nombre_erreurs).to eql(1)
         expect(restitution.nombre_de_non_remplissage).to eql(1)
         expect(restitution.nombre_erreurs_sauf_de_non_remplissage).to eql(0)

--- a/spec/models/restitution/securite/attention_visuo_spaciale_spec.rb
+++ b/spec/models/restitution/securite/attention_visuo_spaciale_spec.rb
@@ -26,7 +26,7 @@ describe Restitution::Securite::AttentionVisuoSpaciale do
 
     context "avec identification du danger après avoir activé l'aide" do
       let(:evenements) do
-        [build(:evenement_demarrage, date: 3.minute.ago),
+        [build(:evenement_demarrage, date: 3.minutes.ago),
          build(:activation_aide, date: 2.minutes.ago),
          build(:evenement_identification_danger,
                donnees: { reponse: 'oui', danger: danger_visuo_spatial },
@@ -37,11 +37,11 @@ describe Restitution::Securite::AttentionVisuoSpaciale do
 
     context "avec identification du danger avant avoir activé l'aide" do
       let(:evenements) do
-        [build(:evenement_demarrage, date: 3.minute.ago),
+        [build(:evenement_demarrage, date: 3.minutes.ago),
          build(:evenement_identification_danger,
                donnees: { reponse: 'oui', danger: danger_visuo_spatial },
-               date: 2.minute.ago),
-         build(:activation_aide, date: 1.minutes.ago)]
+               date: 2.minutes.ago),
+         build(:activation_aide, date: 1.minute.ago)]
       end
       it { expect(metrique_attention_visuo_spaciale).to eq Competence::APTE }
     end

--- a/spec/models/restitution/securite/delai_ouvertures_zones_dangers_spec.rb
+++ b/spec/models/restitution/securite/delai_ouvertures_zones_dangers_spec.rb
@@ -15,42 +15,42 @@ describe Restitution::Securite::DelaiOuverturesZonesDangers do
 
     context 'une zone danger ouverte' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1))]
+               donnees: { danger: 'danger' }, date: Time.zone.local(2019, 10, 9, 10, 1))]
       end
       it { expect(metrique_delai_ouvertures_zones_dangers).to eq [60.0] }
     end
 
     context 'deux zones danger ouverts' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1)),
-         build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2)),
+               donnees: { danger: 'danger' }, date: Time.zone.local(2019, 10, 9, 10, 1)),
+         build(:evenement_qualification_danger, date: Time.zone.local(2019, 10, 9, 10, 2)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'd2' }, date: Time.local(2019, 10, 9, 10, 4, 1.5))]
+               donnees: { danger: 'd2' }, date: Time.zone.local(2019, 10, 9, 10, 4, 1.5))]
       end
       it { expect(metrique_delai_ouvertures_zones_dangers).to eq [60.0, 121.5] }
     end
 
     context 'ignore les zones non dangers ouverts' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: {}, date: Time.local(2019, 10, 9, 10, 1)),
+               donnees: {}, date: Time.zone.local(2019, 10, 9, 10, 1)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 3))]
+               donnees: { danger: 'danger' }, date: Time.zone.local(2019, 10, 9, 10, 3))]
       end
       it { expect(metrique_delai_ouvertures_zones_dangers).to eq [180] }
     end
 
     context 'quand on ne finit pas par une identification' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1)),
-         build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2))]
+               donnees: { danger: 'danger' }, date: Time.zone.local(2019, 10, 9, 10, 1)),
+         build(:evenement_qualification_danger, date: Time.zone.local(2019, 10, 9, 10, 2))]
       end
       it { expect(metrique_delai_ouvertures_zones_dangers).to eq [60] }
     end

--- a/spec/models/restitution/securite/temps_bonnes_qualifications_dangers_spec.rb
+++ b/spec/models/restitution/securite/temps_bonnes_qualifications_dangers_spec.rb
@@ -3,153 +3,160 @@
 require 'rails_helper'
 
 describe Restitution::Securite::TempsBonnesQualificationsDangers do
-  let(:metrique_temps_bonnes_qualifications_dangers) do
+  let(:temps_bonnes_qualifications_dangers) do
     described_class.new.calcule(evenements_decores(evenements, :securite), [])
   end
 
   describe '#temps_bonnes_qualifications_dangers' do
     context 'sans évenement' do
-      let(:evenements) { [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0))] }
-      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq({}) }
+      let(:evenements) { [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0))] }
+      it { expect(temps_bonnes_qualifications_dangers).to eq({}) }
     end
 
     context 'avec une bonne qualification' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
+               donnees: { danger: 'casque' }, date: Time.zone.local(2019, 10, 9, 10, 1)),
          build(:evenement_qualification_danger,
                donnees: { reponse: 'bonne', danger: 'casque' },
-               date: Time.local(2019, 10, 9, 10, 2))]
+               date: Time.zone.local(2019, 10, 9, 10, 2))]
       end
-      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq('casque' => 60) }
+      it { expect(temps_bonnes_qualifications_dangers).to eq('casque' => 60) }
     end
 
     context 'avec deux bonnes qualifications pour des dangers différents' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
+               donnees: { danger: 'casque' }, date: Time.zone.local(2019, 10, 9, 10, 1)),
          build(:evenement_qualification_danger,
                donnees: { reponse: 'bonne', danger: 'casque' },
-               date: Time.local(2019, 10, 9, 10, 2)),
+               date: Time.zone.local(2019, 10, 9, 10, 2)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'camion' }, date: Time.local(2019, 10, 9, 10, 3)),
+               donnees: { danger: 'camion' }, date: Time.zone.local(2019, 10, 9, 10, 3)),
          build(:evenement_qualification_danger,
                donnees: { reponse: 'bonne', danger: 'camion' },
-               date: Time.local(2019, 10, 9, 10, 5))]
+               date: Time.zone.local(2019, 10, 9, 10, 5))]
       end
       it do
-        temps = metrique_temps_bonnes_qualifications_dangers
+        temps = temps_bonnes_qualifications_dangers
         expect(temps).to eq('casque' => 60, 'camion' => 120)
       end
     end
 
     context 'avec deux bonnes qualifications pour le même danger, on prend la première' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
+               donnees: { danger: 'casque' }, date: Time.zone.local(2019, 10, 9, 10, 1)),
          build(:evenement_qualification_danger,
                donnees: { reponse: 'bonne', danger: 'casque' },
-               date: Time.local(2019, 10, 9, 10, 2)),
+               date: Time.zone.local(2019, 10, 9, 10, 2)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 3)),
+               donnees: { danger: 'casque' }, date: Time.zone.local(2019, 10, 9, 10, 3)),
          build(:evenement_qualification_danger,
                donnees: { reponse: 'bonne', danger: 'casque' },
-               date: Time.local(2019, 10, 9, 10, 5))]
+               date: Time.zone.local(2019, 10, 9, 10, 5))]
       end
       it do
-        temps = metrique_temps_bonnes_qualifications_dangers
+        temps = temps_bonnes_qualifications_dangers
         expect(temps).to eq('casque' => 60)
       end
     end
 
     context 'ignore les mauvaises qualifications' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 1)),
+               donnees: { danger: 'd1' }, date: Time.zone.local(2019, 10, 9, 10, 1)),
          build(:evenement_qualification_danger,
-               donnees: { reponse: 'mauvais', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 2))]
+               donnees: { reponse: 'mauvais', danger: 'd1' },
+               date: Time.zone.local(2019, 10, 9, 10, 2))]
       end
-      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq({}) }
+      it { expect(temps_bonnes_qualifications_dangers).to eq({}) }
     end
 
     context 'ignore les mauvaises qualifications précédant une bonne qualification' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 1)),
+               donnees: { danger: 'd1' }, date: Time.zone.local(2019, 10, 9, 10, 1)),
          build(:evenement_qualification_danger,
-               donnees: { reponse: 'mauvais', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 2)),
+               donnees: { reponse: 'mauvais', danger: 'd1' },
+               date: Time.zone.local(2019, 10, 9, 10, 2)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 3)),
+               donnees: { danger: 'd1' }, date: Time.zone.local(2019, 10, 9, 10, 3)),
          build(:evenement_qualification_danger,
-               donnees: { reponse: 'bonne', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 5))]
+               donnees: { reponse: 'bonne', danger: 'd1' },
+               date: Time.zone.local(2019, 10, 9, 10, 5))]
       end
-      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq('d1' => 120) }
+      it { expect(temps_bonnes_qualifications_dangers).to eq('d1' => 120) }
     end
 
     context 'ignore les mauvaises qualifications même suivant une bonne qualification' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 1)),
+               donnees: { danger: 'd1' }, date: Time.zone.local(2019, 10, 9, 10, 1)),
          build(:evenement_qualification_danger,
-               donnees: { reponse: 'bonne', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 2)),
+               donnees: { reponse: 'bonne', danger: 'd1' },
+               date: Time.zone.local(2019, 10, 9, 10, 2)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 3)),
+               donnees: { danger: 'd1' }, date: Time.zone.local(2019, 10, 9, 10, 3)),
          build(:evenement_qualification_danger,
-               donnees: { reponse: 'mauvais', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 5))]
+               donnees: { reponse: 'mauvais', danger: 'd1' },
+               date: Time.zone.local(2019, 10, 9, 10, 5))]
       end
-      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq('d1' => 60) }
+      it { expect(temps_bonnes_qualifications_dangers).to eq('d1' => 60) }
     end
 
     context 'ouverture sans qualification' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1))]
+               donnees: { danger: 'danger' }, date: Time.zone.local(2019, 10, 9, 10, 1))]
       end
-      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq({}) }
+      it { expect(temps_bonnes_qualifications_dangers).to eq({}) }
     end
 
     context 'ignore les événements hors ouverture et qualification' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_ouverture_zone, date: Time.local(2019, 10, 9, 10, 1))]
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
+         build(:evenement_ouverture_zone, date: Time.zone.local(2019, 10, 9, 10, 1))]
       end
-      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq({}) }
+      it { expect(temps_bonnes_qualifications_dangers).to eq({}) }
     end
 
     context 'ignore les zones non dangers ouvertes' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: {}, date: Time.local(2019, 10, 9, 10, 1)),
+               donnees: {}, date: Time.zone.local(2019, 10, 9, 10, 1)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 2)),
+               donnees: { danger: 'casque' }, date: Time.zone.local(2019, 10, 9, 10, 2)),
          build(:evenement_qualification_danger,
                donnees: { reponse: 'bonne', danger: 'casque' },
-               date: Time.local(2019, 10, 9, 10, 3))]
+               date: Time.zone.local(2019, 10, 9, 10, 3))]
       end
-      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq('casque' => 60) }
+      it { expect(temps_bonnes_qualifications_dangers).to eq('casque' => 60) }
     end
 
     context 'plusieurs ouverture de la même zone' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 1)),
+               donnees: { danger: 'd1' }, date: Time.zone.local(2019, 10, 9, 10, 1)),
          build(:evenement_qualification_danger,
-               donnees: { reponse: 'mauvais', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 2)),
+               donnees: { reponse: 'mauvais', danger: 'd1' },
+               date: Time.zone.local(2019, 10, 9, 10, 2)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 3)),
+               donnees: { danger: 'd1' }, date: Time.zone.local(2019, 10, 9, 10, 3)),
          build(:evenement_qualification_danger,
-               donnees: { reponse: 'bonne', danger: 'd1' }, date: Time.local(2019, 10, 9, 10, 4))]
+               donnees: { reponse: 'bonne', danger: 'd1' },
+               date: Time.zone.local(2019, 10, 9, 10, 4))]
       end
-      it { expect(metrique_temps_bonnes_qualifications_dangers).to eq('d1' => 120) }
+      it { expect(temps_bonnes_qualifications_dangers).to eq('d1' => 120) }
     end
   end
 end

--- a/spec/models/restitution/securite/temps_recherche_zones_dangers_spec.rb
+++ b/spec/models/restitution/securite/temps_recherche_zones_dangers_spec.rb
@@ -15,21 +15,21 @@ describe Restitution::Securite::TempsRechercheZonesDangers do
 
     context 'une zone danger ouverte' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1))]
+               donnees: { danger: 'casque' }, date: Time.zone.local(2019, 10, 9, 10, 1))]
       end
       it { expect(metrique_temps_recherche_zones_dangers).to eq('casque' => 60) }
     end
 
     context 'deux zones danger ouverts' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
-         build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2)),
+               donnees: { danger: 'casque' }, date: Time.zone.local(2019, 10, 9, 10, 1)),
+         build(:evenement_qualification_danger, date: Time.zone.local(2019, 10, 9, 10, 2)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'camion' }, date: Time.local(2019, 10, 9, 10, 4))]
+               donnees: { danger: 'camion' }, date: Time.zone.local(2019, 10, 9, 10, 4))]
       end
       it 'calcule les temps de recherche' do
         temps = metrique_temps_recherche_zones_dangers
@@ -43,10 +43,10 @@ describe Restitution::Securite::TempsRechercheZonesDangers do
 
     context 'quand on ne finit pas par une identification' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
-         build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2))]
+               donnees: { danger: 'casque' }, date: Time.zone.local(2019, 10, 9, 10, 1)),
+         build(:evenement_qualification_danger, date: Time.zone.local(2019, 10, 9, 10, 2))]
       end
 
       it { expect(metrique_temps_recherche_zones_dangers).to eq('casque' => 60) }

--- a/spec/models/restitution/securite/temps_total_ouverture_zones_dangers_spec.rb
+++ b/spec/models/restitution/securite/temps_total_ouverture_zones_dangers_spec.rb
@@ -15,27 +15,27 @@ describe Restitution::Securite::TempsTotalOuvertureZonesDangers do
 
     context 'une zone danger ouverte' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
+               donnees: { danger: 'casque' }, date: Time.zone.local(2019, 10, 9, 10, 1)),
          build(:evenement_qualification_danger,
                donnees: { danger: 'casque' },
-               date: Time.local(2019, 10, 9, 10, 2))]
+               date: Time.zone.local(2019, 10, 9, 10, 2))]
       end
       it { expect(metrique_temps_total_ouverture_zones_dangers).to eq('casque' => 60) }
     end
 
     context 'deux zones danger ouverts' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1)),
+               donnees: { danger: 'casque' }, date: Time.zone.local(2019, 10, 9, 10, 1)),
          build(:evenement_qualification_danger,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 2)),
+               donnees: { danger: 'casque' }, date: Time.zone.local(2019, 10, 9, 10, 2)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'camion' }, date: Time.local(2019, 10, 9, 10, 4)),
+               donnees: { danger: 'camion' }, date: Time.zone.local(2019, 10, 9, 10, 4)),
          build(:evenement_qualification_danger,
-               donnees: { danger: 'camion' }, date: Time.local(2019, 10, 9, 10, 6))]
+               donnees: { danger: 'camion' }, date: Time.zone.local(2019, 10, 9, 10, 6))]
       end
       it 'calcule les temps de chaque zone' do
         temps = metrique_temps_total_ouverture_zones_dangers
@@ -49,9 +49,9 @@ describe Restitution::Securite::TempsTotalOuvertureZonesDangers do
 
     context 'quand on ne finit pas par une qualification' do
       let(:evenements) do
-        [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
+        [build(:evenement_demarrage, date: Time.zone.local(2019, 10, 9, 10, 0)),
          build(:evenement_ouverture_zone,
-               donnees: { danger: 'casque' }, date: Time.local(2019, 10, 9, 10, 1))]
+               donnees: { danger: 'casque' }, date: Time.zone.local(2019, 10, 9, 10, 1))]
       end
 
       it { expect(metrique_temps_total_ouverture_zones_dangers).to eq({}) }

--- a/spec/models/statistiques_campagne_spec.rb
+++ b/spec/models/statistiques_campagne_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe StatistiquesCampagne do
   let(:campagne) { create :campagne }
-  let(:date_creation_evaluation) { Time.local(2021, 1, 1, 8, 2) }
+  let(:date_creation_evaluation) { Time.zone.local(2021, 1, 1, 8, 2) }
   let(:maintenance) { create :situation_maintenance }
 
   describe '#calcule!' do
@@ -38,7 +38,8 @@ describe StatistiquesCampagne do
 
       context 'avec une évaluation avec des événements' do
         let!(:fin1) do
-          create :evenement_fin_situation, partie: partie1, created_at: Time.local(2021, 1, 1, 8, 4)
+          create :evenement_fin_situation, partie: partie1,
+                                           created_at: Time.zone.local(2021, 1, 1, 8, 4)
         end
 
         it do
@@ -55,10 +56,12 @@ describe StatistiquesCampagne do
 
       context 'avec deux évaluations avec des événements' do
         let!(:fin1) do
-          create :evenement_fin_situation, partie: partie1, created_at: Time.local(2021, 1, 1, 8, 4)
+          create :evenement_fin_situation, partie: partie1,
+                                           created_at: Time.zone.local(2021, 1, 1, 8, 4)
         end
         let!(:fin2) do
-          create :evenement_fin_situation, partie: partie2, created_at: Time.local(2021, 1, 1, 8, 6)
+          create :evenement_fin_situation, partie: partie2,
+                                           created_at: Time.zone.local(2021, 1, 1, 8, 6)
         end
 
         it do

--- a/spec/models/statistiques_evaluation_spec.rb
+++ b/spec/models/statistiques_evaluation_spec.rb
@@ -3,24 +3,25 @@
 require 'rails_helper'
 
 describe StatistiquesEvaluation do
-  let(:date_creation_evaluation) { Time.local(2021, 1, 1, 8, 2) }
+  let(:date_creation_evaluation) { Time.zone.local(2021, 1, 1, 8, 2) }
   let(:evaluation) { create :evaluation, nom: 'Test', created_at: date_creation_evaluation }
   let!(:partie) { create :partie, evaluation: evaluation }
 
   describe '#calcule_temps_total' do
     context 'avec une date de fin' do
       it do
-        evaluation.terminee_le = Time.local(2021, 1, 1, 8, 4)
+        evaluation.terminee_le = Time.zone.local(2021, 1, 1, 8, 4)
         expect(described_class.new(evaluation).temps_total).to eql(120.0)
       end
     end
 
     context 'avec des événements' do
       let!(:debut) do
-        create :evenement_demarrage, partie: partie, created_at: Time.local(2021, 1, 1, 8, 3)
+        create :evenement_demarrage, partie: partie, created_at: Time.zone.local(2021, 1, 1, 8, 3)
       end
       let!(:fin) do
-        create :evenement_fin_situation, partie: partie, created_at: Time.local(2021, 1, 1, 8, 4)
+        create :evenement_fin_situation, partie: partie,
+                                         created_at: Time.zone.local(2021, 1, 1, 8, 4)
       end
 
       it { expect(described_class.new(evaluation).temps_total).to eql(120.0) }

--- a/spec/params/evenement_params_spec.rb
+++ b/spec/params/evenement_params_spec.rb
@@ -16,7 +16,7 @@ describe EvenementParams do
       )
 
       evenement_params = described_class.from(params)
-      expect(evenement_params[:date]).to eql(Time.at(1_580_743_539, 508, :millisecond))
+      expect(evenement_params[:date]).to eql(Time.zone.at(1_580_743_539, 508, :millisecond))
       expect(evenement_params.keys.sort).to eql(
         %w[date donnees nom session_id]
       )

--- a/spec/requests/evenements_spec.rb
+++ b/spec/requests/evenements_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe 'Evenement API', type: :request do
   describe 'POST /evenements' do
-    let(:chemin) { "#{Rails.root}/spec/support/evenement/donnees.json" }
+    let(:chemin) { Rails.root.join('spec/support/evenement/donnees.json') }
     let(:donnees) { JSON.parse(File.read(chemin)) }
     let!(:situation_inventaire) { create :situation_inventaire, nom_technique: 'inventaire' }
     let(:evaluation) { create :evaluation }
@@ -39,7 +39,7 @@ describe 'Evenement API', type: :request do
                                         .and change { Partie.count }.by(1)
         expect(response).to have_http_status(201)
         evenement = Evenement.last
-        expect(evenement.date.to_datetime).to eq Time.at(1_551_111_089, 238_000).to_datetime
+        expect(evenement.date.to_datetime).to eq Time.zone.at(1_551_111_089, 238_000).to_datetime
         expect(evenement.position).to eq 58
 
         partie = Partie.last

--- a/spec/tasks/supprime_evenements_apres_la_fin_spec.rb
+++ b/spec/tasks/supprime_evenements_apres_la_fin_spec.rb
@@ -21,8 +21,8 @@ describe 'nettoyage:supprime_evenements_apres_la_fin' do
 
   context 'avec événements après la fin' do
     let!(:evenements) do
-      [create(:evenement_fin_situation, partie: partie, date: 3.minute.ago),
-       create(:evenement_piece_bien_placee, partie: partie, date: 2.minute.ago),
+      [create(:evenement_fin_situation, partie: partie, date: 3.minutes.ago),
+       create(:evenement_piece_bien_placee, partie: partie, date: 2.minutes.ago),
        create(:evenement_piece_bien_placee, partie: partie, date: 1.minute.ago)]
     end
 
@@ -47,7 +47,7 @@ describe 'nettoyage:supprime_evenements_apres_la_fin' do
 
   context 'utilise la position en priorité pour trier' do
     let!(:evenement_fin) do
-      create(:evenement_fin_situation, partie: partie, date: 2.minute.ago, position: 2)
+      create(:evenement_fin_situation, partie: partie, date: 2.minutes.ago, position: 2)
     end
     let!(:evenement_recent_autre) do
       create(:evenement_piece_bien_placee, partie: partie, date: 1.minute.ago, position: 1)
@@ -68,7 +68,7 @@ describe 'nettoyage:supprime_evenements_apres_la_fin' do
 
   context 'regroupe par partie' do
     let(:autre_partie) { create :partie, situation: situation }
-    let!(:evenement_fin) { create(:evenement_fin_situation, partie: partie, date: 2.minute.ago) }
+    let!(:evenement_fin) { create(:evenement_fin_situation, partie: partie, date: 2.minutes.ago) }
     let!(:evenement_recent_autre) do
       create(:evenement_piece_bien_placee, partie: autre_partie, date: 1.minute.ago)
     end


### PR DESCRIPTION
Quand on lance les tests, rubocop nous suggère d'installer l'extension `rubocop-rails`. Je l'ai fait et cette PR propose une partie des évolutions que relève l'extension.
Il reste une vingtaine de changements à apporter, que j'envisage de soumettre dans une PR à part. Ici la PR n'inclut volontairement pas `rubocop-rails` mais prépare son intégration