### PR TITLE
corrige espacement entre les sous compétences du bloc lettrisme et le…

### DIFF
--- a/app/assets/stylesheets/admin/composants/_lettrisme.scss
+++ b/app/assets/stylesheets/admin/composants/_lettrisme.scss
@@ -22,13 +22,6 @@
     }
   }
 
-  &:has(.telechargement_des_reponses) {
-    .panel--avec-references, .referentiel_anlci {
-      border-bottom-left-radius: 0px;
-      border-bottom-right-radius: 0px;
-    }
-  }
-
   .telechargement_des_reponses:hover {
     background-color: $eva_light;
     border: 2px solid $eva_main_blue;

--- a/app/assets/stylesheets/admin/composants/_lettrisme.scss
+++ b/app/assets/stylesheets/admin/composants/_lettrisme.scss
@@ -1,7 +1,7 @@
 .evaluation__restitution-globale {
   .sous-competence__container {
-    padding: 10px 0px;
-    margin-top: 2rem;
+    padding: .5rem 0;
+    margin: 2rem;
     img {
       height: 4rem;
     }

--- a/app/assets/stylesheets/admin/pages/restitution_globale/_base.scss
+++ b/app/assets/stylesheets/admin/pages/restitution_globale/_base.scss
@@ -224,7 +224,7 @@
     color: $eva_light;
     border-radius: 2rem;
     padding: 2rem 2rem;
-    margin: 0 5rem 3rem;
+    margin: 0 5rem 2rem;
     background-color: $eva-dark;
 
     a {


### PR DESCRIPTION
J'ai utilisé un `margin-bottom` sur le composant sous_compétences plutôt qu'un `margin-top` sur le composant référentiels_anlci pour éviter de devoir retravailler le style du pdf (car on ne veut pas de margin-top sur le composant référentiels dans le pdf)

## Sans sous compétences
![Capture d’écran 2023-01-25 à 17 41 41](https://user-images.githubusercontent.com/81169078/214624240-aceddf59-2dd7-4304-8d0d-f246466115e1.png)

## Avec sous compétences
![Capture d’écran 2023-01-25 à 17 42 07](https://user-images.githubusercontent.com/81169078/214624244-7e19fe40-5850-4f4a-97bd-c81b8c0fd18d.png)
