### PR TITLE
🐛 Assigne la région Corse pour les structures dont le code postal com…

### DIFF
--- a/app/models/structure.rb
+++ b/app/models/structure.rb
@@ -10,7 +10,9 @@ class Structure < ApplicationRecord
 
   geocoded_by :code_postal, state: :region, params: { countrycodes: 'fr' } do |obj, resultats|
     if (resultat = resultats.first)
-      obj.region = obj.code_postal.start_with?('988') ? 'Nouvelle-Calédonie' : resultat.state
+      obj.region = 'Nouvelle-Calédonie' if obj.code_postal.start_with?('988')
+      obj.region = 'Corse' if obj.code_postal.start_with?('20', '21')
+      obj.region ||= resultat.state
       obj.latitude = resultat.latitude
       obj.longitude = resultat.longitude
     end

--- a/spec/models/structure_spec.rb
+++ b/spec/models/structure_spec.rb
@@ -55,5 +55,45 @@ describe Structure, type: :model do
         expect(structure.region).to eql('Nouvelle-Calédonie')
       end
     end
+
+    describe 'si ma structure a un code postal commençant par 20' do
+      let(:structure) { Structure.new code_postal: '20090' }
+
+      before do
+        Geocoder::Lookup::Test.add_stub(
+          '20090', [
+            {
+              'state' => '',
+              'coordinates' => [41.9333, 8.7507]
+            }
+          ]
+        )
+        structure.valid?
+      end
+
+      it 'lui attribue la région Corse' do
+        expect(structure.region).to eql('Corse')
+      end
+    end
+
+    describe 'si ma structure a un code postal commençant par 21' do
+      let(:structure) { Structure.new code_postal: '20114' }
+
+      before do
+        Geocoder::Lookup::Test.add_stub(
+          '20114', [
+            {
+              'state' => '',
+              'coordinates' => [41.5188, 9.1264]
+            }
+          ]
+        )
+        structure.valid?
+      end
+
+      it 'lui attribue la région Corse' do
+        expect(structure.region).to eql('Corse')
+      end
+    end
   end
 end


### PR DESCRIPTION
…mence par 20 ou 21

On assigne manuellement la région car l'api ne renvoit pas de "state", en effet la Corse n'est pas une région au sens administratif du terme