### PR TITLE
:coffin: Retire le filtre sur les mises en action dans les evaluations

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -24,9 +24,6 @@ ActiveAdmin.register Evaluation do
          display_name: 'display_name',
          minimum_input_length: 2,
          order_by: 'email_asc'
-  filter :mise_en_action_effectuee_null,
-         as: :boolean,
-         label: I18n.t('activerecord.attributes.evaluation.mise_en_action_effectuee_null')
   filter :statut,
          as: :select,
          collection: Evaluation.statuts.map { |v, id|

--- a/config/locales/models/evaluation.yml
+++ b/config/locales/models/evaluation.yml
@@ -33,7 +33,6 @@ fr:
         competences_de_base_incompletes: Évaluation des compétences de base incomplète
         beneficiaire: Bénéficiaire
         responsable_suivi: Responsable de suivi
-        mise_en_action_effectuee_null: Suivi en attente
         interpretations:
           synthese_competences_de_base:
             socle_clea: supérieur


### PR DESCRIPTION
Retrait du filtre suivant dont le wording porte à confusion :
cf https://eva-beta.slack.com/archives/CGPG52SA3/p1677055949053989
![Capture d’écran 2023-02-22 à 09 40 28](https://user-images.githubusercontent.com/81169078/220576908-025e0da5-d1b6-447c-aae5-6301d7dc51aa.png)
