### PR TITLE
🗑️ Corrige un deprecation warning dans les tests liés à l'utilisation…

### DIFF
--- a/app/assets/stylesheets/admin/pages/dashboard/_actualites.scss
+++ b/app/assets/stylesheets/admin/pages/dashboard/_actualites.scss
@@ -65,7 +65,7 @@
       width: 100%;
       display: flex;
       justify-content: space-between;
-      align-items: end;
+      align-items: flex-end;
     }
   }
 }


### PR DESCRIPTION
… de align-items: end;

L'erreur : autoprefixer: app/assets/stylesheets/active_admin.scss:14367:3: end value has mixed support, consider using flex-end instead