### PR TITLE
Création de catégorie sur parcours_type

### DIFF
--- a/app/admin/parcours_type.rb
+++ b/app/admin/parcours_type.rb
@@ -3,7 +3,7 @@
 ActiveAdmin.register ParcoursType do
   menu parent: 'Parcours', if: proc { can? :manage, Compte }
 
-  permit_params :libelle, :nom_technique, :duree_moyenne, :description,
+  permit_params :libelle, :nom_technique, :duree_moyenne, :description, :categorie,
                 situations_configurations_attributes: %i[id situation_id questionnaire_id _destroy]
 
   filter :libelle

--- a/app/models/parcours_type.rb
+++ b/app/models/parcours_type.rb
@@ -2,6 +2,7 @@
 
 class ParcoursType < ApplicationRecord
   self.implicit_order_column = 'created_at'
+  CATEGORIES = %w[pre_positionnement evaluation_avancee].freeze
 
   validates :libelle, :duree_moyenne, presence: true
   validates :nom_technique, presence: true, uniqueness: true
@@ -10,6 +11,8 @@ class ParcoursType < ApplicationRecord
                                          order(position: :asc)
                                        }, dependent: :destroy
   accepts_nested_attributes_for :situations_configurations, allow_destroy: true
+
+  enum :categorie, CATEGORIES.zip(CATEGORIES).to_h
 
   def display_name
     libelle

--- a/app/views/admin/parcours_type/_form.html.arb
+++ b/app/views/admin/parcours_type/_form.html.arb
@@ -5,6 +5,7 @@ active_admin_form_for [:admin, resource] do |f|
     f.input :libelle
     f.input :nom_technique
     f.input :duree_moyenne
+    f.input :categorie, as: :select
     f.input :description, as: :text
     render partial: 'admin/situations_configurations/input_situations_configurations',
            locals: { f: f }

--- a/app/views/admin/parcours_type/_show.html.arb
+++ b/app/views/admin/parcours_type/_show.html.arb
@@ -5,6 +5,10 @@ panel 'Détails du parcours type' do
     row :libelle
     row :nom_technique
     row :duree_moyenne
+    row(:categorie) do
+      scope = 'activerecord.attributes.parcours_type.categories.'
+      parcours_type.categorie ? t("#{scope}#{parcours_type.categorie}") : nil
+    end
     row(:description) { md(parcours_type.description) }
     row :created_at
     row :updated_at

--- a/config/locales/models/parcours_type.yml
+++ b/config/locales/models/parcours_type.yml
@@ -9,6 +9,10 @@ fr:
         libelle: Libellé
         nom_technique: Nom technique
         duree_moyenne: Durée moyenne
+        categorie: Catégorie
+        categories:
+          pre_positionnement: Pré-positionnement
+          evaluation_avancee: Évaluation avancée
         created_at: créé le
         updated_at: Mis à jour le
   formtastic:

--- a/db/migrate/20220926084604_add_categorie_to_parcours_type.rb
+++ b/db/migrate/20220926084604_add_categorie_to_parcours_type.rb
@@ -1,0 +1,5 @@
+class AddCategorieToParcoursType < ActiveRecord::Migration[7.0]
+  def change
+    add_column :parcours_type, :categorie, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_09_132500) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_26_084604) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -194,6 +194,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_09_132500) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "description"
+    t.string "categorie"
   end
 
   create_table "parties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -218,8 +219,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_09_132500) do
 
   create_table "questionnaires_questions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.uuid "questionnaire_id"
     t.uuid "question_id"
     t.index ["question_id"], name: "index_questionnaires_questions_on_question_id"
@@ -228,8 +229,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_09_132500) do
 
   create_table "questions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "intitule"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "type"
     t.string "description"
     t.string "reponse_placeholder"


### PR DESCRIPTION
## 🌟 Enjeux

> On veut séparer les parcours type selon 2 catégories : "Pré-positionnement" et "Évaluation avancée". À terme on veut 3 parcours type pour chaque catégorie

## 🎯 Résultats à atteindre

- Pouvoir affecter une catégorie parmi "Pré-positionnement" et "Évaluation avancée" à un parcours type. (ex : radio button / select…)

‌