### PR TITLE
Ajoute une tache qui supprime les événements en doublons

### DIFF
--- a/lib/tasks/nettoyage.rake
+++ b/lib/tasks/nettoyage.rake
@@ -174,4 +174,32 @@ namespace :nettoyage do
       print '.'
     end
   end
+
+  desc 'supprime les doublons'
+  task supprime_doublons_evenements: :environment do
+    logger = RakeLogger.logger
+
+    evenements_en_double = Evenement.find_by_sql('select "session_id", "position"
+from (select
+        "session_id", "position",
+        count(*) "evenementsParGroup"
+    from evenements
+    WHERE "evenements"."position" IS not NULL
+    group by "session_id", "position"
+    ) as "evenements_groupes"
+where "evenementsParGroup" > 1')
+
+    nombre_evenements = evenements_en_double.size
+    logger.info "Nombre d'événements en double : #{nombre_evenements}"
+
+    evenements_en_double.each do |evenement|
+      doubles = Evenement.where(session_id: evenement.session_id,
+                                position: evenement.position)
+      first_id = doubles.first.id
+      doubles.where.not(id: first_id).destroy_all
+
+      nombre_evenements -= 1
+      logger.info "Il reste #{nombre_evenements} événements en double"
+    end
+  end
 end

--- a/spec/tasks/supprime_evenements_en_doubles_spec.rb
+++ b/spec/tasks/supprime_evenements_en_doubles_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'nettoyage:supprime_doublons_evenements' do
+  include_context 'rake'
+
+  let(:situation) { create :situation_livraison }
+  let!(:partie) { create :partie, situation: situation }
+  let(:logger) { RakeLogger.logger }
+
+  before { allow(logger).to receive :info }
+
+  context 'sans événement en double' do
+    let!(:evenements) { [create(:evenement_fin_situation, partie: partie)] }
+
+    it do
+      expect(logger).to receive(:info).exactly(1).times
+      expect { subject.invoke }.to_not(change { Evenement.count })
+    end
+  end
+
+  context 'avec deux événements en même position dans des parties differentes' do
+    let!(:partie2) { create :partie, situation: situation }
+    let!(:evenements) do
+      [create(:evenement_fin_situation, partie: partie, position: 0),
+       create(:evenement_piece_bien_placee, partie: partie, position: 1),
+       create(:evenement_piece_bien_placee, partie: partie2, position: 1)]
+    end
+
+    it { expect { subject.invoke }.to_not(change { Evenement.count }) }
+  end
+
+  context 'avec deux événements en double dans la même partie' do
+    let!(:evenements) do
+      [create(:evenement_fin_situation, partie: partie, position: 0),
+       create(:evenement_piece_bien_placee, partie: partie, position: 1),
+       create(:evenement_piece_bien_placee, partie: partie, position: 2)]
+    end
+
+    before do
+      evenements[2].position = 1
+      evenements[2].save(validate: false)
+    end
+
+    it do
+      expect(logger).to receive(:info).exactly(2).times
+      expect { subject.invoke }.to(change { Evenement.count }.by(-1))
+    end
+  end
+end


### PR DESCRIPTION
Cette PR ne traite que les événement avec une position. Pour dédoublonner les événements sans position c'est beaucoup plus difficile car la date client n'est parfois pas enregistrée avec les secondes.