### PR TITLE
Fix : erreur rollbar #163

### DIFF
--- a/app/models/partie.rb
+++ b/app/models/partie.rb
@@ -4,7 +4,7 @@ class Partie < ApplicationRecord
   belongs_to :evaluation
   belongs_to :situation
 
-  validates :session_id, presence: true
+  validates :session_id, presence: true, uniqueness: true
 
   delegate :campagne, to: :evaluation
 

--- a/spec/controllers/evenements_controller_spec.rb
+++ b/spec/controllers/evenements_controller_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::EvenementsController, type: :controller do
+  describe 'POST create' do
+    context "quand la création de l'évènement échoue" do
+      it 'ne crée pas de partie' do
+        evaluation = create :evaluation
+        create :situation_inventaire
+        params = {
+          date: 1_551_111_089_238,
+          nom: nil,
+          donnees: {},
+          situation: 'inventaire',
+          position: 58,
+          session_id: 'O8j78U2xcb2',
+          evaluation_id: evaluation.id
+        }
+
+        expect do
+          post :create, params: params
+        end.to change(Partie, :count)
+          .by(0)
+          .and change(Evenement, :count)
+          .by(0)
+      end
+    end
+  end
+end

--- a/spec/models/partie_spec.rb
+++ b/spec/models/partie_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 describe Partie do
   it { is_expected.to validate_presence_of(:session_id) }
+  it { is_expected.to validate_uniqueness_of(:session_id) }
   it { is_expected.to belong_to(:evaluation) }
   it { is_expected.to belong_to(:situation) }
 end


### PR DESCRIPTION
> PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "index_parties_on_session_id" #390

Aujourd'hui le front peut créer deux events en même temps, et le back tente de créer la partie en même temps. PG retourne alors cette erreur qui provoque une erreur 500.

Pour corriger cette erreur 500, j'ai rajouté une validation activerecord qui viendra catcher l'erreur et donc retourner une 422.
Le fait de retourner une 422 n'est pas un problème pour le front qui retentra l'appel quelques instants après et donc passera.