### PR TITLE
Affiche la synthèse de positionnement pour lettrisme

### DIFF
--- a/app/views/admin/evaluations/_restitution_globale.arb
+++ b/app/views/admin/evaluations/_restitution_globale.arb
@@ -111,7 +111,7 @@ div class: 'evaluation__restitution-globale' do
 
       render partial: 'lettrisme',
              locals: {
-               synthese: restitution_globale.synthese,
+               synthese: restitution_globale.synthese_positionnement,
                pdf: pdf
              }
       render 'pied_page'


### PR DESCRIPTION
Si par erreur on a fait une campagne avec des MES de pré-positionnement des compétences de base et en même ajouté café de la place, il ne faut pas essaye d'afficher la synthèse globale pour la restitution de café de la place, mais seulement la synthèse de positionnement.

Il n'en reste pas moins que la restitution sera incohérente puis qu'elle affichera à la fois un résultat de pré-positionnement et de positionnement. Mais au moins, l'affichage de la restitution du positionnement n'aura pas l'air buggée.

Avant : 
<img width="963" alt="Capture d’écran 2023-01-13 à 15 00 31" src="https://user-images.githubusercontent.com/298214/212337489-ed71c109-f8e5-413c-89f5-fe92358ab1a2.png">

Après : 
<img width="975" alt="Capture d’écran 2023-01-13 à 15 00 19" src="https://user-images.githubusercontent.com/298214/212337529-2a4e159b-353c-402b-a538-cd9bc7055d6e.png">
