### PR TITLE
affecte le code postal correspondant à la recherche en cas de succès …

### DIFF
--- a/app/assets/javascripts/autocomplete_recherche_structure.js
+++ b/app/assets/javascripts/autocomplete_recherche_structure.js
@@ -2,6 +2,19 @@ function estUnCodePostal(texte) {
   return texte.match(/^\d{5}$/);
 }
 
+function construitReponse(item, codePostalSaisi) {
+  const ville = item.nom;
+  let codePostal = '';
+  if (codePostalSaisi && item.codesPostaux.length > 1) {
+    codePostal = codePostalSaisi
+  } else {
+    codePostal = item.codesPostaux[0];
+  }
+  const label = `${ville} (${codePostal})`;
+  return { label: label, value: label, code_postal: codePostal };
+}
+
+
 document.addEventListener('DOMContentLoaded', () => {
   $( ".champ-recherche" ).autocomplete({
     source: function (request, response) {
@@ -9,7 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!request.term.match(/^\d{1,4}$/)) {
         let data = { limit: 6, type: 'commune-actuelle,arrondissement-municipal' };
         if (estUnCodePostal(request.term)) {
-          data.codePostal = request.term 
+          data.codePostal = request.term
         } else {
           data.nom = request.term;
           data.boost = 'population';
@@ -18,12 +31,10 @@ document.addEventListener('DOMContentLoaded', () => {
           url: "https://geo.api.gouv.fr/communes",
           data: data,
           dataType: "json",
-          success: function (data) {
-            response($.map(data, function (item) {
-              const ville = item.nom;
-              const codePostal = item.codesPostaux[0];
-              const label = `${ville} (${codePostal})`;
-              return { label: label, value: label, code_postal: codePostal };
+          success: function (datas) {
+            response($.map(datas, function (item) {
+              const reponse = construitReponse(item, data.codePostal)
+              return reponse;
             }))
           },
           error: function () {


### PR DESCRIPTION
…plutôt que le premier element du tableau qui n'est pas systématiquement trié par pertinence du résultat.

## Explications

On constate que pour une ville donnée, l'API renvoie un tableau de codes postaux qui peut en contenir plusieurs. (ex de Montpellier ci dessous ⤵️)
<img width="1501" alt="Capture d’écran 2022-12-27 à 13 05 09" src="https://user-images.githubusercontent.com/81169078/209695131-81c02d58-0385-4ba2-995e-b4408662ad2c.png">

En cas de succès, il est nécessaire d'affecter au résultat le code postal saisi par l'utilisateur et non pas le premier élément du tableau.
Si la ville ne possède qu'un seul code postal, alors on peut affecter au résultat le premier élément du tableau.

<img width="634" alt="Capture d’écran 2022-12-27 à 17 39 35" src="https://user-images.githubusercontent.com/81169078/209695635-911b193b-1412-407a-9c82-f4da0ba0ab4f.png">
<img width="631" alt="Capture d’écran 2022-12-27 à 17 39 44" src="https://user-images.githubusercontent.com/81169078/209695646-931ec0b8-3b4c-4ce7-ba13-80a6dea3af14.png">
