### PR TITLE
ajout de l'email pour préremplir le formulaire

### DIFF
--- a/app/views/active_admin/devise/confirmations/new.html.erb
+++ b/app/views/active_admin/devise/confirmations/new.html.erb
@@ -5,7 +5,7 @@
     <%= render partial: "active_admin/devise/shared/error_messages", resource: resource %>
     <%= active_admin_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
       f.inputs do
-        f.input :email
+        f.input :email, input_html: { value: params[:email] }
       end
       f.actions do
         f.action :submit, label: t('active_admin.devise.resend_confirmation_instructions.submit'), button_html: { value: t('active_admin.devise.resend_confirmation_instructions.submit') }

--- a/app/views/admin/comptes/_show.html.arb
+++ b/app/views/admin/comptes/_show.html.arb
@@ -22,7 +22,8 @@ div class: 'mon-compte row' do
             end
             div do
               link_to 'Renvoyer l’email de<br> confirmation'.html_safe,
-                      new_confirmation_path(compte), class: 'bouton bouton-principal text-center'
+                      new_confirmation_path(compte, email: compte.email),
+                      class: 'bouton bouton-principal text-center'
             end
           end
         end

--- a/app/views/components/_banner_confirmation_email.html.arb
+++ b/app/views/components/_banner_confirmation_email.html.arb
@@ -10,7 +10,8 @@ div class: 'card__banner card__banner--alert w-100 d-flex' do
     div class: 'd-flex justify-content-between align-items-center' do
       div md t('.description.email_non_recu')
       div do
-        link_to t('.description.action'), new_confirmation_path(current_compte),
+        link_to t('.description.action'),
+                new_confirmation_path(current_compte, email: current_compte),
                 class: 'bouton bouton-principal text-center'
       end
     end


### PR DESCRIPTION
## ❌ Comportement observé

L'email à confirmé n'est pas prérempli

## ✅ Comportement voulu

soit :

- l'email est prérempli
  ou bien
- cliquer sur le bouton de renvoi envoie directement cet email sans passer par la page intermédiaire


## Scénario : 

<img width="680" alt="Screenshot 2022-09-21 at 16 51 41" src="https://user-images.githubusercontent.com/1191842/191537516-937e604f-2a55-490a-be53-50a2dfae8c3d.png">

<img width="604" alt="Screenshot 2022-09-21 at 16 51 45" src="https://user-images.githubusercontent.com/1191842/191537510-e45255dc-a2ba-4779-8885-d05d5cea0f46.png">
