### PR TITLE
Revert "Ajoute un bouton 'recalcule' pour recalculer une évaluation"

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -18,12 +18,6 @@ ActiveAdmin.register Evaluation do
          order_by: 'libelle_asc'
   filter :created_at
 
-  action_item :recalcule, only: :show, if: proc { can?(:manage, Compte) } do
-    restitution_globale = FabriqueRestitution.restitution_globale(resource)
-    restitution_globale.persiste
-    link_to 'Recalcule', resource_path
-  end
-
   index download_links: lambda {
                           params[:action] == 'show' ? [:pdf] : %i[csv xls json]
                         }, row_class: lambda { |elem|


### PR DESCRIPTION
This reverts commit 095290c18dfc2810057a125d7378fc1ff73af072.

ça ne marche pas, le code est executé au chargement de la page, avant d'appuyer sur le bouton.