### PR TITLE
ajout de la catégorie du parcours type

### DIFF
--- a/app/admin/parcours_type.rb
+++ b/app/admin/parcours_type.rb
@@ -4,6 +4,7 @@ ActiveAdmin.register ParcoursType do
   menu parent: 'Parcours', if: proc { can? :manage, Compte }
 
   permit_params :libelle, :nom_technique, :duree_moyenne, :description,
+                :parcours_type_categorie_id,
                 situations_configurations_attributes: %i[id situation_id questionnaire_id _destroy]
 
   filter :libelle

--- a/app/models/parcours_type.rb
+++ b/app/models/parcours_type.rb
@@ -6,6 +6,8 @@ class ParcoursType < ApplicationRecord
   validates :libelle, :duree_moyenne, presence: true
   validates :nom_technique, presence: true, uniqueness: true
 
+  belongs_to :parcours_type_categorie, optional: true
+
   has_many :situations_configurations, lambda {
                                          order(position: :asc)
                                        }, dependent: :destroy

--- a/app/models/parcours_type_categorie.rb
+++ b/app/models/parcours_type_categorie.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ParcoursTypeCategorie < ApplicationRecord
+  def display_name
+    nom
+  end
+end

--- a/app/views/admin/parcours_type/_form.html.arb
+++ b/app/views/admin/parcours_type/_form.html.arb
@@ -6,6 +6,7 @@ active_admin_form_for [:admin, resource] do |f|
     f.input :nom_technique
     f.input :duree_moyenne
     f.input :description, as: :text
+    f.input :parcours_type_categorie
     render partial: 'admin/situations_configurations/input_situations_configurations',
            locals: { f: f }
   end

--- a/app/views/admin/parcours_type/_show.html.arb
+++ b/app/views/admin/parcours_type/_show.html.arb
@@ -5,6 +5,7 @@ panel 'Détails du parcours type' do
     row :libelle
     row :nom_technique
     row :duree_moyenne
+    row :parcours_type_categorie
     row(:description) { md(parcours_type.description) }
     row :created_at
     row :updated_at

--- a/config/locales/models/parcours_type.yml
+++ b/config/locales/models/parcours_type.yml
@@ -9,6 +9,7 @@ fr:
         libelle: Libellé
         nom_technique: Nom technique
         duree_moyenne: Durée moyenne
+        parcours_type_categorie: Catégorie
         created_at: créé le
         updated_at: Mis à jour le
   formtastic:

--- a/db/migrate/20220922074803_create_parcours_type_categories.rb
+++ b/db/migrate/20220922074803_create_parcours_type_categories.rb
@@ -1,0 +1,9 @@
+class CreateParcoursTypeCategories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :parcours_type_categories, id: :uuid do |t|
+      t.string :nom
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220922074918_ajoute_parcours_type_categories.rb
+++ b/db/migrate/20220922074918_ajoute_parcours_type_categories.rb
@@ -1,0 +1,10 @@
+class AjouteParcoursTypeCategories < ActiveRecord::Migration[7.0]
+  def up
+    [
+      'Pré-positionnement',
+      'Évaluation avancée',
+    ].each do |nom|
+      ParcoursTypeCategorie.find_or_create_by!(nom: nom)
+    end
+  end
+end

--- a/db/migrate/20220922080356_add_parcours_type_categorie_to_parcours_type.rb
+++ b/db/migrate/20220922080356_add_parcours_type_categorie_to_parcours_type.rb
@@ -1,0 +1,5 @@
+class AddParcoursTypeCategorieToParcoursType < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :parcours_type, :parcours_type_categorie, null: true, foreign_key: true, type: :uuid
+  end
+end

--- a/spec/models/parcours_type_categorie_spec.rb
+++ b/spec/models/parcours_type_categorie_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ParcoursTypeCategorie, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 🌟 Enjeux

> On veut séparer les parcours type selon 2 catégories : "Pré-positionnement" et "Évaluation avancée". À terme on veut 3 parcours type pour chaque catégorie

## 🎯 Résultats à atteindre

- Pouvoir affecter une catégorie parmi "Pré-positionnement" et "Évaluation avancée" à un parcours type. (ex : radio button / select…)

‌