### PR TITLE
Supprime N+1 query dans l'index des campagnes

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -36,9 +36,7 @@ class Ability # rubocop:disable Metrics/ClassLength
     can :create, Campagne
     can %i[update read], Campagne, comptes_de_meme_structure(compte) if compte.validation_acceptee?
     can %i[update read], Campagne, compte_id: compte.id
-    can :destroy, Campagne do |c|
-      Evaluation.where(campagne: c).count.zero?
-    end
+    can :destroy, Campagne, nombre_evaluations: 0
   end
 
   def droit_evaluation(compte)


### PR DESCRIPTION
Pour chaque ligne de campagne, on vérifie si la campagne a des évaluations.

Or, on a mis en place un système de "count cache" qui pourrait être utilisé et serait plus performant


**avant** : `ActiveRecord: 72.9ms`
**après** : `ActiveRecord: 24.9ms`