### PR TITLE
Export des évaluations :  profil ANLCI pour les évaluations café de la place

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -87,24 +87,24 @@ ActiveAdmin.register Evaluation do
     whitelist
     column('structure') { |evaluation| evaluation.campagne.compte.structure.nom }
     column(:campagne) { |evaluation| evaluation.campagne.libelle }
-    column('date') { |evaluation| I18n.l(evaluation.created_at, format: :sans_heure) }
+    column(:created_at) { |evaluation| I18n.l(evaluation.created_at, format: :sans_heure) }
     column :nom
     column(:completude) do |evaluation|
       I18n.t(evaluation.completude, scope: 'activerecord.attributes.evaluation')
     end
-    column('synthese') do |evaluation|
+    column(:synthese_competences_de_base) do |evaluation|
       traduction_niveau(evaluation, :synthese_competences_de_base)
     end
-    column('niveau_cefr') do |evaluation|
+    column(:niveau_cefr) do |evaluation|
       traduction_niveau(evaluation, :niveau_cefr)
     end
-    column('niveau_cnef') do |evaluation|
+    column(:niveau_cnef) do |evaluation|
       traduction_niveau(evaluation, :niveau_cnef)
     end
-    column('anlci_litteratie') do |evaluation|
+    column(:niveau_anlci_litteratie) do |evaluation|
       traduction_niveau(evaluation, :niveau_anlci_litteratie)
     end
-    column('anlci_numeratie') do |evaluation|
+    column(:niveau_anlci_numeratie) do |evaluation|
       traduction_niveau(evaluation, :niveau_anlci_numeratie)
     end
   end

--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -43,7 +43,7 @@ ActiveAdmin.register Evaluation do
         }, :illettrisme_potentiel
 
   index download_links: lambda {
-                          params[:action] == 'show' ? [:pdf] : %i[csv xls json]
+                          params[:action] == 'show' ? %i[pdf] : %i[xls]
                         }, row_class: lambda { |elem|
                                         'anonyme' if elem.anonyme?
                                       } do

--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -83,28 +83,28 @@ ActiveAdmin.register Evaluation do
     end
   end
 
-  xls do
+  xls(i18n_scope: %i[active_admin xls evaluation]) do
     whitelist
-    column('Structure') { |evaluation| evaluation.campagne.compte.structure.nom }
+    column('structure') { |evaluation| evaluation.campagne.compte.structure.nom }
     column(:campagne) { |evaluation| evaluation.campagne.libelle }
-    column('Date') { |evaluation| I18n.l(evaluation.created_at, format: :sans_heure) }
+    column('date') { |evaluation| I18n.l(evaluation.created_at, format: :sans_heure) }
     column :nom
-    column('passation complète') do |evaluation|
+    column(:completude) do |evaluation|
       I18n.t(evaluation.completude, scope: 'activerecord.attributes.evaluation')
     end
-    column('Niveau global') do |evaluation|
+    column('synthese') do |evaluation|
       traduction_niveau(evaluation, :synthese_competences_de_base)
     end
-    column('Niveau cefr') do |evaluation|
+    column('niveau_cefr') do |evaluation|
       traduction_niveau(evaluation, :niveau_cefr)
     end
-    column('Niveau cnef') do |evaluation|
+    column('niveau_cnef') do |evaluation|
       traduction_niveau(evaluation, :niveau_cnef)
     end
-    column('ANLCI Littératie') do |evaluation|
+    column('anlci_litteratie') do |evaluation|
       traduction_niveau(evaluation, :niveau_anlci_litteratie)
     end
-    column('ANLCI Numératie') do |evaluation|
+    column('anlci_numeratie') do |evaluation|
       traduction_niveau(evaluation, :niveau_anlci_numeratie)
     end
   end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -4,7 +4,10 @@ class Evaluation < ApplicationRecord
   SYNTHESES = %w[illettrisme_potentiel socle_clea ni_ni aberrant].freeze
   NIVEAUX_CEFR = %w[pre_A1 A1 A2 B1].freeze
   NIVEAUX_CNEF = %w[pre_X1 X1 X2 Y1].freeze
-  NIVEAUX_ANLCI = %w[profil1 profil2 profil3 profil4 profil4_plus profil4_plus_plus].freeze
+  NIVEAUX_ANLCI = %w[profil1 profil2 profil3
+                     profil4 profil4_plus profil4_plus_plus
+                     profil_4h profil_4h_plus profil_4h_plus_plus
+                     profil_aberrant indetermine].freeze
   NIVEAUX_COMPLETUDE = %w[incomplete
                           competences_de_base_incompletes
                           competences_transversales_incompletes

--- a/app/models/restitution/globale.rb
+++ b/app/models/restitution/globale.rb
@@ -10,7 +10,8 @@ module Restitution
              to: :scores_niveau2_standardises, prefix: :niveau2
     delegate :moyennes_metriques, :ecarts_types_metriques,
              to: :scores_niveau1_standardises, prefix: :niveau1
-    delegate :synthese, :synthese_positionnement, :synthese_pre_positionnement, to: :synthetiseur
+    delegate :synthese, :synthese_positionnement, :synthese_pre_positionnement,
+             :niveau_anlci_litteratie, to: :synthetiseur
 
     def initialize(evaluation:, restitutions:)
       @evaluation = evaluation
@@ -79,7 +80,7 @@ module Restitution
         synthese_competences_de_base: synthese,
         niveau_cefr: interpreteur_niveau1.interpretations_cefr[:litteratie],
         niveau_cnef: interpreteur_niveau1.interpretations_cefr[:numeratie],
-        niveau_anlci_litteratie: interpreteur_niveau1.interpretations_anlci[:litteratie],
+        niveau_anlci_litteratie: niveau_anlci_litteratie,
         niveau_anlci_numeratie: interpreteur_niveau1.interpretations_anlci[:numeratie]
       }
     end

--- a/app/models/restitution/illettrisme/synthetiseur.rb
+++ b/app/models/restitution/illettrisme/synthetiseur.rb
@@ -26,6 +26,11 @@ module Restitution
         Synthetiseur.calcule_synthese(@algo_pre_positionnement)
       end
 
+      def niveau_anlci_litteratie
+        @algo_positionnement&.niveau_anlci_litteratie ||
+          @algo_pre_positionnement&.niveau_anlci_litteratie
+      end
+
       def self.calcule_synthese(algo)
         return if algo.blank? || algo.indetermine?
         return 'illettrisme_potentiel' if algo.illettrisme_potentiel?
@@ -58,6 +63,10 @@ module Restitution
           @interpreteur.interpretations_cefr[:litteratie].blank? and
             @interpreteur.interpretations_cefr[:numeratie].blank?
         end
+
+        def niveau_anlci_litteratie
+          @interpreteur.interpretations_anlci[:litteratie]
+        end
       end
 
       class SynthetiseurPositionnement
@@ -79,6 +88,10 @@ module Restitution
 
         def indetermine?
           @niveau_positionnement == :indetermine
+        end
+
+        def niveau_anlci_litteratie
+          @niveau_positionnement
         end
       end
     end

--- a/config/locales/models/evaluation.yml
+++ b/config/locales/models/evaluation.yml
@@ -91,11 +91,11 @@ fr:
       evaluation:
         structure: Structure
         campagne: Campagne
-        date: Date
+        created_at: Date
         nom: Nom
         completude: Passation complète ?
-        synthese: Niveau global
+        synthese_competences_de_base: Niveau global
         niveau_cefr: Niveau CEFR
         niveau_cnef: Niveau CNEF
-        anlci_litteratie: ANLCI Littératie
-        anlci_numeratie: ANLCI Numératie
+        niveau_anlci_litteratie: ANLCI Littératie
+        niveau_anlci_numeratie: ANLCI Numératie

--- a/config/locales/models/evaluation.yml
+++ b/config/locales/models/evaluation.yml
@@ -57,6 +57,11 @@ fr:
             profil4: Profil 4
             profil4_plus: Profil 4+
             profil4_plus_plus: Profil 4++
+            profil_4h: Profil 4H
+            profil_4h_plus: Profil 4H+
+            profil_4h_plus_plus: Profil 4H++
+            profil_aberrant: Aberrant
+            indetermine: Indéterminé
           niveau_anlci_numeratie:
             profil1: Profil 1
             profil2: Profil 2

--- a/config/locales/models/evaluation.yml
+++ b/config/locales/models/evaluation.yml
@@ -87,3 +87,15 @@ fr:
       evaluation:
         delete_model: Supprimer
         edit_model: Modifier
+    xls:
+      evaluation:
+        structure: Structure
+        campagne: Campagne
+        date: Date
+        nom: Nom
+        completude: Passation complète ?
+        synthese: Niveau global
+        niveau_cefr: Niveau CEFR
+        niveau_cnef: Niveau CNEF
+        anlci_litteratie: ANLCI Littératie
+        anlci_numeratie: ANLCI Numératie

--- a/lib/tasks/evaluations.rake
+++ b/lib/tasks/evaluations.rake
@@ -6,9 +6,14 @@ namespace :evaluations do
   desc "calcule les restitutions pour l'ensemble des évaluations"
   task calcule_restitution: :environment do
     logger = RakeLogger.logger
-    nombre_eval = Evaluation.count
+    evaluations = Evaluation
+    if ENV.key?('CAFE_DE_LA_PLACE_SEULEMENT')
+      parties = Partie.where(situation: Situation.where(nom_technique: 'cafe_de_la_place'))
+      evaluations = evaluations.where(parties: parties)
+    end
+    nombre_eval = evaluations.count
     logger.info "Nombre d'évaluation : #{nombre_eval}"
-    Evaluation.find_each do |evaluation|
+    evaluations.find_each do |evaluation|
       restitution_globale = FabriqueRestitution.restitution_globale(evaluation)
       restitution_globale.persiste
       nombre_eval -= 1

--- a/spec/models/restitution/globale_spec.rb
+++ b/spec/models/restitution/globale_spec.rb
@@ -193,7 +193,7 @@ describe Restitution::Globale do
       end
     end
 
-    context 'evaluation avancée' do
+    context 'positionnement' do
       let(:interpreteur_niveau1) do
         double(
           synthese: nil,
@@ -218,7 +218,7 @@ describe Restitution::Globale do
               synthese_competences_de_base: 'illettrisme_potentiel',
               niveau_cefr: nil,
               niveau_cnef: nil,
-              niveau_anlci_litteratie: nil,
+              niveau_anlci_litteratie: :profil2,
               niveau_anlci_numeratie: nil
             }
           )
@@ -235,7 +235,7 @@ describe Restitution::Globale do
               synthese_competences_de_base: 'ni_ni',
               niveau_cefr: nil,
               niveau_cnef: nil,
-              niveau_anlci_litteratie: nil,
+              niveau_anlci_litteratie: :profil3,
               niveau_anlci_numeratie: nil
             }
           )

--- a/spec/models/restitution/illettrisme/synthetiseur_spec.rb
+++ b/spec/models/restitution/illettrisme/synthetiseur_spec.rb
@@ -189,9 +189,31 @@ describe Restitution::Illettrisme::Synthetiseur do
       it { expect(synthese(:profil_aberrant)).to eq 'aberrant' }
       it { expect(synthese(:indetermine)).to eq nil }
     end
+
+    describe '#niveau_anlci_litteratie' do
+      it "quand l'interpreteur n'existe pas" do
+        synthetiseur = Restitution::Illettrisme::Synthetiseur.new nil, nil
+        expect(synthetiseur.niveau_anlci_litteratie).to eq nil
+      end
+
+      it "quand le niveau n'existe pas" do
+        allow(interpreteur_positionnement).to receive(:synthese).and_return({})
+        expect(subject.niveau_anlci_litteratie).to eq nil
+      end
+
+      it 'quand le niveau existe' do
+        allow(interpreteur_positionnement).to receive(:synthese).and_return(
+          {
+            niveau_litteratie: :profil1
+          }
+        )
+
+        expect(subject.niveau_anlci_litteratie).to eq :profil1
+      end
+    end
   end
 
-  describe '#synthese' do
+  context 'quand il y a un positionnement et un pré-positionnement' do
     let(:interpreteur_positionnement) { double }
     let(:interpreteur_pre_positionnement) { double }
     let(:subject) do
@@ -199,22 +221,28 @@ describe Restitution::Illettrisme::Synthetiseur do
                                                  interpreteur_positionnement
     end
 
-    context 'quand il y a un positionnement et un pré-positionnement' do
-      before do
-        allow(interpreteur_positionnement).to receive(:synthese).and_return(
-          {
-            niveau_litteratie: :profil_aberrant
-          }
-        )
-        allow(interpreteur_pre_positionnement).to receive(:interpretations_cefr).and_return(
-          {
-            litteratie: nil, numeratie: nil
-          }
-        )
-      end
+    before do
+      allow(interpreteur_positionnement).to receive(:synthese).and_return(
+        {
+          niveau_litteratie: :profil_aberrant
+        }
+      )
+      allow(interpreteur_pre_positionnement).to receive(:interpretations_cefr).and_return(
+        {
+          litteratie: nil, numeratie: nil
+        }
+      )
+    end
 
+    describe '#synthese' do
       it 'retourne la synthèse positionnement' do
         expect(subject.synthese).to eq 'aberrant'
+      end
+    end
+
+    describe '#niveau_anlci_litteratie' do
+      it 'retourne le niveau de positionnement' do
+        expect(subject.niveau_anlci_litteratie).to eq :profil_aberrant
       end
     end
   end


### PR DESCRIPTION
<img width="1358" alt="Capture d’écran 2023-02-03 à 14 34 54" src="https://user-images.githubusercontent.com/298214/216616528-533c942d-6341-4858-ab25-257894022287.png">

Cette PR retire aussi les exports CSV et JSON :
En effet, ces téléchargements n'étaient pas gérés et permettaient d'accéder à des informations normalement réservées aux `superadmin` comme la date de fin d'une évaluation.

Pour tester il faut refaire le calcul des évaluations contenant `cafe_de_la_place` : 

    $> bundle exec rake evaluations:calcule_restitution CAFE_DE_LA_PLACE_SEULEMENT=true