### PR TITLE
Empêche la création d'une structure avec un nom et un code postal déj…

### DIFF
--- a/app/models/structure.rb
+++ b/app/models/structure.rb
@@ -3,7 +3,8 @@
 class Structure < ApplicationRecord
   belongs_to :structure_referente, optional: true, class_name: 'StructureAdministrative'
 
-  validates :nom, presence: true, uniqueness: true
+  validates :nom, presence: true
+  validates :nom, uniqueness: { case_sensitive: false, scope: :code_postal }
 
   auto_strip_attributes :nom, squish: true
 

--- a/db/migrate/20220622141727_modifie_index_sur_nom_de_structures.rb
+++ b/db/migrate/20220622141727_modifie_index_sur_nom_de_structures.rb
@@ -1,0 +1,6 @@
+class ModifieIndexSurNomDeStructures < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :structures, :nom, unique: true
+    add_index :structures, [:nom, :code_postal], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_20_103206) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_22_141727) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -272,7 +272,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_20_103206) do
     t.uuid "structure_referente_id"
     t.string "type"
     t.index ["latitude", "longitude"], name: "index_structures_on_latitude_and_longitude"
-    t.index ["nom"], name: "index_structures_on_nom", unique: true
+    t.index ["nom", "code_postal"], name: "index_structures_on_nom_and_code_postal", unique: true
     t.index ["structure_referente_id"], name: "index_structures_on_structure_referente_id"
     t.index ["type"], name: "index_structures_on_type"
   end

--- a/spec/models/structure_spec.rb
+++ b/spec/models/structure_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe Structure, type: :model do
   it { is_expected.to validate_presence_of(:nom) }
-  it { is_expected.to validate_uniqueness_of(:nom) }
+  it { is_expected.to validate_uniqueness_of(:nom).scoped_to(:code_postal).case_insensitive }
 
   it do
     expect(subject).to belong_to(:structure_referente).class_name('StructureAdministrative')


### PR DESCRIPTION
…à existant

On fait en sorte aussi que la validation soit insensible à la casse

ex: afpa ne doit pas être accepté si on a déjà AFPA