### PR TITLE
Limite le nombre d'evaluation que l'on peut exporter d'un coup

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -126,7 +126,12 @@ ActiveAdmin.register Evaluation do
     end
 
     def fabrique_restitutions_globales
-      find_collection(except: :pagination).each_with_object({}) do |e, restitutions|
+      evaluations = find_collection(except: :pagination)
+      if evaluations.size > 200
+        raise "Impossible d'exporter plus de 200 evaluations en une seule fois"
+      end
+
+      evaluations.each_with_object({}) do |e, restitutions|
         restitution = FabriqueRestitution.restitution_globale(e)
         restitutions[e.id] = restitution.interpretations
       end

--- a/app/views/admin/evaluations/_competence_niveau1.arb
+++ b/app/views/admin/evaluations/_competence_niveau1.arb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+scope = "admin.restitutions.#{referentiel}.#{competence}"
+
+div class: 'col-auto badge' do
+  if pdf
+    div svg_tag_base64 "#{competence}_#{referentiel}.svg"
+    div svg_tag_base64 "badges/#{referentiel}/#{niveau}.svg" if niveau.present?
+  else
+    div image_tag "#{competence}_#{referentiel}.svg"
+    if niveau.present?
+      div image_tag "badges/#{referentiel}/#{niveau}.svg",
+                    alt: "Niveau #{niveau}"
+    end
+  end
+end
+div class: 'col' do
+  h2 class: 'mb-3 mt-0' do
+    div t(:titre, scope: scope)
+  end
+
+  div class: 'stanine-niveau-francais-mathematique' do
+    if niveau.present?
+      md t("#{niveau}.description", scope: scope)
+    else
+      md t('admin.restitutions.pas_de_score')
+    end
+  end
+end


### PR DESCRIPTION
En attendant de faire la persistence des données d'évaluation, on limite
le nombre d'évaluations que l'on peut exporter d'un coup à 200 pour
éviter de voir notre serveur s'écrouler sur la charge de calcul.