### PR TITLE
mise à jour des droits des comptes chargé de mission régionale

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -157,6 +157,7 @@ class Ability # rubocop:disable Metrics/ClassLength
     can :read, :all
     cannot(%i[update create destroy], :all)
     cannot(:read, AnnonceGenerale)
+    cannot(:read, Beneficiaire)
     cannot(:read, SourceAide)
     cannot(:read, Aide::QuestionFrequente)
   end

--- a/spec/integrations/ability_spec.rb
+++ b/spec/integrations/ability_spec.rb
@@ -177,6 +177,7 @@ describe Ability do
       it { is_expected.to be_able_to(:destroy, evaluation_collegue) }
       it { is_expected.to be_able_to(:autoriser, mon_collegue) }
       it { is_expected.to be_able_to(:refuser, mon_collegue) }
+      it { is_expected.not_to be_able_to(:read, Beneficiaire) }
 
       context 'quand un compte est admin' do
         before { mon_collegue.update(role: :admin) }
@@ -263,6 +264,7 @@ describe Ability do
     it { is_expected.to be_able_to(:manage, Restitution::Base.new(campagne_conseiller, nil)) }
     it { is_expected.to be_able_to(:read, Actualite.new) }
     it { is_expected.to be_able_to(:read, ActiveAdmin::Page.new(1, 2, 3)) }
+    it { is_expected.not_to be_able_to(:read, Beneficiaire) }
 
     context 'peut consulter les campagnes de ma structure' do
       let(:mon_collegue) { create :compte, structure: compte_conseiller.structure }

--- a/spec/integrations/ability_spec.rb
+++ b/spec/integrations/ability_spec.rb
@@ -43,6 +43,7 @@ describe Ability do
     it { is_expected.to be_able_to(:manage, Campagne.new) }
     it { is_expected.to be_able_to(:manage, Restitution::Base.new(nil, nil)) }
     it { is_expected.to be_able_to(:manage, Actualite) }
+    it { is_expected.to be_able_to(:manage, Beneficiaire) }
 
     it 'avec une campagne qui a des évaluations' do
       expect(subject).not_to be_able_to(:destroy, campagne_superadmin)
@@ -157,6 +158,7 @@ describe Ability do
     it { is_expected.not_to be_able_to(:read, AnnonceGenerale) }
     it { is_expected.not_to be_able_to(:read, SourceAide) }
     it { is_expected.not_to be_able_to(:read, Aide::QuestionFrequente) }
+    it { is_expected.not_to be_able_to(:read, Beneficiaire) }
   end
 
   context 'Compte admin' do


### PR DESCRIPTION
## Avant : 
un compte chargé de mission régionale à accès en lecture aux Bénéficiaires.

## Après : 
Uniquement les superadmin doivent avoir accès aux Bénéficaires.