### PR TITLE
affiche un message d'erreur si on essaye de personnaliser une campagn…

### DIFF
--- a/app/models/campagne.rb
+++ b/app/models/campagne.rb
@@ -7,6 +7,7 @@ class Campagne < ApplicationRecord
   SITUATIONS_PRE_POSITIONNEMENT = %w[maintenance livraison objets_trouves].freeze
   SITUATIONS_POSITIONNEMENT = %w[cafe_de_la_place].freeze
   PERSONNALISATION = %w[plan_de_la_ville bienvenue livraison].freeze
+  SITUATION_BUREAU = %w[questions].freeze
 
   acts_as_paranoid
 
@@ -17,6 +18,7 @@ class Campagne < ApplicationRecord
   belongs_to :compte
   belongs_to :parcours_type, optional: true
 
+  validate :ajoute_questionnaire_bureau, if: proc { configuration_inclus?(SITUATION_BUREAU) }
   validates :type_programme, presence: true, on: :create
   validates :parcours_type, presence: true, on: :create
   validates :libelle, presence: true
@@ -121,5 +123,11 @@ class Campagne < ApplicationRecord
     return false if options_personnalisation.nil?
 
     options_personnalisation.include? 'livraison'
+  end
+
+  def ajoute_questionnaire_bureau
+    return if questionnaire&.nom_technique == 'bureau'
+
+    errors.add :questionnaire, :bureau
   end
 end

--- a/config/locales/models/campagne.yml
+++ b/config/locales/models/campagne.yml
@@ -22,6 +22,8 @@ fr:
               blank: 'Vous devez choisir un type de programme.'
             code:
               invalid: Majuscules et chiffres uniquement
+            questionnaire:
+              bureau: "Doit contenir le questionnaire associé à Bureau"
   formtastic:
     labels:
       libelle: Libellé

--- a/spec/models/campagne_spec.rb
+++ b/spec/models/campagne_spec.rb
@@ -10,6 +10,32 @@ describe Campagne, type: :model do
   it { is_expected.not_to allow_value('abcd1234').for(:code) }
   it { is_expected.to belong_to(:questionnaire).optional }
 
+  describe 'configuration personnalisée' do
+    let(:campagne) { Campagne.new }
+
+    context 'quand la situation bureau est dans la configuration' do
+      let(:bureau) { create :situation, nom_technique: :questions }
+
+      before do
+        campagne.situations_configurations
+                .push SituationConfiguration.new situation: bureau
+      end
+
+      it 'ne peut pas créer la campagne sans lui associer le questionnaire bureau' do
+        campagne.save
+        erreur = 'Doit contenir le questionnaire associé à Bureau'
+        expect(campagne.errors[:questionnaire]).to include erreur
+      end
+    end
+
+    context "quand la situation bureau n'est pas dans la configuration" do
+      it do
+        campagne.save
+        expect(campagne.errors[:questionnaire]).to eq []
+      end
+    end
+  end
+
   describe '#questionnaire_pour' do
     let(:campagne) { Campagne.new }
     let(:situation) { Situation.new }


### PR DESCRIPTION
…e avec la situation bureau sans le questionnaire correspondant.

Ce fix intervient suite à l'erreur [rollbar #690] (https://rollbar.com/eva-betagouv/eva/items/690/?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification)

Fonctionnalité accessible qu'au superadmin.

![Capture d’écran 2023-01-11 à 17 15 17](https://user-images.githubusercontent.com/81169078/211858428-c0b4beac-4221-49a9-b77a-05846b86e576.png)
