### PR TITLE
config rubocop : Renomme `IgnoredMedods` (qui est devenu obsolete) en `AllowedMethods`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,7 +31,7 @@ Metrics/BlockLength:
     - 'app/views/**/*'
     - 'spec/factories/*'
     - 'Guardfile'
-  IgnoredMethods:
+  AllowedMethods:
     - describe
     - it
     - resource


### PR DESCRIPTION
Pour corriger l'alerte : 
Warning: obsolete parameter `IgnoredMethods` (for `Metrics/BlockLength`) found in .rubocop.yml
`IgnoredMethods` has been renamed to `AllowedMethods` and/or `AllowedPatterns`.