### PR TITLE
🐛 Mauvais encodage de l'apostrophe dans les résultats de recherche …

### DIFF
--- a/app/views/admin/evaluations/_recherche_responsable_suivi.html.erb
+++ b/app/views/admin/evaluations/_recherche_responsable_suivi.html.erb
@@ -12,8 +12,8 @@ document.addEventListener('DOMContentLoaded', () => {
   afficheRecherche(boutonAjout, formulaireRecherche);
 
   const comptes = [<% responsables_suivi_possibles.each do |compte| %>
-      { value: "<%= compte.display_name %>", id: "<%= compte.id %>" },
-    <% end %>];
+    { value: "<%= escape_javascript(compte.display_name.html_safe) %>", id: "<%= compte.id %>" },
+  <% end %>];
   $("#nom_responsable_suivi" ).autocomplete({
     source: function (request, response) {
       const term = request.term.toLowerCase();


### PR DESCRIPTION
…d'un responsable de suivi

L'encodage n'était pas pris en compte dans le javascript. C'est pourquoi on escape manuellement le javascript

![Capture d’écran 2023-02-13 à 16 32 49](https://user-images.githubusercontent.com/7428736/218504622-452e6515-92e2-4c44-b1d9-fa88a2b88312.png)
