### PR TITLE
Corrige le contenu d'un des niveaux d'études sociodémographique

### DIFF
--- a/app/models/donnee_sociodemographique.rb
+++ b/app/models/donnee_sociodemographique.rb
@@ -5,7 +5,7 @@ class DonneeSociodemographique < ApplicationRecord
 
   GENRES = ['Homme', 'Femme', 'Autre genre'].freeze
   enum :genre, GENRES.zip(GENRES).to_h
-  NIVEAUX_ETUDES = ['Niveau Collège', 'Niveau CFG / DNB (BEPC)', 'Niveau CAP/ BEP', 'Niveau Bac',
+  NIVEAUX_ETUDES = ['Niveau Collège', 'Niveau CFG / DNB (BEPC)', 'Niveau CAP / BEP', 'Niveau Bac',
                     'Niveau Bac +2', 'Supérieur Bac +2'].freeze
   enum :dernier_niveau_etude, NIVEAUX_ETUDES.zip(NIVEAUX_ETUDES).to_h
   SITUATIONS = ['Scolarisation', 'Formation professionnelle', 'Alternance', 'Emploi',

--- a/app/models/donnee_sociodemographique.rb
+++ b/app/models/donnee_sociodemographique.rb
@@ -3,13 +3,13 @@
 class DonneeSociodemographique < ApplicationRecord
   belongs_to :evaluation
 
-  GENRES = ['Homme', 'Femme', 'Autre genre'].freeze
+  GENRES = %w[homme femme autre].freeze
   enum :genre, GENRES.zip(GENRES).to_h
-  NIVEAUX_ETUDES = ['Niveau Collège', 'Niveau CFG / DNB (BEPC)', 'Niveau CAP / BEP', 'Niveau Bac',
-                    'Niveau Bac +2', 'Supérieur Bac +2'].freeze
+  NIVEAUX_ETUDES = %w[college cfg_dnb_bepc cap_bep bac
+                      bac_plus2 superieur_bac_plus2].freeze
   enum :dernier_niveau_etude, NIVEAUX_ETUDES.zip(NIVEAUX_ETUDES).to_h
-  SITUATIONS = ['Scolarisation', 'Formation professionnelle', 'Alternance', 'Emploi',
-                'Sans emploi'].freeze
+  SITUATIONS = %w[scolarisation formation_professionnelle alternance emploi
+                  sans_emploi].freeze
   enum :derniere_situation, SITUATIONS.zip(SITUATIONS).to_h
 
   validates :genre, inclusion: { in: GENRES, allow_blank: true }

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -23,9 +23,9 @@ describe 'Evaluation API', type: :request do
           },
           donnee_sociodemographique_attributes: {
             age: 18,
-            genre: 'Homme',
-            dernier_niveau_etude: 'Niveau Collège',
-            derniere_situation: 'Scolarisation'
+            genre: 'homme',
+            dernier_niveau_etude: 'college',
+            derniere_situation: 'scolarisation'
           }
         }
       end
@@ -59,9 +59,9 @@ describe 'Evaluation API', type: :request do
       end
 
       it { expect(@donnee_sociodemographique.age).to eq 18 }
-      it { expect(@donnee_sociodemographique.genre).to eq 'Homme' }
-      it { expect(@donnee_sociodemographique.dernier_niveau_etude).to eq 'Niveau Collège' }
-      it { expect(@donnee_sociodemographique.derniere_situation).to eq 'Scolarisation' }
+      it { expect(@donnee_sociodemographique.genre).to eq 'homme' }
+      it { expect(@donnee_sociodemographique.dernier_niveau_etude).to eq 'college' }
+      it { expect(@donnee_sociodemographique.derniere_situation).to eq 'scolarisation' }
     end
 
     context 'Quand le code campagne est inconnu' do


### PR DESCRIPTION
C'était écrit différemment côté application. J'ai choisi d'uniformiser avec la forme avec une espace de chaque côté de la barre oblique.