### PR TITLE
config railt 7 : action_view --> i18n

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   config.hosts << "api.eva-dev"
 
   # Raises error for missing translations.
-  # config.action_view.raise_on_missing_translations = true
+  # config.i18n.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -56,5 +56,5 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations.
-  # config.action_view.raise_on_missing_translations = true
+  # config.i18n.raise_on_missing_translations = true
 end


### PR DESCRIPTION
Pour pouvoir activer `raise_on_missing_translations ` on utilise avec rails 7 :

```
config.i18n.raise_on_missing_translations = true
```

Plus d'info : https://edgeguides.rubyonrails.org/7_0_release_notes.html#action-view