### PR TITLE
Calcule le temps total d'une évaluation non terminé avec les dates clients

### DIFF
--- a/app/models/statistiques/helper.rb
+++ b/app/models/statistiques/helper.rb
@@ -14,7 +14,7 @@ module Statistiques
       private
 
       def sql_duree_evaluation
-        'extract(epoch from (max(evenements.created_at) - evaluations.debutee_le)) as duree'
+        'extract(epoch from (max(evenements.date) - evaluations.debutee_le)) as duree'
       end
     end
   end

--- a/spec/models/statistiques_campagne_spec.rb
+++ b/spec/models/statistiques_campagne_spec.rb
@@ -39,7 +39,7 @@ describe StatistiquesCampagne do
       context 'avec une évaluation avec des événements' do
         let!(:fin1) do
           create :evenement_fin_situation, partie: partie1,
-                                           created_at: Time.zone.local(2021, 1, 1, 8, 4)
+                                           date: Time.zone.local(2021, 1, 1, 8, 4)
         end
 
         it do
@@ -57,11 +57,11 @@ describe StatistiquesCampagne do
       context 'avec deux évaluations avec des événements' do
         let!(:fin1) do
           create :evenement_fin_situation, partie: partie1,
-                                           created_at: Time.zone.local(2021, 1, 1, 8, 4)
+                                           date: Time.zone.local(2021, 1, 1, 8, 4)
         end
         let!(:fin2) do
           create :evenement_fin_situation, partie: partie2,
-                                           created_at: Time.zone.local(2021, 1, 1, 8, 6)
+                                           date: Time.zone.local(2021, 1, 1, 8, 6)
         end
 
         it do

--- a/spec/models/statistiques_evaluation_spec.rb
+++ b/spec/models/statistiques_evaluation_spec.rb
@@ -17,11 +17,11 @@ describe StatistiquesEvaluation do
 
     context 'avec des événements' do
       let!(:debut) do
-        create :evenement_demarrage, partie: partie, created_at: Time.zone.local(2021, 1, 1, 8, 3)
+        create :evenement_demarrage, partie: partie, date: Time.zone.local(2021, 1, 1, 8, 3)
       end
       let!(:fin) do
         create :evenement_fin_situation, partie: partie,
-                                         created_at: Time.zone.local(2021, 1, 1, 8, 4)
+                                         date: Time.zone.local(2021, 1, 1, 8, 4)
       end
 
       it { expect(described_class.new(evaluation).temps_total).to eql(120.0) }


### PR DESCRIPTION
Dans le cas d'une évaluation non terminé, on calcule le temps total en
se basant sur la date des évenements. Il faut utiliser la date client et
non la date de création des evenements pour que ça fonctionne pour le
hors ligne.