### PR TITLE
Corrige le build des assets en production

### DIFF
--- a/config/locales/views/structures.yml
+++ b/config/locales/views/structures.yml
@@ -11,11 +11,10 @@ fr:
     structure:
       code_postal: 'Code postal : '
       rejoindre_structure: Rejoindre
-   
   admin:
     structures:
       show:
-        introduction:  |
+        introduction: |
           Ici vous pouvez gérer votre structure et vos collègues ayant accès à eva.
         
           Si vous avez besoin d'aide, 


### PR DESCRIPTION
Il s'agissait d'un problème de syntaxe sur le fichier yml de structure

Ce bug empéchait le déploiement sur Scalingo.

Pour débugger cela, j'ai :

- Lancer la tache rake qui buggé lors du déploiement de Scalingo : rake assets:precompile
- Supprimer les changements par fichiers un par un pour retrouver le fichier concerner
- Une fois le fichier structure détecté, analyser le contenu plus en détails