### PR TITLE
masquer les actualites sur le tableau de bord pendant la prise en main

### DIFF
--- a/app/views/admin/dashboard/_dashboard.html.arb
+++ b/app/views/admin/dashboard/_dashboard.html.arb
@@ -33,7 +33,7 @@ if evaluations.present?
   end
 end
 
-if actualites.present?
+if actualites.present? && prise_en_main.terminee?
   div class: 'section-actualites' do
     columns do
       render 'actualites', actualites: actualites


### PR DESCRIPTION
![Capture d’écran 2022-12-21 à 16 19 50](https://user-images.githubusercontent.com/81169078/208939941-418b277a-fcc6-42dd-9bb6-129a5cd1cbbd.png)
