### PR TITLE
Corrige deprecation warning de autoprefixer

### DIFF
--- a/app/assets/stylesheets/admin/composants/_modal.scss
+++ b/app/assets/stylesheets/admin/composants/_modal.scss
@@ -21,7 +21,7 @@
       
       .actions {
         display: flex;
-        justify-content: end;
+        justify-content: flex-end;
   
         .bouton {
           margin-right: 0.5rem;

--- a/app/assets/stylesheets/admin/pages/_logged_out.scss
+++ b/app/assets/stylesheets/admin/pages/_logged_out.scss
@@ -153,7 +153,7 @@ body.logged_out {
           }
           .actions {
             display: flex;
-            justify-content: end;
+            justify-content: flex-end;
           }
         }
       }
@@ -246,7 +246,7 @@ body.logged_out {
     .actions {
       display: flex;
       justify-content: space-between;
-      align-items: end;
+      align-items: flex-end;
     }
   }
 


### PR DESCRIPTION
Il fallait remplacer :
align-items: end;
par
'align-items: flex-end;