### PR TITLE
🐛 Certaines structures de la réunion n'ont plus de région

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,7 +1,7 @@
 Geocoder.configure(
   # Geocoding options
   # timeout: 3,                 # geocoding service timeout (secs)
-  lookup: :ban_data_gouv_fr,         # name of geocoding service (symbol)
+  lookup: :nominatim,         # name of geocoding service (symbol)
   # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
   language: :fr,              # ISO-639 language code
   # use_https: false,           # use HTTPS for lookup requests? (if supported)

--- a/lib/tasks/structure.rake
+++ b/lib/tasks/structure.rake
@@ -3,12 +3,11 @@
 namespace :structure do
   desc 'Assigne les régions pour les structures sans région'
   task assigne_region: :environment do
-    Structure.where(region: nil).find_each do |structure|
-      resultats = Geocoder.search("#{structure.code_postal} FRANCE")
-      if (resultat = resultats.first)
-        structure.update(region: resultat.state)
-        puts "assigne région #{resultat.state} pour #{structure.nom}"
-      end
+    structures = Structure.where(region: nil).where.not(code_postal: nil)
+    structures.find_each do |structure|
+      structure.geocode
+      structure.save
+      puts "assigne région \"#{structure.region}\" pour #{structure.nom}"
     end
   end
 end


### PR DESCRIPTION
Utilise l'ancien système de geolocalisation Nominatim car il considère La réunion comme une région contrairement à Adresse API
Le service Nominatim est aussi beaucoup plus rapide à répondre. On avait des problèmes avec Adresse API qui parfois partait en timeout (3s)

![Capture d’écran 2022-07-13 à 16 10 29](https://user-images.githubusercontent.com/7428736/178754428-80a5c89d-c560-41be-8363-9162bd3eab1f.png)
