### PR TITLE
Utilise les variables de dimentionnement de la sidebar d'activeadmin et corrige la taille des champs

### DIFF
--- a/app/assets/stylesheets/admin/_variables.scss
+++ b/app/assets/stylesheets/admin/_variables.scss
@@ -26,7 +26,7 @@ $couleur-niveau-3: $couleur-accent-erreur;
 
 $container: 1220px;
 $sidebar-width: 290px;
-$sidebar-space: calc(#{$sidebar-width} + 20px);
+$section-padding: 10px;
 
 $grid-gutter-width: 3rem;
 

--- a/app/assets/stylesheets/admin/composants/_filtres.scss
+++ b/app/assets/stylesheets/admin/composants/_filtres.scss
@@ -1,7 +1,11 @@
 .sidebar_section {
   form.filter_form {
     .filter_form_field {
-      &.select_and_search,
+      &.select_and_search {
+        input[type='text'] {
+          width: 6.4rem;
+        }
+      }
       &.filter_date_range {
         input[type='text'] {
           width: 7.188rem;

--- a/app/assets/stylesheets/admin/layout/_main_structure.scss
+++ b/app/assets/stylesheets/admin/layout/_main_structure.scss
@@ -1,15 +1,5 @@
 #active_admin_content {
   padding: 3rem 0;
-
-  #main_content_wrapper {
-    #main_content {
-      margin-right: $sidebar-space;
-    }
-  }
-  #sidebar {
-    width: $sidebar-width;
-    margin-left: -$sidebar-width;
-  }
 }
 
 body.logged_in {

--- a/app/assets/stylesheets/admin/pages/_structure.scss
+++ b/app/assets/stylesheets/admin/pages/_structure.scss
@@ -5,7 +5,7 @@
 
   // laisse une place à droite du #main_content pour la sidebar même si elle n'est pas là.
   #active_admin_content.without_sidebar #main_content_wrapper #main_content {
-    margin-right: $sidebar-space;
+    margin-right: $sidebar-width + ($section-padding * 2);
   }
 
   &.show {


### PR DESCRIPTION
Utilise les variables de dimentionnement de la sidebar d'activeadmin et corrige la taille des champs

Avant :
<img width="1302" alt="Capture d’écran 2023-01-25 à 10 12 38" src="https://user-images.githubusercontent.com/298214/214540085-3eb6ef25-64d2-4401-9d85-7c87fa046830.png">


Après :
<img width="1258" alt="Capture d’écran 2023-01-25 à 11 26 35" src="https://user-images.githubusercontent.com/298214/214539536-b019a833-c4f4-4e7d-b83c-4eb67a12188c.png">
