### PR TITLE
✨ Listing des évaluations : Afficher les actions au dessus de la date

### DIFF
--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -38,6 +38,7 @@
 @import "admin/composants/tooltip";
 @import "admin/composants/situation_illustration";
 @import "admin/composants/referentiel_anlci";
+@import "admin/composants/roue_dentee";
 
 // UTILITIES
 @import 'admin/utilities';

--- a/app/assets/stylesheets/admin/composants/_roue_dentee.scss
+++ b/app/assets/stylesheets/admin/composants/_roue_dentee.scss
@@ -2,7 +2,7 @@
   background-image: image-url('roue-dentee.svg');
   background-position: right center;
   background-repeat: no-repeat;
-  min-height: 20px;
+  min-height: 1.25rem;
 
   display: flex;
   justify-content: flex-end;

--- a/app/assets/stylesheets/admin/composants/_roue_dentee.scss
+++ b/app/assets/stylesheets/admin/composants/_roue_dentee.scss
@@ -1,0 +1,31 @@
+@mixin roue-dentee() {
+  background-image: image-url('roue-dentee.svg');
+  background-position: right center;
+  background-repeat: no-repeat;
+  min-height: 20px;
+
+  display: flex;
+  justify-content: flex-end;
+
+  .roue-dentee__actions, .table_actions {
+    opacity: 0;
+    transition: opacity 0.2s;
+    position: absolute;
+  }
+
+  &:hover {
+    background-image: none;
+
+    .roue-dentee__actions, .table_actions {
+      opacity: 1;
+    }
+  }
+}
+
+.roue-dentee {
+  @include roue-dentee();
+
+  .roue-dentee__actions a {
+    @include boutons-groupes()
+  }
+}

--- a/app/assets/stylesheets/admin/mixins/_buttons.scss
+++ b/app/assets/stylesheets/admin/mixins/_buttons.scss
@@ -51,3 +51,34 @@
   }
 }
 
+@mixin boutons-groupes() {
+  @include bouton();
+  border-radius: 0;
+  margin: 0;
+
+  &:first-child {
+    border-top-left-radius: 0.25rem;
+    border-bottom-left-radius: 0.25rem;
+  }
+  &:last-child {
+    border-top-right-radius: 0.25rem;
+    border-bottom-right-radius: 0.25rem;
+  }
+
+  &.view_link {
+    background-color: $couleur-legere-accent-validation;
+    border-color: $couleur-legere-accent-validation;
+    color: $eva_dark;
+  }
+  &.edit_link {
+    background-color: $eva_main_blue;
+    border-color: $eva_main_blue;
+    color: white;
+  }
+  &.delete_link {
+    background-color: $couleur-accent-erreur;
+    border-color: $couleur-accent-erreur;
+    color: white;
+  }
+}
+

--- a/app/assets/stylesheets/admin/pages/_evaluations.scss
+++ b/app/assets/stylesheets/admin/pages/_evaluations.scss
@@ -1,5 +1,5 @@
 @mixin bloc-evaluation() {
-  .evaluation--nom {
+  .evaluation__nom {
     @include tronque();
     width: 15.25rem;
     font-family: $font-titre;
@@ -18,7 +18,7 @@
     }
   }
 
-  .evaluation--campagne {
+  .evaluation__campagne {
     font-weight: 600;
     @include tronque();
     width: 28.75rem;
@@ -30,11 +30,11 @@
     }
   }
 
-  .evaluation--suivi-par {
+  .evaluation__suivi-par {
     margin-left: 1.75rem;
   }
 
-  .evaluation--suivi-par, .evaluation--parcours-type, .evaluation--created_at {
+  .evaluation__suivi-par, .evaluation__parcours-type, .evaluation__created_at {
     color: $eva_dark_blue_grey;
     @include texte-xs();
     font-style: normal;
@@ -46,7 +46,7 @@
     }
   }
 
-  .evaluation--created_at {
+  .evaluation__created_at {
     text-align: right;
     white-space: nowrap;
     margin-top: .75rem;

--- a/app/assets/stylesheets/admin/pages/_evaluations.scss
+++ b/app/assets/stylesheets/admin/pages/_evaluations.scss
@@ -96,8 +96,7 @@
   .tag {
     $largeur-panel: 18.125rem;
     $padding: 1rem;
-    display: inline-block;
-    @include tronque;
+    @include tronque();
     display: inline-block;
     max-width: calc(#{ $largeur-panel - ($padding * 2) });
     padding: 0.25rem 1rem;

--- a/app/assets/stylesheets/admin/pages/_evaluations.scss
+++ b/app/assets/stylesheets/admin/pages/_evaluations.scss
@@ -1,6 +1,7 @@
 @mixin bloc-evaluation() {
   .evaluation--nom {
     @include tronque();
+    width: 15.25rem;
     font-family: $font-titre;
     font-size: 1.125rem;
     line-height: 1.375rem;
@@ -19,6 +20,8 @@
 
   .evaluation--campagne {
     font-weight: 600;
+    @include tronque();
+    width: 28.75rem;
     @include texte-lg();
 
     &, &:link, &:visited {
@@ -29,11 +32,6 @@
 
   .evaluation--suivi-par {
     margin-left: 1.75rem;
-    margin-top: .5rem;
-  }
-
-  .evaluation--parcours-type {
-    margin-top: 1rem;
   }
 
   .evaluation--suivi-par, .evaluation--parcours-type, .evaluation--created_at {
@@ -56,16 +54,27 @@
 }
 
 #index_table_evaluations {
-  $padding-horizontal : 1rem;
+  $padding-horizontal: 0.625rem;
   thead th { padding: 0 $padding-horizontal .5rem; }
   tbody tr {
     min-height: 4.5rem;
   }
+  .cellule {
+    display: flex;
+    flex-direction: column;
+    height: 2.875rem;
+    justify-content: space-between;
+  }
   .col-nom {
-    max-width: 20rem;
     .ellipse {
       margin-right: .75rem;
     }
+  }
+  td:first-child {
+    padding-left: 1rem;
+  }
+  td:last-child {
+    padding-right: 1rem;
   }
   td {
     padding: .75rem $padding-horizontal;

--- a/app/assets/stylesheets/admin/pages/_evaluations.scss
+++ b/app/assets/stylesheets/admin/pages/_evaluations.scss
@@ -33,10 +33,10 @@
   }
 
   .evaluation--parcours-type {
-    margin-top: 0.625rem;
+    margin-top: 1rem;
   }
 
-  .evaluation--suivi-par, .evaluation--parcours-type {
+  .evaluation--suivi-par, .evaluation--parcours-type, .evaluation--created_at {
     color: $eva_dark_blue_grey;
     @include texte-xs();
     font-style: normal;
@@ -48,6 +48,11 @@
     }
   }
 
+  .evaluation--created_at {
+    text-align: right;
+    white-space: nowrap;
+    margin-top: .75rem;
+  }
 }
 
 #index_table_evaluations {

--- a/app/views/admin/evaluations/_index.html.arb
+++ b/app/views/admin/evaluations/_index.html.arb
@@ -7,11 +7,13 @@ context.instance_eval do
 
   column :campagne do |evaluation|
     campagne = evaluation.campagne
-    div link_to(campagne.display_name, admin_campagne_path(campagne),
-                class: 'evaluation--campagne'),
-        class: 'd-flex align-items-center'
-    parcours_type = campagne.parcours_type
-    div parcours_type.display_name, class: 'evaluation--parcours-type' if parcours_type.present?
+    div class: 'cellule' do
+      div link_to(campagne.display_name, admin_campagne_path(campagne),
+                  class: 'evaluation--campagne'),
+          class: 'd-flex align-items-center'
+      parcours_type = campagne.parcours_type
+      div parcours_type.display_name, class: 'evaluation--parcours-type' if parcours_type.present?
+    end
   end
   column :created_at do |evaluation|
     div class: 'roue-dentee' do

--- a/app/views/admin/evaluations/_index.html.arb
+++ b/app/views/admin/evaluations/_index.html.arb
@@ -13,6 +13,26 @@ context.instance_eval do
     parcours_type = campagne.parcours_type
     div parcours_type.display_name, class: 'evaluation--parcours-type' if parcours_type.present?
   end
-  column :created_at
-  actions
+  column :created_at do |evaluation|
+    div class: 'roue-dentee' do
+      div class: 'roue-dentee__actions table_actions' do
+        if can?(:read, evaluation)
+          text_node link_to t('.voir'), admin_evaluation_path(evaluation),
+                            class: 'view_link member_link'
+        end
+        if can?(:edit, evaluation)
+          text_node link_to t('.modifier'), edit_admin_evaluation_path(evaluation),
+                            class: 'edit_link member_link'
+        end
+        if can?(:destroy, evaluation)
+          text_node link_to t('.supprimer'),
+                            admin_evaluation_path(evaluation),
+                            method: :delete,
+                            class: 'delete_link member_link',
+                            data: { confirm: t('.confirmation_suppression') }
+        end
+      end
+    end
+    div(l(evaluation.created_at), class: 'evaluation--created_at')
+  end
 end

--- a/app/views/admin/evaluations/_index.html.arb
+++ b/app/views/admin/evaluations/_index.html.arb
@@ -9,10 +9,10 @@ context.instance_eval do
     campagne = evaluation.campagne
     div class: 'cellule' do
       div link_to(campagne.display_name, admin_campagne_path(campagne),
-                  class: 'evaluation--campagne'),
+                  class: 'evaluation__campagne'),
           class: 'd-flex align-items-center'
       parcours_type = campagne.parcours_type
-      div parcours_type.display_name, class: 'evaluation--parcours-type' if parcours_type.present?
+      div parcours_type.display_name, class: 'evaluation__parcours-type' if parcours_type.present?
     end
   end
   column :created_at do |evaluation|
@@ -35,6 +35,6 @@ context.instance_eval do
         end
       end
     end
-    div(l(evaluation.created_at), class: 'evaluation--created_at')
+    div(l(evaluation.created_at), class: 'evaluation__created_at')
   end
 end

--- a/app/views/admin/evaluations/_nom_evaluation.html.erb
+++ b/app/views/admin/evaluations/_nom_evaluation.html.erb
@@ -1,15 +1,15 @@
-<div class="d-flex align-items-center">
-  <% if presence_pastille? %>
-   <%= render(PastilleComponent.new(
-                 couleur: evaluation.illettrisme_potentiel? ? 'alerte' : '',
-                 tooltip_content: I18n.t('components.pastille.illettrisme_potentiel')
-       ))%>
-  <% end %>
-  <%= link_to admin_evaluation_path(evaluation), class: "evaluation--nom" do %>
-    <%= render(NomAnonymisableComponent.new(evaluation)) %>
-  <% end %>
-</div>
-<div>
+<div class="cellule">
+  <div class="d-flex align-items-center">
+    <% if presence_pastille? %>
+     <%= render(PastilleComponent.new(
+                   couleur: evaluation.illettrisme_potentiel? ? 'alerte' : '',
+                   tooltip_content: I18n.t('components.pastille.illettrisme_potentiel')
+         ))%>
+    <% end %>
+    <%= link_to admin_evaluation_path(evaluation), class: "evaluation--nom" do %>
+      <%= render(NomAnonymisableComponent.new(evaluation)) %>
+    <% end %>
+  </div>
   <% responsable = evaluation.responsable_suivi %>
   <div class= "evaluation--suivi-par <%= presence_pastille? ? '' : 'ml-0' %>">
     <% if responsable.present? %>

--- a/app/views/admin/evaluations/_nom_evaluation.html.erb
+++ b/app/views/admin/evaluations/_nom_evaluation.html.erb
@@ -6,12 +6,12 @@
                    tooltip_content: I18n.t('components.pastille.illettrisme_potentiel')
          ))%>
     <% end %>
-    <%= link_to admin_evaluation_path(evaluation), class: "evaluation--nom" do %>
+    <%= link_to admin_evaluation_path(evaluation), class: "evaluation__nom" do %>
       <%= render(NomAnonymisableComponent.new(evaluation)) %>
     <% end %>
   </div>
   <% responsable = evaluation.responsable_suivi %>
-  <div class= "evaluation--suivi-par <%= presence_pastille? ? '' : 'ml-0' %>">
+  <div class= "evaluation__suivi-par <%= presence_pastille? ? '' : 'ml-0' %>">
     <% if responsable.present? %>
       <%= t('.suivi_par') %> <%= link_to(responsable.display_name, admin_compte_path(responsable), class: 'lien-secondaire') %>
     <% else %>

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -1,6 +1,11 @@
 fr:
   admin:
     evaluations:
+      index:
+        confirmation_suppression: 'Voulez-vous vraiment supprimer cette évaluation ?'
+        supprimer: Supprimer
+        modifier: Modifier
+        voir: Voir
       commun: &commun
         efficience: Efficience
         nombre_erreurs: "Nombre d'erreurs"


### PR DESCRIPTION
Cette PR format la date et place les boutons des actions au-dessus.
Les colonnes Nom et Campagne ont été ajustées en largeur et le contenu est tronquée si il dépasse.

<img width="978" alt="Capture d’écran 2023-03-06 à 21 18 17" src="https://user-images.githubusercontent.com/298214/223221307-517b0b7b-d717-45af-9182-3d08b01efba8.png">
