### PR TITLE
Erreur 500: asset punaise-aberrant manquante

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -110,9 +110,9 @@ ActiveAdmin.register Evaluation do
 
   controller do
     helper_method :restitution_globale, :parties, :prise_en_main?, :auto_positionnement,
-                  :cafe_de_la_place, :statistiques, :mes_avec_redaction_de_notes,
+                  :restitution_cafe_de_la_place, :statistiques, :mes_avec_redaction_de_notes,
                   :campagnes_accessibles, :beneficiaires_accessibles, :traduction_niveau,
-                  :campagne_avec_competences_transversales?
+                  :campagne_avec_competences_transversales?, :campagne_avec_positionnement?
 
     def show
       show! do |format|
@@ -157,6 +157,10 @@ ActiveAdmin.register Evaluation do
       @evaluation.campagne.avec_competences_transversales?
     end
 
+    def campagne_avec_positionnement?
+      @evaluation.campagne.avec_positionnement?
+    end
+
     def prise_en_main?
       selectionne_derniere_restitution(Situation::PLAN_DE_LA_VILLE)&.termine?
     end
@@ -165,7 +169,7 @@ ActiveAdmin.register Evaluation do
       selectionne_derniere_restitution(Situation::BIENVENUE)
     end
 
-    def cafe_de_la_place
+    def restitution_cafe_de_la_place
       selectionne_derniere_restitution(Situation::CAFE_DE_LA_PLACE)
     end
 

--- a/app/models/campagne.rb
+++ b/app/models/campagne.rb
@@ -3,8 +3,9 @@
 require 'generateur_aleatoire'
 
 class Campagne < ApplicationRecord
-  SITUATIONS_AVEC_COMPETENCES_TRANSVERSALES = %w[controle inventaire securite tri].freeze
-  SITUATIONS_AVEC_REPERAGE_ILLETTRISME = %w[maintenance livraison objets_trouves].freeze
+  SITUATIONS_COMPETENCES_TRANSVERSALES = %w[controle inventaire securite tri].freeze
+  SITUATIONS_PRE_POSITIONNEMENT = %w[maintenance livraison objets_trouves].freeze
+  SITUATIONS_POSITIONNEMENT = %w[cafe_de_la_place].freeze
   PERSONNALISATION = %w[plan_de_la_ville bienvenue livraison].freeze
 
   acts_as_paranoid
@@ -52,18 +53,24 @@ class Campagne < ApplicationRecord
   end
 
   def avec_competences_transversales?
-    situations_configurations.any? do |configuration|
-      SITUATIONS_AVEC_COMPETENCES_TRANSVERSALES.include?(configuration.situation.nom_technique)
-    end
+    configuration_inclus?(SITUATIONS_COMPETENCES_TRANSVERSALES)
   end
 
-  def avec_reperage_illettrisme?
-    situations_configurations.any? do |configuration|
-      SITUATIONS_AVEC_REPERAGE_ILLETTRISME.include?(configuration.situation.nom_technique)
-    end
+  def avec_positionnement?
+    configuration_inclus?(SITUATIONS_POSITIONNEMENT)
+  end
+
+  def avec_pre_positionnement?
+    configuration_inclus?(SITUATIONS_PRE_POSITIONNEMENT)
   end
 
   private
+
+  def configuration_inclus?(situations)
+    situations_configurations.any? do |configuration|
+      situations.include?(configuration.situation.nom_technique)
+    end
+  end
 
   def initialise_situations
     initialise_situations_optionnelles

--- a/app/models/restitution/globale.rb
+++ b/app/models/restitution/globale.rb
@@ -2,7 +2,7 @@
 
 module Restitution
   class Globale
-    attr_reader :evaluation, :restitutions
+    attr_reader :evaluation, :restitutions, :synthese_positionnement, :synthese_pre_positionnement
 
     NIVEAU_INDETERMINE = :indetermine
 
@@ -10,7 +10,7 @@ module Restitution
              to: :scores_niveau2_standardises, prefix: :niveau2
     delegate :moyennes_metriques, :ecarts_types_metriques,
              to: :scores_niveau1_standardises, prefix: :niveau1
-    delegate :synthese, to: :synthetiseur
+    delegate :synthese, :synthese_positionnement, :synthese_pre_positionnement, to: :synthetiseur
 
     def initialize(evaluation:, restitutions:)
       @evaluation = evaluation

--- a/app/models/restitution/illettrisme/synthetiseur.rb
+++ b/app/models/restitution/illettrisme/synthetiseur.rb
@@ -3,21 +3,34 @@
 module Restitution
   module Illettrisme
     class Synthetiseur
-      attr_reader :algo
-
       def initialize(interpreteur_pre_positionnement, interpreteur_positionnement)
-        @algo = if interpreteur_positionnement.present?
-                  SynthetiseurPositionnement.new(interpreteur_positionnement)
-                else
-                  SynthetiseurPrePositionnement.new(interpreteur_pre_positionnement)
-                end
+        @algo_pre_positionnement =
+          if interpreteur_pre_positionnement.present?
+            SynthetiseurPrePositionnement.new(interpreteur_pre_positionnement)
+          end
+        @algo_positionnement =
+          if interpreteur_positionnement.present?
+            SynthetiseurPositionnement.new(interpreteur_positionnement)
+          end
       end
 
       def synthese
+        synthese_positionnement.presence || synthese_pre_positionnement
+      end
+
+      def synthese_positionnement
+        Synthetiseur.calcule_synthese(@algo_positionnement)
+      end
+
+      def synthese_pre_positionnement
+        Synthetiseur.calcule_synthese(@algo_pre_positionnement)
+      end
+
+      def self.calcule_synthese(algo)
+        return if algo.blank? || algo.indetermine?
         return 'illettrisme_potentiel' if algo.illettrisme_potentiel?
         return 'socle_clea' if algo.socle_clea?
         return 'aberrant' if algo.aberrant?
-        return if algo.indeterminee?
 
         'ni_ni'
       end
@@ -41,7 +54,7 @@ module Restitution
           false
         end
 
-        def indeterminee?
+        def indetermine?
           @interpreteur.interpretations_cefr[:litteratie].blank? and
             @interpreteur.interpretations_cefr[:numeratie].blank?
         end
@@ -64,7 +77,7 @@ module Restitution
           @niveau_positionnement == :profil_aberrant
         end
 
-        def indeterminee?
+        def indetermine?
           @niveau_positionnement == :indetermine
         end
       end

--- a/app/views/admin/evaluations/_francais_mathematique.arb
+++ b/app/views/admin/evaluations/_francais_mathematique.arb
@@ -3,7 +3,6 @@
 div id: 'francais_mathematiques', class: 'francais-mathematiques marges-page' do
   render 'demande_aide_illettrisme' if !pdf && resource.illettrisme_potentiel?
 
-  synthese = resource.synthese_competences_de_base
   render 'litteratie_numeratie_synthese',
          synthese: synthese,
          description: synthese,

--- a/app/views/admin/evaluations/_lettrisme.erb
+++ b/app/views/admin/evaluations/_lettrisme.erb
@@ -1,4 +1,4 @@
-<% profil = cafe_de_la_place.niveau_litteratie %>
+<% profil = restitution_cafe_de_la_place ? restitution_cafe_de_la_place.niveau_litteratie : 'indetermine' %>
 
 <div class="panel panel-lettrisme">
   <div class='marges-page'>
@@ -11,15 +11,15 @@
       pdf: pdf %>
     <% if niveau_bas?(profil) %>
       <div class="lettrisme-sous-competences">
-        <% cafe_de_la_place.competences_lettrisme.each do |competence, profil| %>
+        <% restitution_cafe_de_la_place.competences_lettrisme.each do |competence, profil| %>
           <%= render 'lettrisme_sous_competence', sous_competence: competence, profil: profil %>
         <% end %>
       </div>
     <% end %>
   </div>
 </div>
-<% if !pdf %>
-  <a href="<%= admin_partie_cafe_de_la_place_reponses_path(cafe_de_la_place.partie.id) %>" class="telechargement_des_reponses">
+<% if !pdf && restitution_cafe_de_la_place %>
+  <a href="<%= admin_partie_cafe_de_la_place_reponses_path(restitution_cafe_de_la_place.partie.id) %>" class="telechargement_des_reponses">
   <h3>
     <%= t('.telechargement_des_reponses')%>
   </h3>

--- a/app/views/admin/evaluations/_restitution_globale.arb
+++ b/app/views/admin/evaluations/_restitution_globale.arb
@@ -50,7 +50,7 @@ div class: 'evaluation__restitution-globale' do
     render 'competences_transversales', pdf: pdf, restitution_globale: restitution_globale
   end
 
-  if resource.campagne.avec_reperage_illettrisme?
+  if resource.campagne.avec_pre_positionnement?
     if pdf
       div class: 'page' do
         render 'entete_page', restitution_globale: restitution_globale
@@ -90,7 +90,7 @@ div class: 'evaluation__restitution-globale' do
     end
   end
 
-  if resource.campagne.avec_reperage_illettrisme?
+  if resource.campagne.avec_pre_positionnement?
     render partial: 'correspondance_anlci',
            locals: {
              restitution_globale: restitution_globale,
@@ -98,7 +98,7 @@ div class: 'evaluation__restitution-globale' do
            }
   end
 
-  if restitution_globale.synthese_positionnement.present?
+  if campagne_avec_positionnement?
     div id: 'lettrisme', class: 'page page-lettrisme' do
       render 'entete_page', restitution_globale: restitution_globale
 
@@ -119,7 +119,7 @@ div class: 'evaluation__restitution-globale' do
   end
 end
 
-if can?(:manage, Compte) && resource.campagne.avec_reperage_illettrisme? && !pdf
+if can?(:manage, Compte) && resource.campagne.avec_pre_positionnement? && !pdf
   div class: 'evaluation__scores panel' do
     tabs do
       tab 'Scores litteratie et numératie' do

--- a/app/views/admin/evaluations/_restitution_globale.arb
+++ b/app/views/admin/evaluations/_restitution_globale.arb
@@ -58,7 +58,8 @@ div class: 'evaluation__restitution-globale' do
         h2 t('titre', scope: 'admin.restitutions.cefr'), class: 'text-center mt-5 mb-4'
 
         div class: 'panel' do
-          render 'francais_mathematique', pdf: pdf
+          render 'francais_mathematique', pdf: pdf,
+                                          synthese: restitution_globale.synthese_pre_positionnement
         end
 
         render 'pied_page', avant_pied_page: 'references_restitution_illettrisme'
@@ -78,7 +79,8 @@ div class: 'evaluation__restitution-globale' do
         h2 t('titre', scope: 'admin.restitutions.cefr'), class: titre_avec_aide_illettrisme.to_s
 
         div class: 'panel panel--avec-references' do
-          render 'francais_mathematique', pdf: pdf
+          render 'francais_mathematique', pdf: pdf,
+                                          synthese: restitution_globale.synthese_pre_positionnement
 
           render 'communication_ecrite', restitution_globale: restitution_globale, pdf: pdf
 
@@ -96,7 +98,7 @@ div class: 'evaluation__restitution-globale' do
            }
   end
 
-  if cafe_de_la_place
+  if restitution_globale.synthese_positionnement.present?
     div id: 'lettrisme', class: 'page page-lettrisme' do
       render 'entete_page', restitution_globale: restitution_globale
 

--- a/spec/features/admin/evaluation_spec.rb
+++ b/spec/features/admin/evaluation_spec.rb
@@ -151,6 +151,8 @@ describe 'Admin - Evaluation', type: :feature do
             .and_return(interpretations)
           allow(restitution_globale).to receive(:structure).and_return('structure')
           allow(restitution_globale).to receive(:synthese)
+          allow(restitution_globale).to receive(:synthese_pre_positionnement)
+          allow(restitution_globale).to receive(:synthese_positionnement)
           allow(FabriqueRestitution).to receive(:restitution_globale)
             .and_return(restitution_globale)
         end
@@ -182,13 +184,15 @@ describe 'Admin - Evaluation', type: :feature do
           end
 
           it "Socle cléa en cours d'acquisition" do
-            mon_evaluation.update(synthese_competences_de_base: :socle_clea)
+            allow(restitution_globale).to receive(:synthese_pre_positionnement)
+              .and_return('socle_clea')
             visit admin_evaluation_path(mon_evaluation)
             expect(page).to have_content 'Certification Cléa indiquée'
           end
 
           it "Potentiellement en situation d'illettrisme" do
-            mon_evaluation.update(synthese_competences_de_base: :illettrisme_potentiel)
+            allow(restitution_globale).to receive(:synthese_pre_positionnement)
+              .and_return('illettrisme_potentiel')
             visit admin_evaluation_path(mon_evaluation)
             expect(page).to have_content 'Formation vivement recommandée'
           end


### PR DESCRIPTION
Jusqu'à présent, la synthèse compétences de base se voyait attribuée la synthèse de positionnement si elle était présente, sinon elle prenait la synthèse de pré-positionnement car aujourd'hui sur le produit, une campagne ne peut pas comporter à la fois café de la place et d'autres situations.
Or notre campagne custom en préprod BAS le permet, ce qui provoque une erreur 500 car il essaye de générer une synthèse "aberrant" au niveau de **Vos compétences en français et mathématiques** de la restitution, dont l'intégration est inexistante.

Aujourd'hui les conseillers ne sont donc pas capables de reproduire ce bug.

Cependant à terme, avoir toutes les situations dans une même campagne sera potentiellement quelque chose qu'on vaudra être capable de faire. Nous avons donc décidé de dissocier la synthèse positionnement, la synthèse pré-positionnement (dans deux métriques différentes, utilisées pour l'intégration de la maquette) et la synthèse globale (métrique utilisé pour des rapports de stats).