### PR TITLE
Restitution : supprimer l'erreur sur les compétences transversales pour les campagnes de type compétences de base

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -66,7 +66,7 @@ ActiveAdmin.register Evaluation do
   controller do
     helper_method :restitution_globale, :parties, :auto_positionnement, :statistiques,
                   :mes_avec_redaction_de_notes, :campagnes_accessibles,
-                  :traduction_niveau
+                  :traduction_niveau, :campagne_avec_competences_transversales?
 
     def show
       show! do |format|
@@ -105,6 +105,10 @@ ActiveAdmin.register Evaluation do
         %w[questions livraison].include?(restitution.situation.nom_technique) &&
           !restitution.questions_redaction.empty?
       end
+    end
+
+    def campagne_avec_competences_transversales?
+      @evaluation.campagne.avec_competences_transversales?
     end
 
     def auto_positionnement

--- a/app/models/campagne.rb
+++ b/app/models/campagne.rb
@@ -3,6 +3,8 @@
 require 'generateur_aleatoire'
 
 class Campagne < ApplicationRecord
+  SITUATIONS_AVEC_COMPETENCES_TRANSVERSALES = %w[controle inventaire securite tri].freeze
+
   has_many :situations_configurations, -> { order(position: :asc) }, dependent: :destroy
   belongs_to :questionnaire, optional: true
   belongs_to :compte
@@ -33,6 +35,12 @@ class Campagne < ApplicationRecord
 
   def questionnaire_pour(situation)
     situations_configurations.find_by(situation: situation)&.questionnaire_utile
+  end
+
+  def avec_competences_transversales?
+    situations_configurations.any? do |configuration|
+      SITUATIONS_AVEC_COMPETENCES_TRANSVERSALES.include?(configuration.situation.nom_technique)
+    end
   end
 
   private

--- a/app/views/admin/evaluations/_competences_transversales.arb
+++ b/app/views/admin/evaluations/_competences_transversales.arb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+div id: 'competences_transversales', class: 'page' do
+  render 'entete_page', restitution_globale: restitution_globale
+
+  if pdf
+    h2 t('.competences_fortes_titre'), class: 'text-center my-5'
+  else
+    h2 t('.competences_fortes_titre')
+  end
+
+  div class: 'panel' do
+    div class: 'marges-page' do
+      div class: 'row' do
+        div class: 'col' do
+          if restitution_globale.interpretations_competences_transversales.blank?
+            div class: 'competences-transversales-vides' do
+              md t('.competences_fortes_vides')
+            end
+          end
+
+          interpretations = restitution_globale.interpretations_competences_transversales
+          interpretations.each do |competence, interpretation|
+            div class: 'competence-transversale' do
+              div class: 'conteneur-jauge' do
+                div class: 'jauge'
+                div class: "jauge remplissage remplissage-#{interpretation}"
+              end
+              span class: 'image-competence' do
+                if pdf
+                  svg_tag_base64 "#{competence}.svg"
+                else
+                  image_tag "#{competence}.svg"
+                end
+              end
+              div class: 'informations-competence' do
+                h2 t("#{competence}.nom", scope: 'admin.evaluations.restitution_competence'),
+                   class: 'nom-competence'
+                div class: 'description-competence' do
+                  div md t("#{competence}.stanine#{interpretation}",
+                           scope: 'admin.evaluations.restitution_competence')
+                  div class: 'lien-metier' do
+                    if pdf
+                      text_node svg_tag_base64 'lien.svg', class: 'image-lien'
+                    else
+                      text_node image_tag 'lien.svg', class: 'image-lien'
+                    end
+                    span class: 'align-middle' do
+                      text_node t('.etiquette_lien_metiers')
+                      url_competence = "#{URL_COMPETENCES_SITE_VITRINE}#{competence}/"
+                      a href: url_competence, target: '_blank' do
+                        url_competence
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    render 'pied_page'
+  end
+end

--- a/app/views/admin/evaluations/_restitution_globale.arb
+++ b/app/views/admin/evaluations/_restitution_globale.arb
@@ -23,7 +23,9 @@ div class: 'admin_restitution_globale' do
     end
   end
 
-  render 'competences_transversales', pdf: pdf, restitution_globale: restitution_globale
+  if campagne_avec_competences_transversales?
+    render 'competences_transversales', pdf: pdf, restitution_globale: restitution_globale
+  end
 
   if pdf
     div class: 'page' do

--- a/app/views/admin/evaluations/_restitution_globale.arb
+++ b/app/views/admin/evaluations/_restitution_globale.arb
@@ -23,70 +23,7 @@ div class: 'admin_restitution_globale' do
     end
   end
 
-  div id: 'competences_transversales', class: 'page' do
-    render 'entete_page', restitution_globale: restitution_globale
-
-    if pdf
-      h2 t('.competences_fortes_titre'), class: 'text-center my-5'
-    else
-      h2 t('.competences_fortes_titre')
-    end
-
-    div class: 'panel' do
-      div class: 'marges-page' do
-        div class: 'row' do
-          div class: 'col' do
-            if niveaux_competences.blank?
-              div class: 'competences-transversales-vides' do
-                md t('.competences_fortes_vides')
-              end
-            end
-
-            interpretations = restitution_globale.interpretations_competences_transversales
-            interpretations.each do |competence, interpretation|
-              div class: 'competence-transversale' do
-                div class: 'conteneur-jauge' do
-                  div class: 'jauge'
-                  div class: "jauge remplissage remplissage-#{interpretation}"
-                end
-                span class: 'image-competence' do
-                  if pdf
-                    svg_tag_base64 "#{competence}.svg"
-                  else
-                    image_tag "#{competence}.svg"
-                  end
-                end
-                div class: 'informations-competence' do
-                  h2 t("#{competence}.nom", scope: 'admin.evaluations.restitution_competence'),
-                     class: 'nom-competence'
-                  div class: 'description-competence' do
-                    div md t("#{competence}.stanine#{interpretation}",
-                             scope: 'admin.evaluations.restitution_competence')
-                    div class: 'lien-metier' do
-                      if pdf
-                        text_node svg_tag_base64 'lien.svg', class: 'image-lien'
-                      else
-                        text_node image_tag 'lien.svg', class: 'image-lien'
-                      end
-                      span class: 'align-middle' do
-                        text_node t('.etiquette_lien_metiers')
-                        url_competence = "#{URL_COMPETENCES_SITE_VITRINE}#{competence}/"
-                        a href: url_competence, target: '_blank' do
-                          url_competence
-                        end
-                      end
-                    end
-                  end
-                end
-              end
-            end
-          end
-        end
-      end
-
-      render 'pied_page'
-    end
-  end
+  render 'competences_transversales', pdf: pdf, restitution_globale: restitution_globale
 
   if pdf
     div class: 'page' do

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -27,8 +27,10 @@ fr:
         sante: Santé
       restitution_globale:
         autopositionnement_titre: Questionnaire d'auto-positionnement
-        competences_fortes_titre: 'Vos compétences transversales'
         legende_titre: 'Les compétences transversales sont des compétences que l’on retrouve dans de nombreux métiers'
+        etiquette_lien_metiers: 'Détail et métiers associés : '
+      competences_transversales:
+        competences_fortes_titre: 'Vos compétences transversales'
         competences_fortes_vides: |
           Vos résultats n'ont pas pu être calculés. Les raisons peuvent être les suivantes :
 
@@ -37,7 +39,6 @@ fr:
           - des problèmes techniques ont empêché la sauvegarde de vos données (mauvaise connexion internet par exemple).
 
           Pour obtenir vos scores, n'hésitez pas à repasser le parcours eva plus tard.
-        etiquette_lien_metiers: 'Détail et métiers associés : '
       restitution_competence:
         indetermine: non obs.
         1: 1

--- a/spec/models/campagne_spec.rb
+++ b/spec/models/campagne_spec.rb
@@ -12,9 +12,7 @@ describe Campagne, type: :model do
 
   context 'avec des situations' do
     let(:parcours_type) { ParcoursType.new id: SecureRandom.uuid }
-    let(:situations) do
-      [:bienvenue]
-    end
+    let(:situations) { [:bienvenue] }
     let(:situation_configuration) do
       SituationConfiguration.new situation: situation, questionnaire: questionnaire
     end
@@ -71,6 +69,36 @@ describe Campagne, type: :model do
       let(:situation_configuration) { double(questionnaire_utile: questionnaire) }
       before { bouchonne_config_situation(situation_configuration) }
       it { expect(campagne.questionnaire_pour(situation)).to eq questionnaire }
+    end
+  end
+
+  describe '#avec_competences_transversales?' do
+    let(:campagne) { Campagne.new }
+    let(:maintenance) { create :situation, nom_technique: :maintenance }
+
+    context 'sans situation' do
+      it { expect(campagne.avec_competences_transversales?).to be false }
+    end
+
+    context 'sans situation de compétences transversale' do
+      before do
+        campagne.situations_configurations
+                .push SituationConfiguration.new situation: maintenance
+      end
+
+      it { expect(campagne.avec_competences_transversales?).to be false }
+    end
+
+    context 'avec une situation de compétences transversale' do
+      let!(:tri) { create :situation, nom_technique: :tri }
+
+      before do
+        campagne.situations_configurations
+                .push SituationConfiguration.new situation: maintenance
+        campagne.situations_configurations.push SituationConfiguration.new situation: tri
+      end
+
+      it { expect(campagne.avec_competences_transversales?).to be true }
     end
   end
 end


### PR DESCRIPTION
<img width="1185" alt="Capture d’écran 2022-03-21 à 17 05 47" src="https://user-images.githubusercontent.com/298214/159302193-2d2fffd2-79e6-41c8-89d5-172eb60be09b.png">
