### PR TITLE
Attache l'icone initial de scopes sur le premier élément et non sur le groupe

### DIFF
--- a/app/assets/stylesheets/admin/composants/_scopes.scss
+++ b/app/assets/stylesheets/admin/composants/_scopes.scss
@@ -37,7 +37,10 @@
 
   .scope-default-group {
     display: flex;
+  }
 
+  .scope:first-child {
+    display: flex;
     &::before {
       content: '';
       display: inline-block;


### PR DESCRIPTION
Ça semble marcher, mais j'ai l'impression qu'il y a un effet de sautillement quand on change d'un scope à l'autre.

<img width="746" alt="Capture d’écran 2022-09-28 à 18 02 28" src="https://user-images.githubusercontent.com/298214/192829204-f25beff9-5cd2-465d-a2cf-ec421bdc227a.png">
<img width="487" alt="Capture d’écran 2022-09-28 à 18 02 34" src="https://user-images.githubusercontent.com/298214/192829121-3c6e1fd4-3c49-496e-9577-c4e00199af55.png">
<img width="724" alt="Capture d’écran 2022-09-28 à 18 02 41" src="https://user-images.githubusercontent.com/298214/192829107-06195ed6-1721-46f0-a3e7-73113adfbda8.png">
