### PR TITLE
 Création de campagne : Affiche de manière optionnelle la personnalisation de la rédaction

### DIFF
--- a/app/assets/javascripts/campagnes.js
+++ b/app/assets/javascripts/campagnes.js
@@ -1,8 +1,0 @@
-$(document).ready(function(){
-  $('.input-choix-option-parcours_type').click(function(){
-    $('#zone-de-personnalisation').show();
-    $('html, body').animate({
-      scrollTop: $("#zone-de-personnalisation").offset().top
-    }, 300);
-  });
-});

--- a/app/assets/javascripts/campagnes.js.erb
+++ b/app/assets/javascripts/campagnes.js.erb
@@ -9,7 +9,7 @@ $(document).ready(function () {
       switch (evenement.target.id) {
       <% ParcoursType.all.each do |parcours_type| %>
         case "campagne_parcours_type_id_<%= parcours_type.id%>":
-        <% if parcours_type.situations_configurations.map(&:nom_technique).include?('livraison')  %>
+        <% if parcours_type.option_redaction?  %>
           block_option_personnalisation_livraison.show();
         <% else %>
           block_option_personnalisation_livraison.hide();

--- a/app/assets/javascripts/campagnes.js.erb
+++ b/app/assets/javascripts/campagnes.js.erb
@@ -1,0 +1,22 @@
+$(document).ready(function () {
+  $(".input-choix-option-parcours_type").click(function (evenement) {
+    if (evenement.target.id) {
+      $("#zone-de-personnalisation").show();
+      $('html, body').animate({
+        scrollTop: $("#zone-de-personnalisation").offset().top
+      }, 300);
+      const block_option_personnalisation_livraison = $("#campagne_options_personnalisation_livraison").parent();
+      switch (evenement.target.id) {
+      <% ParcoursType.all.each do |parcours_type| %>
+        case "campagne_parcours_type_id_<%= parcours_type.id%>":
+        <% if parcours_type.situations_configurations.map(&:nom_technique).include?('livraison')  %>
+          block_option_personnalisation_livraison.show();
+        <% else %>
+          block_option_personnalisation_livraison.hide();
+        <% end %>
+          break;
+      <% end %>
+      }
+    }
+  });
+});

--- a/app/models/parcours_type.rb
+++ b/app/models/parcours_type.rb
@@ -14,4 +14,8 @@ class ParcoursType < ApplicationRecord
   def display_name
     libelle
   end
+
+  def option_redaction?
+    situations_configurations.map(&:nom_technique).include?('livraison')
+  end
 end

--- a/spec/models/parcours_type_spec.rb
+++ b/spec/models/parcours_type_spec.rb
@@ -8,6 +8,16 @@ describe ParcoursType, type: :model do
   it { is_expected.to validate_presence_of :nom_technique }
   it { is_expected.to validate_uniqueness_of :nom_technique }
 
+  it 'retourne false lorsque la configuration du parcours type ne contient pas la livraison' do
+    parcours_type_sans_livraison = create :parcours_type
+    expect(parcours_type_sans_livraison.option_redaction?).to eq(false)
+  end
+
+  it 'retourne true lorsque la configuration du parcours type contient la livraison' do
+    parcours_type_avec_livraison = create :parcours_type, :competences_de_base
+    expect(parcours_type_avec_livraison.option_redaction?).to eq(true)
+  end
+
   it do
     expect(subject)
       .to have_many(:situations_configurations).order(position: :asc).dependent(:destroy)


### PR DESCRIPTION
## 🌟 Enjeux
> Pourvoir mettre à disposition le plus rapidement possible les parcours evacob dans les mains des utilisateurs

## 🎯 Résultats à atteindre
Options à choisir ensemble :

- Le plutôt bien : l'option "expression écrite" s'affiche / se cache en fonction du choix sur parcours

Par défaut, l'option est invisible.

L'option est disponible si la situation livraison est inclue dans le parcours


