### PR TITLE
🐛 Les stats de structures actives ne sont pas justes

### DIFF
--- a/app/models/structure.rb
+++ b/app/models/structure.rb
@@ -44,9 +44,10 @@ class Structure < ApplicationRecord
   }
 
   scope :pas_vraiment_utilisatrices, lambda {
-    ids = Evaluation.joins(campagne: { compte: :structure })
-                    .select('structures.id')
-    where.not(id: ids)
+    ids_avec_evaluations = Evaluation.joins(campagne: { compte: :structure })
+                                     .select('structures.id')
+    ids_avec_campagnes = Campagne.joins(:compte).select('structure_id')
+    where.not(id: ids_avec_evaluations).where(id: ids_avec_campagnes)
   }
 
   scope :sans_campagne, lambda {

--- a/app/views/admin/structures_locales/_aide_filtres_sidebar.html.erb
+++ b/app/views/admin/structures_locales/_aide_filtres_sidebar.html.erb
@@ -1,9 +1,9 @@
 <p>ℹ️ Ces filtres s'appliquent à la structure</p>
 <ul>
-  <li><strong>Sans campagne 🙈</strong> : Aucune campagne</li>
-  <li><strong>Pas vraiment utilisatrices ☃️</strong> : Aucune évaluation</li>
-  <li><strong>Non activées 🐤</strong> : Entre 1 et 3 évaluations</li>
-  <li><strong>Actives ❤️</strong> : Au moins 4 évaluations et la dernière évaluation date de moins de 2 mois</li>
-  <li><strong>Inactives 😴</strong> : Au moins 4 évaluations et la dernière évaluation date de 6 mois à 2 mois</li>
-  <li><strong>Abandonnistes 💔</strong> : Au moins 4 évaluations et la dernière évaluation date de plus de 6 mois</li>
+  <li><strong>Sans campagne 🙈</strong> : Aucune campagne</li>
+  <li><strong>Pas vraiment utilisatrices ☃️</strong> : Avec campagne, mais sans évaluation</li>
+  <li><strong>Non activées 🐤</strong> : Entre 1 et 3 évaluations</li>
+  <li><strong>Actives ❤️</strong> : Au moins 4 évaluations et la dernière évaluation date de moins de 2 mois</li>
+  <li><strong>Inactives 😴</strong> : Au moins 4 évaluations et la dernière évaluation date de 6 mois à 2 mois</li>
+  <li><strong>Abandonnistes 💔</strong> : Au moins 4 évaluations et la dernière évaluation date de plus de 6 mois</li>
 <ul>

--- a/spec/integrations/structure_spec.rb
+++ b/spec/integrations/structure_spec.rb
@@ -25,10 +25,22 @@ describe Structure, type: :integration do
       let!(:structure_pas_utilisatrice) { create :structure_locale }
       let!(:structure_utilisatrice) { create :structure_locale }
 
-      before { cree_evaluations_pour_structure(structure_utilisatrice) }
+      context 'quand ma structure a une campagne' do
+        before do
+          compte = create(:compte, structure: structure_pas_utilisatrice)
+          create(:campagne, compte: compte)
+          cree_evaluations_pour_structure(structure_utilisatrice)
+        end
 
-      it { expect(Structure.pas_vraiment_utilisatrices).to include structure_pas_utilisatrice }
-      it { expect(Structure.pas_vraiment_utilisatrices).not_to include structure_utilisatrice }
+        it { expect(Structure.pas_vraiment_utilisatrices).to include structure_pas_utilisatrice }
+        it { expect(Structure.pas_vraiment_utilisatrices).not_to include structure_utilisatrice }
+      end
+
+      context "quand ma structure n'a pas de campagne" do
+        it do
+          expect(Structure.pas_vraiment_utilisatrices).not_to include(structure_pas_utilisatrice)
+        end
+      end
     end
 
     describe '.non_activees' do


### PR DESCRIPTION
Le scope pas_vraiment_utilisatrices prenait en compte les structures n'ayant pas de campagne

![Capture d’écran 2022-12-14 à 15 53 51](https://user-images.githubusercontent.com/7428736/207628944-36cbefc5-e147-450b-a163-f23e6eb6d85f.png)
