### PR TITLE
1396 🐛 le niveau anlci litteratie retenu lorsque je fais uniquement le parcours bas nest pas le bon les trads sont cassés

### DIFF
--- a/app/models/restitution/evacob/score_module.rb
+++ b/app/models/restitution/evacob/score_module.rb
@@ -4,8 +4,10 @@ module Restitution
   module Evacob
     class ScoreModule
       def calcule(evenements, nom_module)
-        MetriquesHelper.filtre_evenements_reponses(evenements) { |e| e.module?(nom_module) }
-                       .sum(&:score_reponse)
+        evenements_filtres = MetriquesHelper.filtre_evenements_reponses(evenements) do |e|
+          e.module?(nom_module)
+        end
+        evenements_filtres.sum(&:score_reponse) if evenements_filtres.present?
       end
     end
   end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -53,7 +53,7 @@ fr:
         parcours_haut:
           nom: Profil parcours haut
         niveau_anlci_litteratie:
-          Niveau ANLCI littératie
+          nom: Niveau ANLCI littératie
         efficience:
           nom: Efficience
         lecture_bas:

--- a/spec/models/restitution/evacob/score_module_spec.rb
+++ b/spec/models/restitution/evacob/score_module_spec.rb
@@ -13,8 +13,9 @@ describe Restitution::Evacob::ScoreModule do
     end
     let(:question_lodi1) { 'LOdi1' }
     let(:question_lodi2) { 'LOdi2' }
+    let(:question_hpar1) { 'HPar1' }
 
-    context 'somme les scores des réponses' do
+    context 'somme les scores des réponses du module' do
       let(:evenements_reponses) do
         [
           build(:evenement_affichage_question_qcm, donnees: { question: question_lodi1 }),
@@ -29,12 +30,27 @@ describe Restitution::Evacob::ScoreModule do
       it { expect(metrique_score_reponse_orientation).to eq(3.5) }
     end
 
-    context 'avec une réponse sans score' do
+    context 'avec une réponse du module sans score' do
       let(:evenements_reponses) do
         [build(:evenement_reponse, donnees: { question: question_lodi1 })]
       end
 
       it { expect(metrique_score_reponse_orientation).to eq(0) }
+    end
+
+    context 'sans réponse du module orientation' do
+      let(:reponse_parcours_haut) do
+        build(:evenement_reponse, donnees: { question: question_hpar1 })
+      end
+      let(:evenements_reponses) { [reponse_parcours_haut] }
+
+      it { expect(metrique_score_reponse_orientation).to eq(nil) }
+    end
+
+    context 'sans réponse' do
+      let(:evenements_reponses) { [] }
+
+      it { expect(metrique_score_reponse_orientation).to eq(nil) }
     end
   end
 end


### PR DESCRIPTION
Lorsque je saute des questions car je suis réorienté dans ma passation, le score des modules "sautés" ne doit pas être calculés.
Exemple ci dessous, je passe l'orientation et le parcours bas uniquement.
<img width="965" alt="Capture d’écran 2022-09-02 à 15 00 34" src="https://user-images.githubusercontent.com/81169078/188151362-52c85c32-2cdf-41ea-977e-c70a1b8b1813.png">
