### PR TITLE
persiste l'évaluation à chaque fois qu'on termine une partie

### DIFF
--- a/app/actions/cree_evenement_action.rb
+++ b/app/actions/cree_evenement_action.rb
@@ -14,10 +14,7 @@ class CreeEvenementAction
     evenement.save.tap do |saved|
       next unless saved
 
-      next unless evenement.nom == FIN_SITUATION
-
-      restitution = FabriqueRestitution.instancie partie
-      restitution.persiste
+      PersisteMetriquesPartieJob.perform_later(partie) if evenement.nom == FIN_SITUATION
     end
   end
 end

--- a/app/controllers/api/evaluations/fins_controller.rb
+++ b/app/controllers/api/evaluations/fins_controller.rb
@@ -7,13 +7,11 @@ module Api
         @competences = []
 
         evaluation = Evaluation.find(params[:evaluation_id])
-
-        restitution_globale = FabriqueRestitution.restitution_globale(evaluation)
-
-        restitution_globale.termine_evaluation!
+        evaluation.update terminee_le: DateTime.now
 
         return unless evaluation.campagne.affiche_competences_fortes?
 
+        restitution_globale = FabriqueRestitution.restitution_globale(evaluation)
         @competences = map_descriptions(restitution_globale.competences)
       end
 

--- a/app/jobs/persiste_metriques_partie_job.rb
+++ b/app/jobs/persiste_metriques_partie_job.rb
@@ -6,5 +6,6 @@ class PersisteMetriquesPartieJob < ApplicationJob
   def perform(partie)
     restitution = FabriqueRestitution.instancie partie
     restitution.persiste
+    PersisteRestitutionJob.perform_later(partie.evaluation)
   end
 end

--- a/app/jobs/persiste_metriques_partie_job.rb
+++ b/app/jobs/persiste_metriques_partie_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class PersisteMetriquesPartieJob < ApplicationJob
+  queue_as :default
+
+  def perform(partie)
+    restitution = FabriqueRestitution.instancie partie
+    restitution.persiste
+  end
+end

--- a/app/jobs/persiste_restitution_job.rb
+++ b/app/jobs/persiste_restitution_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PersisteRestitutionJob < ApplicationJob
+  queue_as :default
+
+  def perform(evaluation)
+    FabriqueRestitution.restitution_globale(evaluation).persiste
+  end
+end

--- a/app/models/restitution/globale.rb
+++ b/app/models/restitution/globale.rb
@@ -21,11 +21,6 @@ module Restitution
       @evaluation.update interpretations
     end
 
-    def termine_evaluation!
-      persiste
-      @evaluation.update terminee_le: DateTime.now
-    end
-
     def utilisateur
       evaluation.nom
     end

--- a/spec/actions/cree_evenement_action_spec.rb
+++ b/spec/actions/cree_evenement_action_spec.rb
@@ -7,39 +7,30 @@ describe CreeEvenementAction do
   let(:situation) { create :situation_securite }
   let!(:demarrage) { create :evenement_demarrage, partie: partie }
   let(:partie) { create :partie, situation: situation, evaluation: evaluation }
-  let(:restitution) { double }
 
-  before do
-    allow(FabriqueRestitution).to receive(:instancie).with(partie).and_return restitution
-  end
-
-  context "sauve l'évenement" do
+  context 'avec un événement quelconque' do
     let(:evenement) { build :evenement_abandon }
-    before { described_class.new(partie, evenement).call }
-    it { expect(evenement).to be_persisted }
+    it "sauve l'évenement mais ne persiste pas les métriques" do
+      expect { described_class.new(partie, evenement).call }
+        .not_to have_enqueued_job(PersisteMetriquesPartieJob)
+      expect(evenement).to be_persisted
+    end
   end
 
   context 'avec un événement fin' do
     let(:evenement_fin) { build :evenement_fin_situation }
 
-    it 'ne persiste pas la restitution quand il ne se sauve pas' do
-      expect(evenement_fin).to receive(:save).and_return(false)
-      expect(restitution).to_not receive(:persiste)
-      described_class.new(partie, evenement_fin).call
+    it 'ne persiste pas les métriques de la partie quand il ne se sauve pas' do
+      expect do
+        expect(evenement_fin).to receive(:save).and_return(false)
+        described_class.new(partie, evenement_fin).call
+      end.not_to have_enqueued_job(PersisteMetriquesPartieJob)
     end
 
-    it 'persiste la restitution quand il se sauve' do
-      expect(restitution).to receive(:persiste)
-      described_class.new(partie, evenement_fin).call
-    end
-  end
-
-  context 'qui ne termine pas la sécurité' do
-    let(:evenement_identification_danger) { build :evenement_identification_danger }
-
-    it do
-      expect(Restitution::Securite).to_not receive(:new)
-      described_class.new(partie, evenement_identification_danger).call
+    it 'persiste les métriques de la partie quand il se sauve' do
+      expect do
+        described_class.new(partie, evenement_fin).call
+      end.to have_enqueued_job(PersisteMetriquesPartieJob).exactly(1)
     end
   end
 end

--- a/spec/jobs/persiste_metriques_partie_job_spec.rb
+++ b/spec/jobs/persiste_metriques_partie_job_spec.rb
@@ -3,12 +3,14 @@
 require 'rails_helper'
 
 describe PersisteMetriquesPartieJob, type: :job do
-  let(:partie) { double }
+  let(:evaluation) { create :evaluation }
+  let(:partie) { create :partie, evaluation: evaluation }
   let(:restitution) { double }
 
   it "persiste les événéments d'une partie" do
     expect(FabriqueRestitution).to receive(:instancie).with(partie).and_return restitution
     expect(restitution).to receive(:persiste)
-    PersisteMetriquesPartieJob.perform_now(partie)
+    expect { PersisteMetriquesPartieJob.perform_now(partie) }
+      .to have_enqueued_job(PersisteRestitutionJob).exactly(1)
   end
 end

--- a/spec/jobs/persiste_metriques_partie_job_spec.rb
+++ b/spec/jobs/persiste_metriques_partie_job_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PersisteMetriquesPartieJob, type: :job do
+  let(:partie) { double }
+  let(:restitution) { double }
+
+  it "persiste les événéments d'une partie" do
+    expect(FabriqueRestitution).to receive(:instancie).with(partie).and_return restitution
+    expect(restitution).to receive(:persiste)
+    PersisteMetriquesPartieJob.perform_now(partie)
+  end
+end

--- a/spec/jobs/persiste_restitution_job_spec.rb
+++ b/spec/jobs/persiste_restitution_job_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PersisteRestitutionJob, type: :job do
+  let(:evaluation) { create :evaluation }
+  let(:restitution) { double }
+
+  it "persiste les événéments d'une partie" do
+    expect(FabriqueRestitution).to receive(:restitution_globale)
+      .with(evaluation)
+      .and_return restitution
+    expect(restitution).to receive(:persiste)
+    PersisteRestitutionJob.perform_now(evaluation)
+  end
+end

--- a/spec/models/fabrique_evenement_spec.rb
+++ b/spec/models/fabrique_evenement_spec.rb
@@ -31,10 +31,9 @@ describe FabriqueEvenement do
     end
 
     it 'assigne les métriques à la partie' do
-      FabriqueEvenement.new(parametres).call
-
-      partie = Partie.order(:created_at).last
-      expect(partie.metriques).not_to eq({})
+      expect do
+        FabriqueEvenement.new(parametres).call
+      end.to have_enqueued_job(PersisteMetriquesPartieJob).exactly(1)
     end
 
     it "retourne l'évènement" do


### PR DESCRIPTION
Cette PR déplace la persistance d'une partie dans un job dédié puis ajoute la persistance de la restitution de l'évaluation.

Ce n'est plus FinController qui s'occupe de la persistance de la restitution de l'évaluation