### PR TITLE
Fixe la largeur du contenu structure sans sidebar

### DIFF
--- a/app/assets/stylesheets/admin/pages/_structure.scss
+++ b/app/assets/stylesheets/admin/pages/_structure.scss
@@ -3,6 +3,12 @@
   $grid-gutter-width: 1.25rem;
   @import "../../bootstrap_minimal";
 
+  .without_sidebar {
+    .structure {
+      @include make-col(3);
+    }
+  }
+
   &.show {
     .bloc-structure-infos {
       .panel {

--- a/app/views/admin/structures/_show.html.arb
+++ b/app/views/admin/structures/_show.html.arb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 div class: 'row' do
-  div class: 'offset-1 col-4' do
+  div class: 'structure offset-1 col-4' do
     div class: 'bloc-structure-infos' do
       h2 structure.nom, class: 'titre-entete-page'
 


### PR DESCRIPTION
Pour : https://trello.com/c/h3yISImS/987-la-longueur-des-panels-sur-la-page-structure-nest-pas-la-bonne-quand-je-me-connecte-en-tant-que-conseiller

![Capture d’écran 2021-11-29 à 16 44 44](https://user-images.githubusercontent.com/1309612/143898477-00c5e4ff-8826-472b-bb5c-2ae6050fa93a.png)
