### PR TITLE
🏗️  Ajoute ancestry pour gérer l'héritage des structures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'activeadmin-xls', git: 'https://github.com/shanser/activeadmin-xls',
                        branch: 'autoload'
 gem 'acts_as_list'
 gem 'addressable'
+gem 'ancestry'
 gem 'auto_strip_attributes', '~> 2.6'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'bootstrap', '~> 4.3', '>= 4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     afm (0.2.2)
+    ancestry (4.2.0)
+      activerecord (>= 5.2.6)
     arbre (1.5.0)
       activesupport (>= 3.0.0, < 7.1)
       ruby2_keywords (>= 0.0.2, < 1.0)
@@ -542,6 +544,7 @@ DEPENDENCIES
   activeadmin_reorderable
   acts_as_list
   addressable
+  ancestry
   auto_strip_attributes (~> 2.6)
   aws-sdk-s3
   bootsnap (>= 1.1.0)

--- a/app/models/structure.rb
+++ b/app/models/structure.rb
@@ -3,7 +3,12 @@
 class Structure < ApplicationRecord
   belongs_to :structure_referente, optional: true, class_name: 'StructureAdministrative'
 
+  REGEX_UUID = /\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i.freeze
+  has_ancestry(primary_key_format: REGEX_UUID)
   acts_as_paranoid
+
+  # À supprimer une fois la transition vers ancestry terminée
+  alias_attribute :parent_id, :structure_referente_id
 
   validates :nom, presence: true
   validates :nom, uniqueness: { case_sensitive: false, scope: :code_postal }

--- a/config/locales/ancestry.yml
+++ b/config/locales/ancestry.yml
@@ -1,0 +1,16 @@
+fr:
+  ancestry:
+    unknown_depth_option: "Unknown depth option: %{scope_name}."
+    invalid_orphan_strategy: "Invalid orphan strategy, valid ones are :rootify, :adopt, :restrict and :destroy."
+    invalid_ancestry_column: "Invalid format for ancestry column of node %{node_id}: %{ancestry_column}."
+    reference_nonexistent_node: "Reference to nonexistent node in node %{node_id}: %{ancestor_id}."
+    conflicting_parent_id: "Conflicting parent id found in node %{node_id}: %{parent_id} for node %{node_id} while expecting %{expected}"
+    cannot_rebuild_depth_cache: "Cannot rebuild depth cache for model without depth caching."
+
+    option_must_be_hash: "Options for has_ancestry must be in a hash."
+    unknown_option: "Unknown option for has_ancestry: %{key} => %{value}."
+    named_scope_depth_cache: "Named scope '%{scope_name}' is only available when depth caching is enabled."
+
+    exclude_self: "%{class_name} cannot be a descendant of itself."
+    cannot_delete_descendants: "Cannot delete record because it has descendants."
+    no_child_for_new_record: "No child ancestry for new record. Save record before performing tree operations."

--- a/db/migrate/20221102151638_add_ancestry_to_structures.rb
+++ b/db/migrate/20221102151638_add_ancestry_to_structures.rb
@@ -1,0 +1,6 @@
+class AddAncestryToStructures < ActiveRecord::Migration[7.0]
+  def change
+    add_column :structures, :ancestry, :string
+    add_index :structures, :ancestry
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_31_165243) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_02_151638) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -339,6 +339,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_31_165243) do
     t.uuid "structure_referente_id"
     t.string "type"
     t.datetime "deleted_at"
+    t.string "ancestry"
+    t.index ["ancestry"], name: "index_structures_on_ancestry"
     t.index ["deleted_at"], name: "index_structures_on_deleted_at"
     t.index ["latitude", "longitude"], name: "index_structures_on_latitude_and_longitude"
     t.index ["nom", "code_postal"], name: "index_structures_on_nom_and_code_postal", unique: true

--- a/lib/tasks/structure.rake
+++ b/lib/tasks/structure.rake
@@ -5,4 +5,10 @@ namespace :structure do
   task assigne_region: :environment do
     Structure::AssigneRegionJob.perform_now
   end
+
+  desc 'Migre la colonne structure_referente vers la colonne ancestry'
+  task migre_structure_referente_id_vers_ancestry: :environment do
+    Structure.build_ancestry_from_parent_ids!
+    Structure.check_ancestry_integrity!
+  end
 end

--- a/spec/models/structure_spec.rb
+++ b/spec/models/structure_spec.rb
@@ -11,6 +11,11 @@ describe Structure, type: :model do
                                                       .optional
   end
 
+  describe 'REGEX_UUID' do
+    it { expect('uuid invalide').not_to match(Structure::REGEX_UUID) }
+    it { expect(SecureRandom.uuid).to match(Structure::REGEX_UUID) }
+  end
+
   describe 'géolocalisation à la validation' do
     describe "pour n'importe quel code postal" do
       let(:structure) { Structure.new code_postal: '75012' }


### PR DESCRIPTION
Il faudra lancer la tâche rake `structure:migre_structure_referente_id_vers_ancestry` une fois la PR passée en staging, puis en production