### PR TITLE
Permet l'export des évaluations sans campagne

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -87,8 +87,8 @@ ActiveAdmin.register Evaluation do
 
   xls(i18n_scope: %i[active_admin xls evaluation]) do
     whitelist
-    column('structure') { |evaluation| evaluation.campagne.compte.structure.nom }
-    column(:campagne) { |evaluation| evaluation.campagne.libelle }
+    column('structure') { |evaluation| evaluation.campagne&.compte&.structure&.nom }
+    column(:campagne) { |evaluation| evaluation.campagne&.libelle }
     column(:created_at) { |evaluation| I18n.l(evaluation.created_at, format: :sans_heure) }
     column :nom
     column(:completude) do |evaluation|

--- a/app/models/ability_utilisateur.rb
+++ b/app/models/ability_utilisateur.rb
@@ -23,7 +23,7 @@ class AbilityUtilisateur
     can :create, Campagne
     can %i[update read], Campagne, comptes_de_meme_structure(compte) if compte.validation_acceptee?
     can %i[update read], Campagne, compte_id: compte.id
-    can :destroy, Campagne, nombre_evaluations: 0
+    can(:destroy, Campagne) { |c| Evaluation.where(campagne: c).empty? }
   end
 
   def droits_generiques(compte)

--- a/app/models/campagne.rb
+++ b/app/models/campagne.rb
@@ -13,6 +13,8 @@ class Campagne < ApplicationRecord
   has_many :situations_configurations, lambda {
                                          order(position: :asc)
                                        }, dependent: :destroy
+
+  has_many :evaluations, dependent: :restrict_with_error
   belongs_to :compte
   belongs_to :parcours_type, optional: true
 


### PR DESCRIPTION
À cause d'un défaut de maintenance correcte cache du nombre d'évaluations des campagnes, il peut arriver qu'une campagne soit détruite alors qu'elle contient des évaluations, qui elles ne sont pas détruites.

Cette PR permet l'export des évaluations orphelines et permet aussi de préparer la réparation des campagnes avec le lien `has_many evaluations`.