### PR TITLE
Bug : Le titre de l'entête de la page Structure ne doit pas passer derrière l'image lorsqu'il est très long

### DIFF
--- a/app/assets/stylesheets/admin/pages/_structure.scss
+++ b/app/assets/stylesheets/admin/pages/_structure.scss
@@ -10,11 +10,17 @@
   }
 
   &.show {
+    $largeur_image_entete: 12rem;
+    $position_image_entete: 1.5rem;
     .bloc-structure-infos {
+      .titre-entete-page {
+        overflow-wrap: break-word;
+        max-width: calc(100% - #{$largeur_image_entete + $position_image_entete});
+      }
       .panel {
         .introduction-image {
-          width: 12rem;
-          right: 1.5rem;
+          width: $largeur_image_entete;
+          right: $position_image_entete;
         }
 
         .attributes_table {


### PR DESCRIPTION

<img width="808" alt="Capture d’écran 2021-12-03 à 15 01 53" src="https://user-images.githubusercontent.com/81169078/144615599-2a61146c-a3b6-4991-8324-9b21bd099ea0.png">
ec l'image