### PR TITLE
:art: Pour explorer la corruption du nombre_evaluations des campagnes

### DIFF
--- a/lib/tasks/nettoyage.rake
+++ b/lib/tasks/nettoyage.rake
@@ -201,4 +201,15 @@ where "evenementsParGroup" > 1')
       logger.info "Il reste #{nombre_evenements} événements en double"
     end
   end
+
+  desc 'liste les campagnes corrompues'
+  task liste_campagnes_corrompues: :environment do
+    logger = RakeLogger.logger
+    Campagne.all.each do |c|
+      count = Evaluation.where(campagne: c).count
+      if c.nombre_evaluations != count
+        logger.info "#{c.id};#{c.libelle};#{c.nombre_evaluations};#{count}"
+      end
+    end
+  end
 end

--- a/spec/integrations/campagne_spec.rb
+++ b/spec/integrations/campagne_spec.rb
@@ -17,6 +17,21 @@ describe Campagne, type: :integration do
     end
   end
 
+  describe '#nombre_evaluations' do
+    let(:campagne) { create :campagne }
+    let(:campagne2) { create :campagne }
+    let!(:mon_evaluation) { create :evaluation, campagne: campagne }
+
+    it "est maintenu quand on change la campagne d'une évaluation" do
+      expect(campagne.nombre_evaluations).to eq(1)
+      expect(campagne2.nombre_evaluations).to eq(0)
+      mon_evaluation.campagne = campagne2
+      mon_evaluation.save
+      expect(campagne.reload.nombre_evaluations).to eq(0)
+      expect(campagne2.reload.nombre_evaluations).to eq(1)
+    end
+  end
+
   describe "création d'une campagne avec des situations" do
     # parcours type
     let!(:questionnaire_sans_livraison) { create :questionnaire, :livraison_sans_redaction }


### PR DESCRIPTION
- Ajoute une tâche pour lister les campagnes corrompues
- Ajoute un test pour vérifier que le nombre d'évaluations est actualisé quand on change la campagne d'une évaluation

Sur la base de prod du 7 mars (avant d'avoir corrigé toutes les corruptions), nous avions 6 campagnes corrompues :

```
I, [2023-03-10T15:18:27.447485 #94051]  INFO -- : 9689abbf-e373-49fd-9aab-6a746bb5cc96;1ers bénéficiaires;21;22
I, [2023-03-10T15:18:28.831031 #94051]  INFO -- : 7b6b265b-54ea-4ede-bee0-d8ff72db18b6;Mission Locale pour l'emploi_Strasbourg;1234;1235
I, [2023-03-10T15:18:29.016934 #94051]  INFO -- : 7241e549-6dbd-4676-94f6-41ab2d37db65;groupe GJ268;5;6
I, [2023-03-10T15:18:31.639314 #94051]  INFO -- : 9840511e-0b0a-4872-bb25-5919bd33fc1c;Atelier Numérique - EVA;-1;0
I, [2023-03-10T15:18:31.806636 #94051]  INFO -- : c5fa43a2-f537-4408-b02c-20043aebbc6b;eval1;5;6
I, [2023-03-10T15:18:33.250921 #94051]  INFO -- : ccc90dc9-edd5-47ea-b297-1449815e6ec5;CEJ TES;-1;0
```