### PR TITLE
email non confirmé et paneau en cas de superadmin

### DIFF
--- a/app/views/admin/comptes/_show.html.arb
+++ b/app/views/admin/comptes/_show.html.arb
@@ -11,7 +11,8 @@ div class: 'mon-compte row' do
     end
 
     div class: 'card' do
-      if compte.unconfirmed_email.present?
+      if compte.unconfirmed_email.present? ||
+         (compte.email_non_confirme? && current_compte.superadmin?)
         div class: 'card__banner card__banner--alert' do
           para 'Une demande de modification d’email a été effectuée.
   La modification ne sera effective qu’une fois l’email confirmé. '
@@ -36,7 +37,7 @@ div class: 'mon-compte row' do
           row :prenom
           row :nom
           row(:email) do
-            if compte.email_non_confirme?
+            if compte.email_non_confirme? && current_compte.superadmin?
               span(compte.email, class: 'email-non-confirme')
             else
               compte.email


### PR DESCRIPTION
## ❌ Comportement observé

Lorsqu'on visite la fiche d'un autre compte, on voit que l'email est en erreur mais on ne sait pas pourquoi

## ✅ Comportement voulu

Pour le superadmin:

- afficher l’email en rouge et le bloc de renvoi d’email

Pour les autres:

- Pas d’email en rouge, ni de bloc orange


## Compte `charge_mission_regionale`
<img width="878" alt="Screenshot 2022-09-21 at 16 34 20" src="https://user-images.githubusercontent.com/1191842/191534412-1933458e-a363-4073-914e-671fd5bad5a3.png">


‌## Compte `superadmin`

<img width="894" alt="Screenshot 2022-09-21 at 16 34 25" src="https://user-images.githubusercontent.com/1191842/191534377-14fbdb10-beb8-4e8d-a94a-06ae70c7a54e.png">
