### PR TITLE
Met la pastille à gauche du nom dans les évaluations et ajout du composant au storybook

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -36,10 +36,10 @@ ActiveAdmin.register Evaluation do
 
   scope proc { I18n.t('activerecord.scopes.evaluation.all') }, :all, default: true
   scope proc {
-          render partial: 'pastille_illettrisme_potentiel',
-                 locals: {
-                   etiquette: I18n.t('activerecord.scopes.evaluation.illettrisme_potentiel')
-                 }
+          render(PastilleComponent.new(
+                   couleur: 'alerte',
+                   etiquette: I18n.t('components.pastille.illettrisme_potentiel')
+                 ))
         }, :illettrisme_potentiel
 
   show do
@@ -54,14 +54,16 @@ ActiveAdmin.register Evaluation do
                         }, row_class: lambda { |elem|
                                         'anonyme' if elem.anonyme?
                                       } do
-    column(:nom) { |e| nom_pour_ressource(e) }
-
-    if params[:scope] != 'illettrisme_potentiel'
-      column do |evaluation|
-        if evaluation.illettrisme_potentiel?
-          render partial: 'pastille_illettrisme_potentiel',
-                 locals: { avec_tooltip: true }
+    column(:nom) do |evaluation|
+      div class: 'd-flex' do
+        if params[:scope] != 'illettrisme_potentiel'
+          render(PastilleComponent.new(
+                   couleur: evaluation.illettrisme_potentiel? ? 'alerte' : '',
+                   tooltip_content: I18n.t('components.pastille.illettrisme_potentiel')
+                 ))
         end
+
+        div nom_pour_ressource(evaluation), class: 'nom'
       end
     end
 

--- a/app/assets/stylesheets/admin/composants/_ellipse.scss
+++ b/app/assets/stylesheets/admin/composants/_ellipse.scss
@@ -7,6 +7,7 @@ $largeur-tick: .75rem;
   height: 1rem;
   border-radius: 50%;
   display: inline-block;
+  flex-shrink: 0;
 
   &.ellipse-a-cocher {
     border: 1px solid $eva_dark_blue_grey;
@@ -15,7 +16,7 @@ $largeur-tick: .75rem;
     height: $taille-ellipse;
   }
 
-  &.ellipse__105 {
+  &.ellipse--alerte {
     background: $eva_orange;
   }
 
@@ -37,6 +38,3 @@ $largeur-tick: .75rem;
   left: calc(#{$taille-ellipse - $largeur-tick} / 2);
 }
 
-.paginated_collection .ellipse {
-  margin-top:6px;
-}

--- a/app/assets/stylesheets/admin/pages/_evaluations.scss
+++ b/app/assets/stylesheets/admin/pages/_evaluations.scss
@@ -1,6 +1,15 @@
 #index_table_evaluations {
   .col-nom {
     max-width: 11.25rem;
+    .nom {
+      @include tronque();
+    }
+    .ellipse {
+      margin-right: .75rem;
+    }
+  }
+  td {
+    padding: .75rem 1rem;
   }
 }
 

--- a/app/components/pastille_component.html.erb
+++ b/app/components/pastille_component.html.erb
@@ -1,0 +1,7 @@
+<span class="ellipse ellipse--<%= @couleur %>"
+      data-toggle=<%= @tooltip_content ? 'tooltip' : 'none' %>
+      data-placement='right'
+      title="<%= @tooltip_content %>">
+</span>
+<%= @etiquette %>
+

--- a/app/components/pastille_component.rb
+++ b/app/components/pastille_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PastilleComponent < ViewComponent::Base
+  def initialize(etiquette: nil, tooltip_content: nil, couleur: nil)
+    @etiquette = etiquette
+    @tooltip_content = tooltip_content
+    @couleur = couleur
+  end
+end

--- a/app/views/admin/dashboard/_bloc_evaluations.html.erb
+++ b/app/views/admin/dashboard/_bloc_evaluations.html.erb
@@ -6,9 +6,7 @@
     </div>
 
     <div class="evaluation-legende">
-      <%= render partial: 'admin/evaluations/pastille_illettrisme_potentiel', locals: {
-        etiquette: t('.legende_info')
-      } %>
+      <%= render(PastilleComponent.new(etiquette: t('.legende_info'), couleur: 'alerte')) %>
     </div>
   </div>
 
@@ -20,8 +18,7 @@
       <div class='col'>
         <span class='carte__pastille'>
           <% if evaluation.illettrisme_potentiel? %>
-            <%= render partial: 'admin/evaluations/pastille_illettrisme_potentiel',
-                  locals: { avec_tooltip: true } %>
+            <%= render(PastilleComponent.new(tooltip_content: t('components.pastille.illettrisme_potentiel'), couleur: 'alerte')) %>
           <% end %>
         </span>
       </div>

--- a/app/views/admin/evaluations/_pastille_illettrisme_potentiel.arb
+++ b/app/views/admin/evaluations/_pastille_illettrisme_potentiel.arb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-options = { class: 'ellipse ellipse__105' }
-options_tooltip = { 'data-toggle': 'tooltip', 'data-placement': 'right',
-                    title: 'Illettrisme potentiel' }
-options.merge!(options_tooltip) if defined? avec_tooltip
-span options
-text_node etiquette if defined? etiquette

--- a/config/locales/models/evaluation.yml
+++ b/config/locales/models/evaluation.yml
@@ -76,7 +76,6 @@ fr:
     scopes:
       evaluation:
         all: 'Toutes les évaluations'
-        illettrisme_potentiel: "Illettrisme potentiel"
   formtastic:
     actions:
       evaluation:

--- a/config/locales/views/components.yml
+++ b/config/locales/views/components.yml
@@ -93,4 +93,5 @@ fr:
             Nos équipes restent à votre disposition :  
             - via <a href="mailto:support@eva.beta.gouv.fr" class="text-primary">support@eva.beta.gouv.fr</a>  
             - via le chat (la petite bulle bleue en bas à droite de votre écran)
-
+    pastille:
+      illettrisme_potentiel: Illettrisme potentiel

--- a/spec/components/stories/pastille_component_stories.rb
+++ b/spec/components/stories/pastille_component_stories.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PastilleComponentStories < ViewComponent::Storybook::Stories
+  story :illettrisme_potentiel do
+    constructor(tooltip_content: 'Illettrisme potentiel', couleur: 'alerte')
+  end
+end


### PR DESCRIPTION
ℹ️ En attendant d'intégrer la suite du nouveau design d'une évaluation, j'ai tronqué le nom de l'évaluation comme on le fait sur la page du dashboard afin d'assurer que la pastille soit toujours alignée avec le nom.

<img width="1105" alt="Capture d’écran 2023-02-07 à 18 19 38" src="https://user-images.githubusercontent.com/81169078/217317343-1e2832b0-643f-4912-a0ed-93be28c0bfff.png">
