### PR TITLE
Ajoute un filtre pour les evaluations sans statut de mise en action

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -17,6 +17,9 @@ ActiveAdmin.register Evaluation do
          minimum_input_length: 2,
          order_by: 'libelle_asc'
   filter :created_at
+  filter :mise_en_action_effectuee_null,
+         as: :boolean,
+         label: I18n.t('activerecord.attributes.evaluation.mise_en_action_effectuee_null')
   filter :statut,
          as: :select,
          collection: Evaluation.statuts.map { |v, id|

--- a/app/assets/stylesheets/admin/layout/_sidebar.scss
+++ b/app/assets/stylesheets/admin/layout/_sidebar.scss
@@ -1,3 +1,7 @@
+#search_status_sidebar_section {
+  display: none;
+}
+
 .sidebar_section.panel {
   &.action-items-sidebar {
     @include annule-panel;

--- a/app/views/admin/dashboard/mise_en_action/_avec_evaluations.arb
+++ b/app/views/admin/dashboard/mise_en_action/_avec_evaluations.arb
@@ -4,7 +4,8 @@ div class: 'contenu-avec-evaluations' do
   div class: 'bloc-apercu-header bg-orange p-4 mb-0' do
     h3 t('.titre')
     text_node link_to t('.action', nombre_evaluations: evaluations.count),
-                      admin_evaluations_path(scope: :illettrisme_potentiel)
+                      admin_evaluations_path(q: { mise_en_action_effectuee_null: true },
+                                             scope: :illettrisme_potentiel)
   end
   div class: 'px-3' do
     div class: 'd-flex align-items-center question' do

--- a/config/locales/models/evaluation.yml
+++ b/config/locales/models/evaluation.yml
@@ -31,6 +31,7 @@ fr:
         competences_transversales_incompletes: Évaluation des compétences transversales incomplète
         competences_de_base_incompletes: Évaluation des compétences de base incomplète
         beneficiaire: Bénéficiaire
+        mise_en_action_effectuee_null: Suivi en attente
         interpretations:
           synthese_competences_de_base:
             socle_clea: supérieur


### PR DESCRIPTION
Ce filtre est utilisé quand on clique sur le bouton de l'encart « Diagnostique illettrisme » du tableau de bord « voir tout »
<img width="612" alt="Capture d’écran 2022-12-16 à 16 25 51" src="https://user-images.githubusercontent.com/298214/208131254-dfecc196-4eb8-49c5-8df3-9c6d7d67165a.png">

<img width="1250" alt="Capture d’écran 2022-12-16 à 16 25 00" src="https://user-images.githubusercontent.com/298214/208131145-56688f09-d49e-4a3a-a2a8-2d53e6abe203.png">
<img width="1253" alt="Capture d’écran 2022-12-16 à 16 25 12" src="https://user-images.githubusercontent.com/298214/208131151-deed62bd-0a24-4739-9f69-baf78cd348b0.png">


Remarque : J'ai masqué le panel résumant les filtres, car la traduction ne fonctionnait pas pour ce type de filtre.
Remarque 2 : le champ s'appelle "Suivi en attente" mais il correspond à la présence ou non de la mise en action, mais il n'est pas en relation avec le champ "Statut" juste en dessous. Heureusement, ce champ n'est visible que par les superadmin pour l'instant.