### PR TITLE
Modifie le message de confirmation d'email à l'accueil

### DIFF
--- a/config/locales/activeadmin.yml
+++ b/config/locales/activeadmin.yml
@@ -2,7 +2,7 @@ fr:
   devise:
     sessions:
       compte:
-        signed_in_but_unconfirmed: Votre adresse email n'a pas été confirmée. Veuillez suivre le lien de confirmation qui vous a été envoyé par mail pour éviter la désactivation prochaine de votre compte.
+        signed_in_but_unconfirmed: Votre adresse email n'a pas été confirmée. Veuillez suivre le lien de confirmation qui vous a été envoyé par email.
   active_admin:
     footer: |
       Ce site est créé avec ❤️ par <a href='https://beta.gouv.fr/startups/eva.html' target='_blank'>l'équipe</a> eva.


### PR DESCRIPTION
Cela fait suite à la création du ticket https://trello.com/c/mWbwCiB4/991-afficher-le-message-demail-non-confirm%C3%A9-en-jaune-au-lieu-de-vert

Le message avait un sens de Warning plutot qu'une simple information.
Or, passer ce message en warning se révèle compliqué techniquement.
C'est pourquoi nous avons décidé de simplement modifié la phrase