### PR TITLE
Supprime la migration qui vient ajouté une unicité sur les évènements

### DIFF
--- a/app/models/evenement.rb
+++ b/app/models/evenement.rb
@@ -2,7 +2,9 @@
 
 class Evenement < ApplicationRecord
   validates :nom, :date, :session_id, presence: true
+  # rubocop:disable Rails/UniqueValidationWithoutIndex
   validates :position, uniqueness: { scope: :session_id }
+  # rubocop:enable Rails/UniqueValidationWithoutIndex
   belongs_to :partie, foreign_key: :session_id, primary_key: :session_id
   delegate :situation, :evaluation, to: :partie
 

--- a/db/migrate/20220420084145_ajoute_unicite_sur_evenements.rb
+++ b/db/migrate/20220420084145_ajoute_unicite_sur_evenements.rb
@@ -1,6 +1,0 @@
-class AjouteUniciteSurEvenements < ActiveRecord::Migration[6.1]
-  def change
-    remove_index :evenements, [:session_id, :position]
-    add_index :evenements, [:position, :session_id], unique: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -160,8 +160,8 @@ ActiveRecord::Schema.define(version: 2022_04_20_151925) do
     t.datetime "updated_at", null: false
     t.string "session_id"
     t.integer "position"
-    t.index ["position", "session_id"], name: "index_evenements_on_position_and_session_id", unique: true
     t.index ["position"], name: "index_evenements_on_position"
+    t.index ["session_id", "position"], name: "index_evenements_on_session_id_and_position"
     t.index ["session_id"], name: "index_evenements_on_session_id"
   end
 


### PR DESCRIPTION

⚠️ Il faut faire rollback la migration avant de déployer en staging avec la commande suivante : `rake db:migrate:down VERSION=20220420084145`