### PR TITLE
Ajoute une largeur minimum à la colonne illettrisme

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -34,7 +34,7 @@ ActiveAdmin.register Evaluation do
     column(:nom) { |e| nom_pour_ressource(e) }
 
     if params[:scope] != 'illettrisme_potentiel'
-      column do |evaluation|
+      column('Illettrisme potentiel') do |evaluation|
         if evaluation.illettrisme_potentiel?
           render partial: 'pastille_illettrisme_potentiel',
                  locals: { avec_tooltip: true }

--- a/app/assets/stylesheets/admin/composants/_ellipse.scss
+++ b/app/assets/stylesheets/admin/composants/_ellipse.scss
@@ -1,3 +1,4 @@
+
 .ellipse {
   width: 1rem;
   height: 1rem;

--- a/app/assets/stylesheets/admin/pages/_evaluations.scss
+++ b/app/assets/stylesheets/admin/pages/_evaluations.scss
@@ -58,3 +58,8 @@
   }
 }
 
+#index_table_evaluations {
+  .col-nom {
+    max-width: 11.25rem;
+  }
+}


### PR DESCRIPTION
Pour éviter que les puces ne soient trop collées au nom de la campagne
<img width="1034" alt="Capture d’écran 2022-10-05 à 16 38 19" src="https://user-images.githubusercontent.com/298214/194088173-a6ca3e61-5731-4091-b07b-c047ce711d74.png">

Est-ce suffisant ?

Voici ce que ça donne avec l'entête et que le nom de la campagne est long :
![Capture d’écran 2022-10-12 à 11 06 28](https://user-images.githubusercontent.com/81169078/195300671-ed496603-68a8-474f-b36f-b2b729b9e00a.png)
