### PR TITLE
Changement du message de confirmation d'adresse email

### DIFF
--- a/config/locales/devise.yml
+++ b/config/locales/devise.yml
@@ -1,7 +1,7 @@
 fr:
   devise:
     confirmations:
-      confirmed: Merci ! Votre adresse email a bien été validée.
+      confirmed: Merci ! Votre adresse email a bien été validée.
     mailer:
       confirmation_instructions:
         subject: "Confirmez votre adresse email"

--- a/config/locales/devise.yml
+++ b/config/locales/devise.yml
@@ -1,5 +1,7 @@
 fr:
   devise:
+    confirmations:
+      confirmed: Merci ! Votre adresse email a bien été validée.
     mailer:
       confirmation_instructions:
         subject: "Confirmez votre adresse email"


### PR DESCRIPTION
Changement du message lorsque l'on confirme l'email d'un compte.

### Avant :
(le message devise de confirmation par défaut) :
```
Votre compte a bien été confirmé.
```

### Après :
```
Merci ! Votre adresse email a bien été validée.
```

### Impression écran après :

<img width="356" alt="Screenshot 2022-08-08 at 12 40 57" src="https://user-images.githubusercontent.com/1191842/183400225-c6e73fc7-f636-43b2-9370-6e10976c1a45.png">
