### PR TITLE
CMR, je peux acceder au menu Terrain

### DIFF
--- a/app/admin/structures_administratives.rb
+++ b/app/admin/structures_administratives.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register StructureAdministrative do
-  menu parent: 'Terrain', if: proc { can?(:manage, Compte) }
+  menu parent: 'Terrain', if: proc { current_compte.anlci? }
 
   permit_params :nom, :structure_referente_id
 

--- a/app/admin/structures_locales.rb
+++ b/app/admin/structures_locales.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register StructureLocale do
-  menu parent: 'Terrain', if: proc { can?(:manage, Compte) }
+  menu parent: 'Terrain', if: proc { current_compte.anlci? }
   actions :all
 
   permit_params :nom, :type_structure, :code_postal, :structure_referente_id

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -156,5 +156,8 @@ class Ability # rubocop:disable Metrics/ClassLength
   def droits_cmr
     can :read, :all
     cannot(%i[update create destroy], :all)
+    cannot(:read, AnnonceGenerale)
+    cannot(:read, SourceAide)
+    cannot(:read, Aide::QuestionFrequente)
   end
 end

--- a/app/models/compte.rb
+++ b/app/models/compte.rb
@@ -8,6 +8,7 @@ class Compte < ApplicationRecord
          :recoverable, :rememberable, :validatable, :registerable, :confirmable
   ROLES = %w[superadmin charge_mission_regionale admin conseiller compte_generique].freeze
   ADMIN_ROLES = %w[superadmin admin compte_generique].freeze
+  ANLCI_ROLES = %w[superadmin charge_mission_regionale].freeze
   include Comptes::EnvoieEmails
   validates :role, inclusion: { in: ROLES }
   enum :role, ROLES.zip(ROLES).to_h
@@ -45,6 +46,10 @@ class Compte < ApplicationRecord
 
   def compte_refuse?
     validation_refusee?
+  end
+
+  def anlci?
+    ANLCI_ROLES.include?(role)
   end
 
   def au_moins_admin?

--- a/spec/integrations/ability_spec.rb
+++ b/spec/integrations/ability_spec.rb
@@ -154,6 +154,9 @@ describe Ability do
     it { is_expected.to be_able_to(:read, Restitution::Base.new(nil, nil)) }
     it { is_expected.to be_able_to(:read, Actualite) }
     it { is_expected.not_to be_able_to(%i[create update destroy], Actualite) }
+    it { is_expected.not_to be_able_to(:read, AnnonceGenerale) }
+    it { is_expected.not_to be_able_to(:read, SourceAide) }
+    it { is_expected.not_to be_able_to(:read, Aide::QuestionFrequente) }
   end
 
   context 'Compte admin' do


### PR DESCRIPTION
Et les rôle admin, compte générique et conseiller continue de n'avoir accès qu'a leur propre structure (sans voire le menu)

Au passage, on a aussi retiré le menu "Accompagnement" au CMR