### PR TITLE
Ajoute un placeholder pour le code postal lors de la création d'une structure

### DIFF
--- a/config/locales/models/structure.yml
+++ b/config/locales/models/structure.yml
@@ -30,7 +30,8 @@ fr:
         update: Modifier
     placeholders:
       structure:
-        nom: Mission Local de Caraces, Pôle Emploi de Marita
+        nom: Mission Locale de Caraces, Pôle Emploi de Marita
+        code_postal: Indiquer le code postal de votre structure
   active_admin:
     resources:
       structure:


### PR DESCRIPTION
Et correction d'une faute d'orthographe à `Mission Locale`

![image](https://user-images.githubusercontent.com/26568502/133750270-fd849905-d775-437b-9ebf-3afbc425a915.png)
