### PR TITLE
Ajoute un bouton 'recalcule' pour recalculer une évaluation

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -18,6 +18,12 @@ ActiveAdmin.register Evaluation do
          order_by: 'libelle_asc'
   filter :created_at
 
+  action_item :recalcule, only: :show, if: proc { can?(:manage, Compte) } do
+    restitution_globale = FabriqueRestitution.restitution_globale(resource)
+    restitution_globale.persiste
+    link_to 'Recalcule', resource_path
+  end
+
   index download_links: lambda {
                           params[:action] == 'show' ? [:pdf] : %i[csv xls json]
                         }, row_class: lambda { |elem|


### PR DESCRIPTION
Ce bouton n'est accessible que pour les super-admin.
Il ne devrait pas servir mais est ajouté en attendant de ne plus avoir de problème de calcule des évaluations