### PR TITLE
changement du markown_helper

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -9,14 +9,14 @@ module MarkdownHelper
 
   private
 
-  def interprete_markdown_en_html(contenu)
-    markdown ||= Redcarpet::Markdown.new(
-      Redcarpet::Render::HTML.new(hard_wrap: true)
-    )
-    customise_rendu_gras(markdown.render(contenu)).html_safe
+  class EvaMarkdownRender < Redcarpet::Render::HTML
+    def double_emphasis(quote)
+      %(<strong class="fw-semi-bold">#{quote}</strong>)
+    end
   end
 
-  def customise_rendu_gras(html)
-    html.gsub('<strong>', '<strong class="fw-semi-bold">')
+  def interprete_markdown_en_html(contenu)
+    markdown ||= Redcarpet::Markdown.new(EvaMarkdownRender, hard_wrap: true)
+    markdown.render(contenu).html_safe
   end
 end


### PR DESCRIPTION
Après relecture de la documentation de la gem [redcarpet](https://github.com/vmg/redcarpet), je propose de changer la personnalisation que l'on effectue sur le rendu html depuis du markdown dans la direction de [l'exemple pour personnaliser le rendu du générateur](https://github.com/vmg/redcarpet#and-you-can-even-cook-your-own).