### PR TITLE
ajout de la légende pour les pastilles sur le dashboard

### DIFF
--- a/app/assets/stylesheets/admin/pages/dashboard/_dashboard.scss
+++ b/app/assets/stylesheets/admin/pages/dashboard/_dashboard.scss
@@ -1,18 +1,30 @@
 .admin_dashboard {
   .bloc-apercu {
-    margin-bottom: 2rem;
+    &-wrapper {
+      margin-bottom: 1.5rem;
+
+      .evaluation-legende {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        padding: 0rem 0.5rem;
+        gap: 1rem;
+        height: 2rem;
+        font-size: 0.875rem;
+      }
+    }
 
     &-header {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      margin-bottom: 1.5rem;
-  
+      margin-bottom: 1.875rem;
+
       h3 {
         @include titre-carte;
         margin-bottom: 0;
       }
-  
+
       > a {
         @include bouton;
         display: inline-block;
@@ -24,8 +36,8 @@
       .liste-entete {
         display: flex;
         padding: 0 1rem;
-        margin-bottom: .75rem;
-        font-size:0.875rem;
+        margin-bottom: 0.75rem;
+        font-size: 0.875rem;
         .entete {
           &-libelle {
             flex: 2;
@@ -41,11 +53,11 @@
       .campagne {
         @include carte-avec-ombre();
         padding: 0.7rem 1rem;
-        margin-bottom: .5rem;
+        margin-bottom: 0.5rem;
         display: flex;
         align-items: center;
         position: relative;
-        font-size:0.875rem;
+        font-size: 0.875rem;
         &-libelle,
         &-code {
           text-decoration: none;

--- a/app/views/admin/dashboard/_evaluations.html.arb
+++ b/app/views/admin/dashboard/_evaluations.html.arb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
 div class: 'evaluations bloc-apercu' do
-  div class: 'bloc-apercu-header' do
-    h3 t('.titre')
-    text_node link_to 'Voir toutes les évaluations', admin_evaluations_path
+  div class: 'bloc-apercu-wrapper' do
+    div class: 'bloc-apercu-header' do
+      h3 t('.titre')
+      text_node link_to t('.voir_tout'), admin_evaluations_path
+    end
+
+    div class: 'evaluation-legende' do
+      render partial: 'admin/evaluations/pastille_illettrisme_potentiel', locals: {
+        etiquette: t('.legende_info')
+      }
+    end
   end
 
   div class: 'evaluations-liste' do

--- a/config/locales/views/dashboard.yml
+++ b/config/locales/views/dashboard.yml
@@ -15,7 +15,9 @@ fr:
       evaluations:
         titre: Vos dernières évaluations
         action: Voir
+        voir_tout: 'Voir toutes les évaluations'
         date: "il y a %{date}"
+        legende_info: "Évaluations contenant un diagnostic d'illettrisme potentiel"
       campagnes:
         titre: Vos campagnes
         action: Gérer mes campagnes


### PR DESCRIPTION
## Après : 

<img width="1299" alt="Capture d’écran 2022-10-07 à 13 14 36" src="https://user-images.githubusercontent.com/298214/194540708-6b479177-2148-494e-8ec6-531f7ff3dbb5.png">
