### PR TITLE
Ne calcule pas de profil quand le parcours est incomplet (profil indéterminé)

### DIFF
--- a/app/models/restitution/cafe_de_la_place.rb
+++ b/app/models/restitution/cafe_de_la_place.rb
@@ -39,7 +39,7 @@ module Restitution
 
     def parcours_bas
       profils = competences.values
-      return if profils.include?(nil)
+      return ::Competence::NIVEAU_INDETERMINE if profils.include?(::Competence::NIVEAU_INDETERMINE)
 
       position_minimum = profils.map do |profil|
         ::Competence::PROFILS.index(profil)

--- a/spec/models/restitution/cafe_de_la_place_spec.rb
+++ b/spec/models/restitution/cafe_de_la_place_spec.rb
@@ -45,11 +45,11 @@ describe Restitution::CafeDeLaPlace do
     it "quand un profil n'est pas définit" do
       expect(restitution).to receive(:competences)
         .and_return({
-                      lecture_bas: nil,
+                      lecture_bas: ::Competence::NIVEAU_INDETERMINE,
                       comprehension: :profil2,
                       production: :profil4
                     })
-      expect(restitution.parcours_bas).to equal(nil)
+      expect(restitution.parcours_bas).to equal(::Competence::NIVEAU_INDETERMINE)
     end
   end
 


### PR DESCRIPTION
Ce n'était pas des valeurs nil, mais la constante "indéterminé". 😅