### PR TITLE
🐛 Corrige la mise en forme de l'image de la dernière actualité sur le…

### DIFF
--- a/app/assets/stylesheets/admin/pages/dashboard/_bloc_actualites.scss
+++ b/app/assets/stylesheets/admin/pages/dashboard/_bloc_actualites.scss
@@ -3,6 +3,10 @@
     height: 17rem;
     .card { padding: 0;}
     .carte__illustration {
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: cover;
+
       overflow: hidden;
       height: 8rem;
       img {

--- a/app/views/admin/dashboard/_bloc_actualites.html.erb
+++ b/app/views/admin/dashboard/_bloc_actualites.html.erb
@@ -8,9 +8,10 @@
     <div class='col derniere-actualite'>
       <%= render(CarteComponent.new([:admin, actualites.first])) do %>
       <% actualite = actualites.first %>
-        <div class='carte__illustration w-100'>
-          <%= image_tag cdn_for(actualite.illustration) if actualite.illustration.attached? %>
-        </div>
+        <% if actualite.illustration.attached? %>
+          <div class='carte__illustration w-100' style="background-image: url('<%= cdn_for(actualite.illustration) %>');">
+          </div>
+        <% end %>
         <div class='carte__texte d-flex'>
           <div class='entete'>
             <%= render 'components/tag', contenu: t(".categories.#{actualite.categorie}"),


### PR DESCRIPTION
… tableau de bord

![Capture d’écran 2023-02-01 à 17 34 40](https://user-images.githubusercontent.com/7428736/216104893-04dae6fd-10b8-41c3-aadf-4c29fcfd571d.png)

![Capture d’écran 2023-02-01 à 17 34 45](https://user-images.githubusercontent.com/7428736/216104873-7ab5b29d-6dc9-4337-9a67-a3c610d5bc58.png)
