### PR TITLE
fix affichage titre de la section détails d'une évaluation dans la show d'une évaluation

### DIFF
--- a/config/locales/views/lettrisme.yml
+++ b/config/locales/views/lettrisme.yml
@@ -1,8 +1,6 @@
 fr:
   admin:
     evaluations:
-      details_evaluation:
-        titre: Detail
       lettrisme:
         telechargement_des_reponses: 'Télécharger le détail des réponses'
         litteratie:


### PR DESCRIPTION
Détail > Détails de l'évaluation

<img width="886" alt="Capture d’écran 2022-09-15 à 10 23 42" src="https://user-images.githubusercontent.com/81169078/190358216-4c024aea-c0aa-45bf-997b-81b85e969982.png">
<img width="825" alt="Capture d’écran 2022-09-15 à 10 39 05" src="https://user-images.githubusercontent.com/81169078/190358220-a80f8c66-34e9-426b-88a5-b4db096618fe.png">
