### PR TITLE
Sais afficher des durées d'évaluation négatives

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,10 +12,11 @@ module ApplicationHelper
   def formate_duree(duree)
     return if duree.blank?
 
-    duree = duree.to_i
+    signe = duree.negative? ? '-' : ''
+    duree = duree.to_i.abs
     heure_minutes_secondes = [duree / 3600, duree / 60 % 60, duree % 60]
     heure_minutes_secondes.shift if heure_minutes_secondes[0].zero?
-    heure_minutes_secondes.map { |t| t.to_s.rjust(2, '0') }.join(':')
+    "#{signe}#{heure_minutes_secondes.map { |t| t.to_s.rjust(2, '0') }.join(':')}"
   end
 
   def rapport_colonne_class

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -39,6 +39,10 @@ describe ApplicationHelper do
     it 'retourne nil si le paramètre est vide' do
       expect(helper.formate_duree('')).to eql(nil)
     end
+
+    it 'retourne une durée negative' do
+      expect(helper.formate_duree(-8.300185)).to eql('-00:08')
+    end
   end
 
   describe '#cdn_for(fichier)' do


### PR DESCRIPTION
<img width="758" alt="Capture d’écran 2021-10-13 à 18 34 46" src="https://user-images.githubusercontent.com/298214/137175891-57118d3f-efc2-4484-9d10-2f33a122ec70.png">

Cette correction n'est pas la plus fantastique de la terre, mais je ne voulais pas remettre en question cette fonction aujourd'hui.