### PR TITLE
🐛 L’ordre des situations est aléatoire dans les nouvelles campagnes

### DIFF
--- a/app/models/campagne.rb
+++ b/app/models/campagne.rb
@@ -57,9 +57,11 @@ class Campagne < ApplicationRecord
   def initialise_situations
     initialise_situations_optionnelles
 
+    # rubocop:disable Rails/FindEach
     parcours_type.situations_configurations
                  .includes(situation: :questionnaire)
-                 .find_each do |situation_configuration|
+                 .each do |situation_configuration|
+      # rubocop:enable Rails/FindEach
       construit_situation_configuration(situation_configuration)
     end
   end

--- a/spec/integrations/campagne_spec.rb
+++ b/spec/integrations/campagne_spec.rb
@@ -24,7 +24,7 @@ describe Campagne, type: :integration do
     let!(:situation_livraison) do
       create :situation_livraison, questionnaire: questionnaire_sans_livraison
     end
-    let!(:parcours_type) do
+    let(:parcours_type) do
       parcours = create :parcours_type
       parcours.situations_configurations.create situation: situation_livraison
       parcours
@@ -44,6 +44,25 @@ describe Campagne, type: :integration do
       campagne.reload
       situations_configurations = campagne.situations_configurations.includes(:situation)
       expect(situations_configurations[0].situation).to eq situation_livraison
+    end
+
+    context 'quand le parcours type a plusieurs situations' do
+      let(:situation_maintenance) { create :situation_maintenance }
+
+      let(:parcours_type) do
+        parcours = create :parcours_type
+        parcours.situations_configurations.create situation: situation_maintenance, position: 1
+        parcours.situations_configurations.create situation: situation_livraison, position: 2
+        parcours
+      end
+
+      it "crée la campagne avec les situations du parcours type dans l'ordre donné" do
+        campagne.reload
+
+        situations_configurations = campagne.situations_configurations.includes(:situation)
+        expect(situations_configurations[0].situation).to eq situation_maintenance
+        expect(situations_configurations[1].situation).to eq situation_livraison
+      end
     end
 
     context 'quand il y a des situations optionnelles' do


### PR DESCRIPTION
Il s'agit d'un problème lié à l'utilisation de la méthode `.find_each` car cette dernière ne prend pas en compte les `.order` et donc ne tiens pas compte des postions situations_configurations

J'utilise donc un `.each` car on suppose que l'on aura pas des millions de situations sur un parcours.

L'erreur a été initié dans le commit 
a4c867d32e880e26dec1d4d4c600b16c6e1e89ec - May 3

puis, est revenue dans le commit suivante (suite à un revert du code initial) :
01a6f180a97173c20ddd8d2eead0017449fd1f78 - May 9