### PR TITLE
Modifie la typo du bloc ANLCI et aère le bloc sur la version PDF

### DIFF
--- a/app/assets/stylesheets/restitution_globale/_base.scss
+++ b/app/assets/stylesheets/restitution_globale/_base.scss
@@ -419,10 +419,10 @@
   }
 
   .recommandation-anlci {
-    font-size: .75rem;
-    color: $anlci_orange;
+    padding: 0 1rem 1.5rem;
+    align-items: center;
     border-bottom: 1px solid $anlci_orange;
-    padding-bottom: 1.5rem;
+    color: $anlci_orange;
   }
 
   .litteratie-numeratie-niveau1-anlci {

--- a/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
+++ b/app/assets/stylesheets/restitution_globale/restitution_globale_pdf.scss
@@ -157,4 +157,9 @@ $grid-gutter-width: 1.25rem;
     font-size: 1.3rem;
     border: 0;
   }
+
+  .recommandation-anlci {
+    padding: 1rem 0 0;
+    border-bottom: 0;
+  }
 }


### PR DESCRIPTION
Pour : https://trello.com/c/aBIsbeIX/739-revoir-la-typo-bloc-anlci-sur-le-pdf

Version desktop :

![Capture d’écran 2021-09-08 à 16 35 11](https://user-images.githubusercontent.com/1309612/132529782-836cf20c-e014-47db-96e1-0f51d3928a7a.png)

Version PDF :
 
![Capture d’écran 2021-09-08 à 16 35 18](https://user-images.githubusercontent.com/1309612/132529792-6697aa4f-e595-4c70-9a9f-46bc482243ca.png)
