### PR TITLE
ne pas créer de nouveau beneficiaire si le beneficiaire existe déjà

### DIFF
--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -15,7 +15,7 @@ class Evaluation < ApplicationRecord
   validates :nom, :debutee_le, presence: true
   belongs_to :campagne, counter_cache: :nombre_evaluations
   belongs_to :beneficiaire, optional: true
-  accepts_nested_attributes_for :beneficiaire
+  accepts_nested_attributes_for :beneficiaire, update_only: true
   attr_accessor :code_campagne
 
   before_validation :trouve_campagne_depuis_code

--- a/lib/tasks/beneficiaires.rake
+++ b/lib/tasks/beneficiaires.rake
@@ -22,7 +22,8 @@ namespace :beneficiaires do
   task supprimer_les_beneficiaires_sans_evaluations: :environment do
     logger = RakeLogger.logger
 
-    beneficiaire_avec_evaluation_ids = Evaluation.where.not(beneficiaire_id: nil).pluck(:beneficiaire_id)
+    beneficiaire_avec_evaluation_ids = Evaluation.where.not(beneficiaire_id: nil)
+                                                 .pluck(:beneficiaire_id)
 
     beneficiaires_sans_evaluation = Beneficiaire.where.not(id: beneficiaire_avec_evaluation_ids)
     total = beneficiaires_sans_evaluation.count

--- a/lib/tasks/beneficiaires.rake
+++ b/lib/tasks/beneficiaires.rake
@@ -17,4 +17,22 @@ namespace :beneficiaires do
     end
     logger.info "C'est fini"
   end
+
+  desc 'Supprime les bénéficiaires sans évaluations'
+  task supprimer_les_beneficiaires_sans_evaluations: :environment do
+    logger = RakeLogger.logger
+
+    beneficiaire_avec_evaluation_ids = Evaluation.where.not(beneficiaire_id: nil).pluck(:beneficiaire_id)
+
+    beneficiaires_sans_evaluation = Beneficiaire.where.not(id: beneficiaire_avec_evaluation_ids)
+    total = beneficiaires_sans_evaluation.count
+    count = 0
+    logger.info "Nombre de bénéficiaire sans évaluation à supprimer : #{total}"
+    beneficiaires_sans_evaluation.find_each do |beneficiaire|
+      beneficiaire.destroy
+      count += 1
+      logger.info "#{count}/#{total}"
+    end
+    logger.info "C'est fini"
+  end
 end

--- a/spec/controllers/api/evaluations_controller_spec.rb
+++ b/spec/controllers/api/evaluations_controller_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::EvaluationsController do
+  let(:compte) { create :compte_admin }
+  let(:campagne) { create :campagne, compte: compte }
+  let(:nom) { 'Evaluation de test nom' }
+  let(:evaluation_params) do
+    {
+      nom: nom,
+      debutee_le: DateTime.current,
+      code_campagne: campagne.code
+    }
+  end
+
+  describe 'creation' do
+    it 'ajoute bien une evaluation à la création' do
+      expect do
+        post :create, params: evaluation_params
+      end.to change { Evaluation.count }.by(1)
+    end
+
+    it "lorsqu'on crée une evaluation, on crée un bénéficiaire" do
+      expect do
+        post :create, params: evaluation_params
+      end.to change { Beneficiaire.count }.by(1)
+    end
+  end
+
+  describe 'update' do
+    it "mets à jour le nom de l'évaluation" do
+      evaluation = create :evaluation
+      put :update, params: { id: evaluation.id, nom: nom }
+      expect(evaluation.reload.nom).to eq(nom)
+    end
+
+    it "la mise à jour d'une évaluation ne change pas le nombre de bénéficiaire" do
+      evaluation = create :evaluation
+      expect do
+        put :update, params: { id: evaluation.id, nom: nom }
+      end.to change { Beneficiaire.count }.by(0)
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/models/evaluation_spec.rb
+++ b/spec/models/evaluation_spec.rb
@@ -6,5 +6,6 @@ describe Evaluation do
   it { is_expected.to validate_presence_of :nom }
   it { is_expected.to validate_presence_of :debutee_le }
   it { is_expected.to belong_to :campagne }
+  it { should accept_nested_attributes_for :beneficiaire }
   it { is_expected.to have_one :condition_passation }
 end


### PR DESCRIPTION
Ajout de `update_only` dans `accepts_nested_attributes_for` pour ne pas créer un nouveau bénéficiaire lors du deuxième appel de l'api.

Plus d'information sur `update_only` : https://api.rubyonrails.org/classes/ActiveRecord/NestedAttributes/ClassMethods.html