### PR TITLE
Changements pour la bannière info de la confirmation des emails

### DIFF
--- a/app/views/admin/comptes/_banniere_demande_modification_email.html.arb
+++ b/app/views/admin/comptes/_banniere_demande_modification_email.html.arb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
 div class: 'card__banner card__banner--alert' do
-  para 'Une demande de modification d’email a été effectuée.
-La modification ne sera effective qu’une fois l’email confirmé. '
+  para t('.demande_effectuee')
   div class: 'd-flex justify-content-between' do
     div do
-      div 'Un email de confirmation a été envoyé à :'
+      div t('.email_envoye_a')
       span compte.unconfirmed_email, class: 'font-weight-bold'
     end
     div do
-      link_to 'Renvoyer l’email de<br> confirmation'.html_safe,
+      link_to t('admin.comptes.renvoyer'),
               new_confirmation_path(compte, email: compte.email_a_confirmer),
               class: 'bouton bouton-principal text-center'
     end

--- a/app/views/admin/comptes/_banniere_demande_modification_email.html.arb
+++ b/app/views/admin/comptes/_banniere_demande_modification_email.html.arb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+div class: 'card__banner card__banner--alert' do
+  para 'Une demande de modification d’email a été effectuée.
+La modification ne sera effective qu’une fois l’email confirmé. '
+  div class: 'd-flex justify-content-between' do
+    div do
+      div 'Un email de confirmation a été envoyé à :'
+      span compte.unconfirmed_email, class: 'font-weight-bold'
+    end
+    div do
+      link_to 'Renvoyer l’email de<br> confirmation'.html_safe,
+              new_confirmation_path(compte, email: compte.email_a_confirmer),
+              class: 'bouton bouton-principal text-center'
+    end
+  end
+end

--- a/app/views/admin/comptes/_banniere_info_email_non_confirme.html.arb
+++ b/app/views/admin/comptes/_banniere_info_email_non_confirme.html.arb
@@ -3,10 +3,10 @@
 div class: 'card__banner card__banner--alert' do
   div class: 'd-flex justify-content-between' do
     div do
-      div "L'email de ce compte n'a pas été confirmé"
+      div t('.email_non_confirme')
     end
     div do
-      link_to 'Renvoyer l’email de<br> confirmation'.html_safe,
+      link_to t('admin.comptes.renvoyer'),
               new_confirmation_path(compte, email: compte.email_a_confirmer),
               class: 'bouton bouton-principal text-center'
     end

--- a/app/views/admin/comptes/_banniere_info_email_non_confirme.html.arb
+++ b/app/views/admin/comptes/_banniere_info_email_non_confirme.html.arb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+div class: 'card__banner card__banner--alert' do
+  div class: 'd-flex justify-content-between' do
+    div do
+      div "L'email de ce compte n'a pas été confirmé"
+    end
+    div do
+      link_to 'Renvoyer l’email de<br> confirmation'.html_safe,
+              new_confirmation_path(compte, email: compte.email_a_confirmer),
+              class: 'bouton bouton-principal text-center'
+    end
+  end
+end

--- a/app/views/admin/comptes/_show.html.arb
+++ b/app/views/admin/comptes/_show.html.arb
@@ -11,23 +11,10 @@ div class: 'mon-compte row' do
     end
 
     div class: 'card' do
-      if compte.unconfirmed_email.present? ||
-         (compte.email_non_confirme? && current_compte.superadmin?)
-        div class: 'card__banner card__banner--alert' do
-          para 'Une demande de modification d’email a été effectuée.
-  La modification ne sera effective qu’une fois l’email confirmé. '
-          div class: 'd-flex justify-content-between' do
-            div do
-              div 'Un email de confirmation a été envoyé à :'
-              span compte.unconfirmed_email, class: 'font-weight-bold'
-            end
-            div do
-              link_to 'Renvoyer l’email de<br> confirmation'.html_safe,
-                      new_confirmation_path(compte, email: compte.email),
-                      class: 'bouton bouton-principal text-center'
-            end
-          end
-        end
+      if compte.unconfirmed_email.present?
+        render 'banniere_demande_modification_email'
+      elsif compte.email_non_confirme? && current_compte.superadmin?
+        render 'banniere_info_email_non_confirme'
       end
       if current_compte == compte && !compte.confirmed?
         render 'components/banner_confirmation_email'

--- a/app/views/admin/comptes/_show.html.arb
+++ b/app/views/admin/comptes/_show.html.arb
@@ -11,13 +11,12 @@ div class: 'mon-compte row' do
     end
 
     div class: 'card' do
-      if compte.unconfirmed_email.present?
+      if current_compte == compte && !compte.confirmed?
+        render 'components/banner_confirmation_email'
+      elsif compte.unconfirmed_email.present?
         render 'banniere_demande_modification_email'
       elsif compte.email_non_confirme? && current_compte.superadmin?
         render 'banniere_info_email_non_confirme'
-      end
-      if current_compte == compte && !compte.confirmed?
-        render 'components/banner_confirmation_email'
       end
       div class: 'card-body' do
         attributes_table_for compte do

--- a/config/locales/views/comptes.yml
+++ b/config/locales/views/comptes.yml
@@ -1,6 +1,16 @@
 fr:
   admin:
     comptes:
+      renvoyer: |
+        Renvoyer l’email de
+        confirmation
+      banniere_info_email_non_confirme:
+        email_non_confirme: L'email de ce compte n'a pas été confirmé
+      banniere_demande_modification_email:
+        email_envoye_a: 'Un email de confirmation a été envoyé à :'
+        demande_effectuee: |
+            Une demande de modification d’email a été effectuée.
+            La modification ne sera effective qu’une fois l’email confirmé.
       show:
         titre: 'Bonjour %{prenom} !'
         introduction: |

--- a/spec/features/admin/compte_spec.rb
+++ b/spec/features/admin/compte_spec.rb
@@ -260,7 +260,7 @@ describe 'Admin - Compte', type: :feature do
   end
 
   describe '#show' do
-    context "quand le compte a fait une demande pour changer d'email" do
+    context "quand le compte connecté a fait une demande pour changer d'email" do
       before do
         compte_connecte.update unconfirmed_email: 'nouvel-email@exemple.fr'
         visit admin_compte_path(compte_connecte)
@@ -268,7 +268,7 @@ describe 'Admin - Compte', type: :feature do
 
       it { expect(page).to have_content(/nouvel-email@exemple.fr/) }
       it do
-        expect(page).to have_content(/Une demande de modification d’email a été effectuée./)
+        expect(page).to have_content(/Consultez votre boîte de réception,/)
       end
     end
 
@@ -293,6 +293,15 @@ describe 'Admin - Compte', type: :feature do
         before { visit admin_compte_path(collegue) }
 
         it { expect(page).to_not have_content(/Confirmez votre adresse email/) }
+      end
+
+      context "quand l'email du compte d'un collègue a été modifié" do
+        before do
+          collegue.update(unconfirmed_email: 'new_email@test.com')
+          visit admin_compte_path(collegue)
+        end
+
+        it { expect(page).to have_content(/Une demande de modification d’email a été effectuée./) }
       end
     end
 


### PR DESCRIPTION
## Modifications : 

<img width="673" alt="Screenshot 2022-09-23 at 11 43 08" src="https://user-images.githubusercontent.com/1191842/191934263-ec5c0c01-efa1-473a-837b-da04405939d8.png">

<img width="684" alt="Screenshot 2022-09-23 at 11 43 02" src="https://user-images.githubusercontent.com/1191842/191934276-452031a4-0098-4670-a68d-0d3f03a9f308.png">

<img width="1144" alt="Screenshot 2022-09-23 at 11 42 53" src="https://user-images.githubusercontent.com/1191842/191934281-aff64a7a-4fc1-4e1e-ad6c-caa751d64272.png">
