### PR TITLE
Corrige la couleur du texte des boutons d'actions sur le tableau de bord

### DIFF
--- a/app/assets/stylesheets/admin/pages/dashboard/_dashboard.scss
+++ b/app/assets/stylesheets/admin/pages/dashboard/_dashboard.scss
@@ -155,6 +155,9 @@
 
     &, .evaluation {
       background-color: transparent;
+    }
+
+    .asterisque, .description {
       a { color: $eva_dark; }
     }
 

--- a/config/locales/views/dashboard.yml
+++ b/config/locales/views/dashboard.yml
@@ -27,7 +27,9 @@ fr:
 
             Nos équipes peuvent vous aider dans cette démarche d’accompagnement.
 
-            Voici les pistes de solutions disponibles dans votre région<br>(ateliers, formations, ré-orientations, accompagnement social...) :<br><a href="https://l.incubateur.net/eva-orientation" target="_blank">https://l.incubateur.net/eva-orientation</a>
+            Voici les pistes de solutions disponibles dans votre région  
+            (ateliers, formations, ré-orientations, accompagnement social…) :  
+            <a href="https://l.incubateur.net/eva-orientation" target="_blank">https://l.incubateur.net/eva-orientation</a>
         avec_evaluations:
           titre: Diagnostics d’illettrisme potentiel
           action: "Voir tout (%{nombre_evaluations})"

--- a/config/locales/views/dashboard.yml
+++ b/config/locales/views/dashboard.yml
@@ -18,6 +18,7 @@ fr:
         legende_info: "Évaluations contenant un diagnostic d'illettrisme potentiel"
       evaluation:
         date: "il y a %{date}"
+        action: Voir
       mise_en_action:
         sans_evaluations:
           titre: Diagnostics d’illettrisme potentiel


### PR DESCRIPTION
Avant
<img width="604" alt="Capture d’écran 2022-12-19 à 18 30 20" src="https://user-images.githubusercontent.com/298214/208485037-8f0b98db-bccd-4676-b3fe-1c8047e60bfe.png">

après
<img width="602" alt="Capture d’écran 2022-12-19 à 18 30 11" src="https://user-images.githubusercontent.com/298214/208485064-603d4b02-404d-45ac-ab21-d7c518db95c6.png">

Au passage, j'ai aussi corrigé un texte pour utiliser les points de suspension plutôt que trois points finaux.