### PR TITLE
Ne fait pas de vérification de la confirmation de l'email s'il n'y a pas de compte à l'ouverture d'une session

### DIFF
--- a/app/controllers/eva/devise/sessions_controller.rb
+++ b/app/controllers/eva/devise/sessions_controller.rb
@@ -37,6 +37,8 @@ module Eva
       end
 
       def check_compte_confirmation
+        return unless params.key?(:compte)
+
         compte = Compte.find_by email: params[:compte][:email].strip
         return if compte.blank?
 


### PR DESCRIPTION
Pour corriger l'erreur rollbar https://rollbar.com/eva-betagouv/eva/items/571/