### PR TITLE
Déplace la gem aws-sdk-s3 pour l'installer seulement en environnement…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'activeadmin-xls', git: 'https://github.com/shanser/activeadmin-xls',
 gem 'acts_as_list'
 gem 'addressable'
 gem 'auto_strip_attributes', '~> 2.6'
-gem 'aws-sdk-s3', require: false
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'bootstrap', '~> 4.3', '>= 4.3.1'
 gem 'cancancan'
@@ -89,4 +88,8 @@ group :test do
   gem 'launchy'
   gem 'pdf-reader'
   gem 'shoulda-matchers'
+end
+
+group :production do
+  gem 'aws-sdk-s3', require: false
 end


### PR DESCRIPTION
… de production

Cela permettra par exemple de ne pas l'installer sur la CI et donc de gagner du temps