### PR TITLE
1359 la font weight bold utilisé pour la police work sans nest pas la bonne sur lespace pro

### DIFF
--- a/app/assets/stylesheets/admin/_utilities.scss
+++ b/app/assets/stylesheets/admin/_utilities.scss
@@ -8,6 +8,7 @@
   }
 }
 
-.fw-text-bold {
+.fw-semi-bold {
   font-weight: 600;
 }
+

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -13,6 +13,10 @@ module MarkdownHelper
     markdown ||= Redcarpet::Markdown.new(
       Redcarpet::Render::HTML.new(hard_wrap: true)
     )
-    markdown.render(contenu).html_safe
+    customise_rendu_gras(markdown.render(contenu)).html_safe
+  end
+
+  def customise_rendu_gras(html)
+    html.gsub('<strong>', '<strong class="fw-semi-bold">')
   end
 end

--- a/app/views/components/_banner_confirmation_email.html.arb
+++ b/app/views/components/_banner_confirmation_email.html.arb
@@ -8,7 +8,7 @@ div class: 'card__banner card__banner--alert w-100 d-flex' do
     h4 t('.titre')
     text_node md "#{t('.description.instructions')}<u>#{current_compte.email_a_confirmer}</u>"
     div class: 'd-flex justify-content-between align-items-center' do
-      div t('.description.email_non_recu'), class: 'fw-text-bold'
+      div md t('.description.email_non_recu')
       div do
         link_to t('.description.action'), new_confirmation_path(current_compte),
                 class: 'bouton bouton-principal text-center'

--- a/config/locales/views/components.yml
+++ b/config/locales/views/components.yml
@@ -21,5 +21,5 @@ fr:
       description:
         instructions: 'Consultez votre boîte de réception, nous vous avons envoyé les instructions de confirmation à l’adresse suivante : '
         email_non_recu: |
-          Vous n’avez pas reçu notre email ?
+          **Vous n’avez pas reçu notre email ?**
         action: Renvoyer les instructions de confirmation

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -13,10 +13,20 @@ describe MarkdownHelper do
     end
 
     context 'quand il y a un contenu' do
-      let(:contenu) { '**évaluer les compétences**' }
+      let(:contenu) { '*évaluer les compétences*' }
 
       it 'retourne le contenu traduit en html' do
-        expect(helper.md(contenu)).to match('<p><strong>évaluer les compétences</strong></p>')
+        expect(helper.md(contenu)).to match('<p><em>évaluer les compétences</em></p>')
+      end
+    end
+
+    context 'quand il y a un contenu avec une phrase en gras' do
+      let(:contenu) { '**évaluer les compétences** transversales' }
+
+      it 'retourne le contenu traduit en html avec une font-weight customisé' do
+        html =
+          '<p><strong class="fw-semi-bold">évaluer les compétences</strong> transversales</p>'
+        expect(helper.md(contenu)).to match(html)
       end
     end
   end


### PR DESCRIPTION
Contexte : La` font-weight` de notre texte 'Work-Sans' ne respecte pas le design system. Lorsque l'on génère notre texte en gras grâce à du markdown. Par défaut, la balise `<strong>` génère un font-weight bold (700).

Plutôt que de repasser sur toute l'app pour spécifier chaque balise `<strong>` générée, je me suis aidé du helper pour générer du semi-bold (600).
Quand à nos headers 'Quicksand' eux doivent rester en `font-weight: 700;`.