### PR TITLE
Restitution : mettre le même padding-top à tous les panel

### DIFF
--- a/app/assets/stylesheets/admin/composants/_lettrisme.scss
+++ b/app/assets/stylesheets/admin/composants/_lettrisme.scss
@@ -18,7 +18,6 @@
     margin-bottom: 0px;
     border-bottom-left-radius: 0px;
     border-bottom-right-radius: 0px;
-    padding: 2rem 0;
     p {
       font-size: 0.875rem;
       margin-bottom: 0;

--- a/app/assets/stylesheets/admin/pages/restitution_globale/_base.scss
+++ b/app/assets/stylesheets/admin/pages/restitution_globale/_base.scss
@@ -30,6 +30,10 @@
     margin: 3rem 0 1rem;
   }
 
+  .titre--avec-aide-illettrisme {
+    margin-bottom: 3rem;
+  }
+
   h3 {
     color: $eva_main_blue;
     font-size: 1rem;
@@ -485,10 +489,6 @@
     .carte__duree {
       font-style: italic;
     }
-  }
-
-  .titre-avec-aide-illettrisme {
-    margin-bottom: 3rem;
   }
 }
 

--- a/app/views/admin/evaluations/_restitution_globale.arb
+++ b/app/views/admin/evaluations/_restitution_globale.arb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 niveaux_competences = restitution_globale.niveaux_competences
-titre_avec_aide_illettrisme = 'titre-avec-aide-illettrisme' if resource.illettrisme_potentiel?
+titre_avec_aide_illettrisme = 'titre--avec-aide-illettrisme' if resource.illettrisme_potentiel?
 
 div class: 'evaluation__restitution-globale' do
   render 'deroulement_passation' unless resource.campagne.parcours_type.blank? || pdf


### PR DESCRIPTION
Les panels qui commencent par un bloc de synthèse ont le même padding-top que les autres panels de la restitution, contrairement à ce qui est indiqué dans les maquettes.

Ce padding ne change pas, même si l'on doit afficher l'encart de demande d'aide illettrisme

J'ai aussi rapproché la règle `.titre--avec-aide-illettrisme` du `h2` qu'elle altère dans le fichier