### PR TITLE
l'icone des filtres rapides prends toute la hauteur disponible

### DIFF
--- a/app/assets/stylesheets/admin/composants/_scopes.scss
+++ b/app/assets/stylesheets/admin/composants/_scopes.scss
@@ -44,7 +44,6 @@
     &::before {
       content: '';
       display: inline-block;
-      height: 2rem;
       width: 2.5rem;
       background-position: center;
       background-repeat: no-repeat;


### PR DESCRIPTION
# Avant
<img width="957" alt="Capture_d’écran_2022-09-28_à_21 57 12" src="https://user-images.githubusercontent.com/298214/193218991-f52d0596-0e94-49a8-b2ce-3da20b448872.png">

# Après 
<img width="1021" alt="Capture d’écran 2022-09-30 à 09 47 33" src="https://user-images.githubusercontent.com/298214/193219126-fcff1fd6-515c-423f-8886-f05aacd333c0.png">




