### PR TITLE
💄 Mise en page du menu "Gestion" dans la fiche évaluation

### DIFF
--- a/app/assets/stylesheets/admin/layout/_main_structure.scss
+++ b/app/assets/stylesheets/admin/layout/_main_structure.scss
@@ -1,5 +1,8 @@
 #active_admin_content {
-  padding: 3rem 0;
+  padding: .5rem 0;
+  #main_content_wrapper #main_content {
+    margin-top: 2.5rem;
+  }
 }
 
 body.logged_in {

--- a/app/assets/stylesheets/admin/layout/_sidebar.scss
+++ b/app/assets/stylesheets/admin/layout/_sidebar.scss
@@ -4,8 +4,9 @@
 
 .sidebar_section.panel {
   &.action-items-sidebar {
-    @include annule-panel;
-    margin-bottom: 2rem;
+    @include annule-carte;
+    @include panel-gris();
+    margin-bottom: 0.5rem;
   }
 
   &.annule-panel {

--- a/app/assets/stylesheets/admin/mixins/_panels.scss
+++ b/app/assets/stylesheets/admin/mixins/_panels.scss
@@ -5,3 +5,17 @@
     display: none;
   }
 }
+
+@mixin panel-gris() {
+  @include carte-grise();
+  padding: 1rem;
+  box-shadow: none;
+  h3 {
+    margin-top: 0;
+    margin-bottom: .5rem;
+    text-transform: uppercase;
+    font-size: 1rem;
+    font-weight: 600;
+    font-family: $font-texte;
+  }
+}

--- a/app/assets/stylesheets/admin/pages/_evaluations.scss
+++ b/app/assets/stylesheets/admin/pages/_evaluations.scss
@@ -11,19 +11,12 @@
 }
 
 #responsable_de_suivi_sidebar_section {
-  $largeur-panel: 18.125rem;
-  $padding: 1rem;
-  @include carte-grise();
-  padding: 1rem;
-  box-shadow: none;
-  h3 {
-    text-transform: uppercase;
-    font-size: 1rem;
-    margin-bottom: .5rem;
-    font-weight: 600;
-    font-family: $font-texte;
-  }
+  @include panel-gris();
   .tag {
+    $largeur-panel: 18.125rem;
+    $padding: 1rem;
+
+    display: inline-block;
     @include tronque;
     display: inline-block;
     max-width: calc(#{ $largeur-panel - ($padding * 2) });

--- a/config/locales/activeadmin.yml
+++ b/config/locales/activeadmin.yml
@@ -58,6 +58,7 @@ fr:
     sidebars:
       filters: Rechercher
       autres_actualites: Les autres actualités sur eva
+      action_items: Gestion
     scopes:
       sans_campagne: Sans campagne 🙈
       pas_vraiment_utilisatrices: Pas vraiment utilisatrices ☃️

--- a/config/locales/models/evaluation.yml
+++ b/config/locales/models/evaluation.yml
@@ -79,3 +79,4 @@ fr:
     resources:
       evaluation:
         delete_model: Supprimer
+        edit_model: Modifier


### PR DESCRIPTION
Le panneau "Gestion" est diffusé sur toutes les pages où on a la possibilité d'effectuer une action.
L'espace entre la sidebar et le header est réduit sur toute l'app pour correspondre à l'espacement qu'on a intégré entre le panneau gestion et le header.
--> ces deux points ont été vu avec Benjamin
![Capture d’écran 2023-01-25 à 16 28 43](https://user-images.githubusercontent.com/81169078/214604524-6442ad6a-8cab-4e7b-a038-5e92bbee7d09.png)

