### PR TITLE
Limite le téléchargement xls à maximum 3000 évaluations

### DIFF
--- a/config/locales/activeadmin.yml
+++ b/config/locales/activeadmin.yml
@@ -6,17 +6,6 @@ fr:
       compte:
         signed_in_but_unconfirmed: ""
   active_admin:
-    footer: |
-      Ce site est créé avec ❤️ par <a href='https://beta.gouv.fr/startups/eva.html' target='_blank'>l'équipe</a> eva.
-      Le <a href='https://github.com/betagouv/eva-serveur' target='_blank'>code source</a> est libre.
-    menu_connexion:
-      compte: Voir mon compte
-      structure: Voir ma structure
-      statistiques: Voir les statistiques
-    resource:
-      index:
-        rapport: Rapport
-        evenements: Évenements
     devise:
       login:
         title: |
@@ -55,6 +44,19 @@ fr:
       reset_password:
         token_invalide: 'Veuillez vérifier de nouveau l’email reçu.'
         saisir_a_nouveau: Si vous souhaitez recevoir de nouveau cet email, merci de saisir votre adresse ci-dessous.
+    export:
+      limite_atteinte: "L'export est limité à %{limite} lignes, les lignes supplémentaires n'ont pas été exportées. Vous pouvez utiliser les filtres pour réduire le nombre de lignes que vous voulez exporter"
+    footer: |
+      Ce site est créé avec ❤️ par <a href='https://beta.gouv.fr/startups/eva.html' target='_blank'>l'équipe</a> eva.
+      Le <a href='https://github.com/betagouv/eva-serveur' target='_blank'>code source</a> est libre.
+    menu_connexion:
+      compte: Voir mon compte
+      structure: Voir ma structure
+      statistiques: Voir les statistiques
+    resource:
+      index:
+        rapport: Rapport
+        evenements: Évenements
     sidebars:
       filters: Rechercher
       autres_actualites: Les autres actualités sur eva


### PR DESCRIPTION
Cette PR Limite le nombre maximal d'évaluations que l'on peut exporter à 3 000

Si on essaye d'exporter plus, seules les 3000 premières lignes sont exportées et un message d'information est affiché en première ligne de l'export.

Le nombre maximal d'évaluations que l'on peut télécharger dans le fichier XLS fixé de manière un peu arbitraire en fonction de ce que l'on est capable d'exporter en un temps raisonnable.

Aujourd'hui notre plus grosse campagne compte environ 1700 évaluations

