### PR TITLE
Corrige le chemin du fichier css du PDF

### DIFF
--- a/app/views/admin/evaluations/show.pdf.erb
+++ b/app/views/admin/evaluations/show.pdf.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset='utf-8' />
-    <%= wicked_pdf_stylesheet_link_tag "restitution_globale/restitution_globale_pdf" -%>
+    <%= wicked_pdf_stylesheet_link_tag "admin/pages/restitution_globale/restitution_globale_pdf" -%>
   </head>
    <div class="admin_restitution_globale">
      <%= render partial: "admin/evaluations/restitution_globale", locals: { restitution_globale: restitution_globale, pdf: true } %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,1 +1,1 @@
-Rails.application.config.assets.precompile += %w[active_admin.css active_admin.js restitution_globale/restitution_globale_pdf.css]
+Rails.application.config.assets.precompile += %w[active_admin.css active_admin.js admin/pages/restitution_globale/restitution_globale_pdf.css]


### PR DESCRIPTION
Pour remettre en route la génération de PDF

l'erreur à été remonté par rollbar ce matin suite à la MEP d'hier : https://rollbar.com/eva-betagouv/eva/items/453/?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification

