### PR TITLE
Création de campagne - Le bloc "personnalisation" s'affiche uniquement après la sélection du parcours

### DIFF
--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -14,6 +14,7 @@
 
 //= require chartkick
 //= require Chart.bundle
+//= require campagnes
 
 jQuery.datetimepicker.setLocale('fr');
 

--- a/app/assets/javascripts/campagnes.js
+++ b/app/assets/javascripts/campagnes.js
@@ -1,0 +1,5 @@
+$(document).ready(function(){
+    $('.input-choix-option-parcours_type').click(function(){
+        $('#zone-de-personnalisation').show();
+    });
+});

--- a/app/assets/stylesheets/admin/composants/_panels.scss
+++ b/app/assets/stylesheets/admin/composants/_panels.scss
@@ -77,3 +77,7 @@ body.logged_out {
     }
   }
 }
+
+.hidden {
+  display: none;
+}

--- a/app/views/admin/campagnes/_form.html.arb
+++ b/app/views/admin/campagnes/_form.html.arb
@@ -23,19 +23,23 @@ div class: 'nouvelle-campagne' do
           div class: 'panel' do
             h2 t('.choix_parcours')
             para t('.explication_choix_parcours'), class: 'description description--secondaire'
-            f.inputs class: 'input-choix' do
+            f.inputs class: 'input-choix input-choix-option-parcours_type' do
               f.input :parcours_type, as: :radio,
                                       collection: collection_parcours_type(parcours_type),
                                       required: true,
                                       label: false
             end
             if resource.new_record?
-              h2 t('.personnalisation')
-              para t('.explication_personnalisation'), class: 'description description--secondaire'
-              f.inputs class: 'input-choix input-choix-option-personnalisation' do
-                f.input :options_personnalisation, as: :check_boxes,
-                                                   collection: collection_options_personnalisation,
-                                                   label: false
+              div id: 'zone-de-personnalisation', class: 'hidden' do
+                h2 t('.personnalisation')
+                para t('.explication_personnalisation'),
+                     class: 'description description--secondaire'
+                f.inputs class: 'input-choix input-choix-option-personnalisation' do
+                  f.input :options_personnalisation,
+                          as: :check_boxes,
+                          collection: collection_options_personnalisation,
+                          label: false
+                end
               end
             end
           end


### PR DESCRIPTION
## 🌟 Enjeux
> On cherche à alléger la page de création de campagne car c'est une des toutes premières pages proposées à un nouvel utilisateur. On fait l'hypothèse que si on propose un formulaire + court qui se déroule par étape

## 🎯 Résultats à atteindre
Le bloc "personnalisation" s'affiche uniquement après la sélection du parcours

