### PR TITLE
Documente la validation des enum avec Rails

### DIFF
--- a/app/models/donnee_sociodemographique.rb
+++ b/app/models/donnee_sociodemographique.rb
@@ -12,10 +12,6 @@ class DonneeSociodemographique < ApplicationRecord
                   sans_emploi].freeze
   enum :derniere_situation, SITUATIONS.zip(SITUATIONS).to_h
 
-  validates :genre, inclusion: { in: GENRES, allow_blank: true }
-  validates :dernier_niveau_etude, inclusion: { in: NIVEAUX_ETUDES, allow_blank: true }
-  validates :derniere_situation, inclusion: { in: SITUATIONS, allow_blank: true }
-
   acts_as_paranoid
 
   def to_s

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -110,6 +110,26 @@ describe 'Evaluation API', type: :request do
   describe 'PATCH /evaluations/:id' do
     let!(:evaluation) { create :evaluation, email: 'monemail@eva.fr', nom: 'James' }
 
+    context 'Quand une requête est invalide pour un enum de données sociodémographiques' do
+      let(:params) do
+        {
+          donnee_sociodemographique_attributes: {
+            dernier_niveau_etude: 'invalide'
+          }
+        }
+      end
+
+      it 'retourne une 500 (comportement par défaut des enums Rails)' do
+        expect do
+          patch "/api/evaluations/#{evaluation.id}", params: params
+        end.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe 'PATCH /evaluations/:id' do
+    let!(:evaluation) { create :evaluation, email: 'monemail@eva.fr', nom: 'James' }
+
     before { patch "/api/evaluations/#{evaluation.id}", params: params }
 
     context 'Met à jour email et téléphone avec une requête valide' do


### PR DESCRIPTION
Rails retourne maintenant une erreur 500 si on essaye d'enregistrer une mauvaise valeur d'un enum.
L'ajout des validations est devenu inutile.

Ceci a un impact au niveau de notre API Patch Evaluation, pour l'enregistrement des données sociodémographiques.

Pour une API, on pourrait vouloir renvoyer plutôt une erreur 422, Mais dans notre cas, tout est bien géré coté front et nous n'avons pas la nécessité de surcharger le comportement par défaut de Rails.

Référence, voir le message de blog suivant :
https://medium.com/nerd-for-tech/using-activerecord-enum-in-rails-35edc2e9070f