### PR TITLE
le texte de la bannière verte ne disparaît plus derrière l'image si l'écran est plus petit

### DIFF
--- a/app/assets/stylesheets/admin/composants/_card.scss
+++ b/app/assets/stylesheets/admin/composants/_card.scss
@@ -18,6 +18,9 @@
       margin-bottom: 1rem;
     }
     &--green {
+      $banner-padding: 1.5rem;
+      padding: $banner-padding;
+      gap: 2rem;
       h4 {
         margin-bottom: 2rem;
       }
@@ -31,12 +34,8 @@
         margin-top: 1rem;
       }
       .banner__icone {
-        position: absolute;
-        bottom: 0;
+        margin-bottom: -$banner-padding;
       }
-    }
-    &__texte {
-      padding: 1.5rem 1.5rem 1.5rem 0.5rem;
     }
     .banner__action {
       p {

--- a/app/views/admin/campagnes/_banniere_test_campagne.html.arb
+++ b/app/views/admin/campagnes/_banniere_test_campagne.html.arb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-div class: 'container card__banner card__banner--green d-flex justify-content-between' do
-  div(class: 'col-3') do
+div class: 'card__banner card__banner--green d-flex justify-content-between' do
+  div class: 'd-flex align-items-end' do
     svg_tag_base64 'avatar_bienvenue.svg', class: 'banner__icone'
   end
   div class: 'card__banner__texte' do


### PR DESCRIPTION
## Avant
![Capture d’écran 2022-12-01 à 14 26 41](https://user-images.githubusercontent.com/81169078/205064594-1d083137-fbff-446a-abfb-51216977339a.png)

## Après
![Capture d’écran 2022-12-01 à 14 23 47](https://user-images.githubusercontent.com/81169078/205063946-0690e5fa-aa93-4eb9-833f-392ae5e20c4c.png)