### PR TITLE
corrige l'affichage de la fenêtre de login sur safari

### DIFF
--- a/app/assets/stylesheets/admin/composants/_forms.scss
+++ b/app/assets/stylesheets/admin/composants/_forms.scss
@@ -56,7 +56,7 @@ form {
         padding-left: 33%;
         display: flex;
         align-items: center;
-        width: auto;
+        width: 100%;
       }
 
       &.libelle-long {


### PR DESCRIPTION
Avant :
<img width="473" alt="Capture d’écran 2021-12-06 à 11 42 40" src="https://user-images.githubusercontent.com/298214/144834549-d2687f14-dd87-40d9-91ef-f7d67f9dd07b.png">

après : 
<img width="459" alt="Capture d’écran 2021-12-06 à 11 58 12" src="https://user-images.githubusercontent.com/298214/144834635-ceec43c7-5c6b-460d-83f3-08260a57961e.png">


