### PR TITLE
fix alignement élèments de la bannière alerte orange

### DIFF
--- a/app/assets/stylesheets/admin/composants/_card.scss
+++ b/app/assets/stylesheets/admin/composants/_card.scss
@@ -18,6 +18,11 @@
     h4 {
       margin-bottom: 1rem;
     }
+    .banner__action {
+      p {
+        margin: 0;
+      }
+    }
     .bouton-principal {
       max-width: 10.5rem;
     }

--- a/app/views/components/_banner_confirmation_email.html.arb
+++ b/app/views/components/_banner_confirmation_email.html.arb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-div class: 'card__banner card__banner--alert w-100 d-flex' do
-  div(class: 'd-flex') do
-    svg_tag_base64 'icones/icone-enveloppe.svg', class: 'banner__icone'
-  end
+div class: 'card__banner card__banner--alert w-100 d-flex align-items-center' do
+  div svg_tag_base64 'icones/icone-enveloppe.svg', class: 'banner__icone'
   div do
     h4 t('.titre')
     text_node md "#{t('.description.instructions')}<u>#{current_compte.email_a_confirmer}</u>"
-    div class: 'd-flex justify-content-between align-items-center' do
+    div class: 'd-flex justify-content-between align-items-center banner__action' do
       div md t('.description.email_non_recu')
       div do
         link_to t('.description.action'),


### PR DESCRIPTION
## Rendu sur la dashboard
![Capture d’écran 2022-10-25 à 10 05 30](https://user-images.githubusercontent.com/81169078/197722470-abdcdb9e-b31a-4697-9403-37f98d8251f1.png)

## Rendu sur la page mon compte
![Capture d’écran 2022-10-25 à 10 21 09](https://user-images.githubusercontent.com/81169078/197722498-76870795-219d-422b-808a-b654023509a5.png)
