### PR TITLE
🐛 Corrige une erreur 500 lorsque l'on va sur une page du détail d'une…

### DIFF
--- a/app/admin/structures_administratives.rb
+++ b/app/admin/structures_administratives.rb
@@ -37,7 +37,7 @@ ActiveAdmin.register StructureAdministrative do
     end
 
     def trouve_structures_dependantes
-      return unless can?(:manage, Compte)
+      return unless current_compte.anlci?
 
       @structures_dependantes = Structure.where(structure_referente: resource)
     end

--- a/spec/features/admin/structure_administrative_spec.rb
+++ b/spec/features/admin/structure_administrative_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 describe 'Admin - Structure administrative', type: :feature do
-  before { se_connecter_comme_superadmin }
+  let(:compte_courant) { create(:compte_superadmin) }
+  before { connecte(compte_courant) }
 
   let!(:structure) { create :structure_administrative, :avec_admin, nom: 'Ma structure' }
 
@@ -39,6 +40,12 @@ describe 'Admin - Structure administrative', type: :feature do
         click_on 'Refuser'
         expect(compte.reload.validation_refusee?).to be true
       end
+    end
+
+    context 'en tant que Chargé de mission régionale' do
+      let(:compte_courant) { create(:compte_charge_mission_regionale, structure: structure) }
+
+      it { expect(page).to have_content structure.nom }
     end
   end
 


### PR DESCRIPTION
… structure administrative en tant que chargé de mission régionale

Ce bug a été remonté par Rollbar : https://rollbar.com/eva-betagouv/eva/items/598/?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification