### PR TITLE
préremplir le code postal de la structure à l'ajout

### DIFF
--- a/app/views/nouvelles_structures/show.html.erb
+++ b/app/views/nouvelles_structures/show.html.erb
@@ -25,6 +25,7 @@
       <h3 class="mb-0"><%= t('.structure.titre') %></h3>
       <p class="description"><%= t('.structure.description') %></p>
       <%= structure.inputs do %>
+        <% structure.object.code_postal = params[:code_postal]&.delete('^0-9') %>
         <%= structure.input :nom, placeholder: t('.placeholders.structure.nom') %>
         <%= structure.input :type_structure, as: :select, collection: collection_types_structures %>
         <%= structure.input :code_postal, placeholder: t('.placeholders.structure.code_postal') %>

--- a/app/views/structures/_bouton_ajouter_une_structure.html.erb
+++ b/app/views/structures/_bouton_ajouter_une_structure.html.erb
@@ -1,3 +1,3 @@
 <div class="actions">
-  <%= link_to t('structures.index.structure_non_referencee'), nouvelle_structure_path, class: 'creer-structure' %>
+  <%= link_to t('structures.index.structure_non_referencee'), nouvelle_structure_path(code_postal: params[:code_postal]), class: 'creer-structure' %>
 </div>


### PR DESCRIPTION
## 🎯 Résultats à atteindre

Le code postal saisi sur la page de recherche est pré-rempli dans la page de création de structure (qui reste modifiable)