### PR TITLE
Laisser la prise en main en 3 étapes

### DIFF
--- a/app/models/prise_en_main.rb
+++ b/app/models/prise_en_main.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PriseEnMain
-  ETAPES = %w[creation_campagne test_campagne passations retour_experience].freeze
+  ETAPES = %w[creation_campagne test_campagne passations].freeze
 
   def initialize(compte:, nombre_campagnes:, nombre_evaluations:)
     @compte = compte
@@ -13,12 +13,10 @@ class PriseEnMain
     return 'creation_campagne' if @nombre_campagnes.zero?
     return 'test_campagne' if @nombre_evaluations.zero?
     return 'passations' if @nombre_evaluations < 4
-
-    'retour_experience'
   end
 
   def terminee?
-    !@compte.nouveau_compte? && @nombre_evaluations >= 4
+    @nombre_evaluations >= 4
   end
 
   def en_cours?

--- a/app/views/components/prise_en_main/_etape_retour_experience.html.arb
+++ b/app/views/components/prise_en_main/_etape_retour_experience.html.arb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-render partial: 'components/prise_en_main/carte_base', locals: {
-  etape_en_cours: 'retour_experience',
-  lien_action: Eva::DOCUMENT_PRISE_EN_MAIN,
-  options_lien: { target: '_blank' }
-}

--- a/config/locales/views/components.yml
+++ b/config/locales/views/components.yml
@@ -64,11 +64,10 @@ fr:
       sous_titre: Bien débuter
       etapes:
         progression:
-          titre: Débutez eva en 4 étapes
+          titre: Débutez eva en 3 étapes
           creation_campagne: Campagne créée
           test_campagne: Campagne testée
           passations: 4 passations effectuées
-          retour_experience: Retour d’expérience effectué
         creation_campagne:
           titre: |
             ## Créez votre campagne
@@ -85,8 +84,3 @@ fr:
           description: "[Organisez une session eva](%{lien}), et faites au moins 4 passations. Vous pouvez les consulter dans la section « *Vos dernières évaluations* » ci-dessous."
           passations_restantes: |
             **Il vous reste %{passations_restantes} à faire pour valider cette étape !**
-        retour_experience:
-          titre: |
-            ## Utilisez eva
-          description: Bravo, vous pouvez maintenant utiliser eva ! Rappelez-vous qu'eva est un service public accompagné, adapté pour un public francophone avec des compétences numériques minimales.
-          action: Consulter le guide de prise en main

--- a/spec/models/prise_en_main_spec.rb
+++ b/spec/models/prise_en_main_spec.rb
@@ -32,13 +32,6 @@ describe PriseEnMain do
 
       it { expect(prise_en_main.etape_en_cours).to eq 'passations' }
     end
-
-    context "quand il y a au moins 4 évaluations et qu'il y a une campagne" do
-      let(:nombre_campagnes) { 1 }
-      let(:nombre_evaluations) { 4 }
-
-      it { expect(prise_en_main.etape_en_cours).to eq 'retour_experience' }
-    end
   end
 
   describe '#terminee?' do


### PR DESCRIPTION
La prise en main reste pour l'instant en 3 étapes. On n'intègre pas la 4éme étape "retour d'expérience".
Pour l'instant, l'encart disparaît lorsque la quatrième passation est effectuée. (un écran de fin est à suivre dans to do dev)
![Capture d’écran 2023-01-02 à 15 41 41](https://user-images.githubusercontent.com/81169078/210246185-ad33bb85-a5d9-4358-8eeb-0983f2e2457e.png)
