### PR TITLE
Ajoute un message flash invitation l'utilisateur à confirmer son email

### DIFF
--- a/config/initializers/active_admin_devise_sessions_controller.rb
+++ b/config/initializers/active_admin_devise_sessions_controller.rb
@@ -1,0 +1,13 @@
+class ActiveAdmin::Devise::SessionsController
+  def create
+    self.resource = warden.authenticate!(auth_options)
+    if !resource.confirmed?
+      set_flash_message! :notice, :"signed_in_but_#{resource.inactive_message}"
+    else
+      set_flash_message!(:notice, :signed_in)
+    end
+    sign_in(resource_name, resource)
+    yield resource if block_given?
+    respond_with resource, location: after_sign_in_path_for(resource)
+  end
+end

--- a/config/locales/activeadmin.yml
+++ b/config/locales/activeadmin.yml
@@ -1,4 +1,8 @@
 fr:
+  devise:
+    sessions:
+      compte:
+        signed_in_but_unconfirmed: Votre adresse email n'a pas été confirmé. Veuillez suivre le lien de confirmation qui vous a été envoyé par mail pour éviter la désactivation prochaine de votre compte.
   active_admin:
     footer: |
       Ce site est créé avec ❤️ par <a href='https://beta.gouv.fr/startups/eva.html' target='_blank'>l'équipe</a> eva.


### PR DESCRIPTION
Ce message est ajouté sur le dashboard.
<img width="1283" alt="Capture d’écran 2021-10-04 à 18 48 07" src="https://user-images.githubusercontent.com/298214/135891415-24b621ff-9ab9-454b-8047-ff971602feae.png">

Je n'ai pas réussi à comprendre pourquoi aucun message ne s'affiche sur l'écran de login quand la connexion est refusée pour cause d'email non confirmé.

