### PR TITLE
1707 🎁 bienvenue 2023 questionnaire sociodemographique autopositionnement

### DIFF
--- a/bin/reviewappdeploy.sh
+++ b/bin/reviewappdeploy.sh
@@ -5,3 +5,4 @@ bundle exec rake reviewapp:initdb
 bundle exec rails db:migrate
 bundle exec rails db:seed
 bundle exec rake reviewapp:seed
+bundle exec rake questionnaire:complete_sociodemographique_autopositionnement

--- a/db/migrate/20230403150717_renomme_nom_techniques_questions_bienvenue.rb
+++ b/db/migrate/20230403150717_renomme_nom_techniques_questions_bienvenue.rb
@@ -1,0 +1,27 @@
+class RenommeNomTechniquesQuestionsBienvenue < ActiveRecord::Migration[7.0]
+  def up
+    QuestionQcm.where(nom_technique: 'bienvenue_1').update(nom_technique: 'concentration')
+    QuestionQcm.where(nom_technique: 'bienvenue_2').update(nom_technique: 'comprehension')
+    QuestionQcm.where(nom_technique: 'bienvenue_3').update(nom_technique: 'differencier_objets')
+    QuestionQcm.where(nom_technique: 'bienvenue_4').update(nom_technique: 'analyse_travail')
+    QuestionQcm.where(nom_technique: 'bienvenue_5').update(nom_technique: 'tache_longue_et_difficile')
+    QuestionQcm.where(nom_technique: 'bienvenue_6').update(nom_technique: 'travail_sans_erreur')
+    QuestionQcm.where(nom_technique: 'bienvenue_7').update(nom_technique: 'dangers')
+    QuestionQcm.where(nom_technique: 'bienvenue_8').update(nom_technique: 'vue')
+    QuestionQcm.where(nom_technique: 'bienvenue_10').update(nom_technique: 'entendre')
+    QuestionQcm.where(nom_technique: 'bienvenue_15').update(nom_technique: 'trouble_dys')
+  end
+
+  def down
+    QuestionQcm.where(nom_technique: 'concentration').update(nom_technique: 'bienvenue_1')
+    QuestionQcm.where(nom_technique: 'comprehension').update(nom_technique: 'bienvenue_2')
+    QuestionQcm.where(nom_technique: 'differencier_objets').update(nom_technique: 'bienvenue_3')
+    QuestionQcm.where(nom_technique: 'analyse_travail').update(nom_technique: 'bienvenue_4')
+    QuestionQcm.where(nom_technique: 'tache_longue_et_difficile').update(nom_technique: 'bienvenue_5')
+    QuestionQcm.where(nom_technique: 'travail_sans_erreur').update(nom_technique: 'bienvenue_6')
+    QuestionQcm.where(nom_technique: 'dangers').update(nom_technique: 'bienvenue_7')
+    QuestionQcm.where(nom_technique: 'vue').update(nom_technique: 'bienvenue_8')
+    QuestionQcm.where(nom_technique: 'entendre').update(nom_technique: 'bienvenue_10')
+    QuestionQcm.where(nom_technique: 'trouble_dys').update(nom_technique: 'bienvenue_15')
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -232,9 +232,10 @@ Questionnaire.find_or_create_by(nom_technique: 'sociodemographique') do |questio
   questionnaire.questions = [age, genre, langue_maternelle, lieu_scolarite, niveau_etude, derniere_situation]
 end
 
-questions_autopositionnement = Questionnaire.find_by(nom_technique: 'autopositionnement')
-                                            .questions
-                                            .where(nom_technique: ["bienvenue_1", "bienvenue_2", "bienvenue_3", "bienvenue_4", "bienvenue_5", "bienvenue_6", "bienvenue_7", "bienvenue_8", "bienvenue_10", "bienvenue_15"])
+questions_autopositionnement =
+  Questionnaire.find_by(nom_technique: 'autopositionnement')
+  .questions
+  .where(nom_technique: ["concentration", "comprehension", "differencier_objets", "analyse_travail", "tache_longue_et_difficile", "travail_sans_erreur", "dangers", "vue", "entendre", "trouble_dys"])
 
 Questionnaire.find_or_create_by(nom_technique: 'sociodemographique_autopositionnement') do |questionnaire|
   questionnaire.libelle = 'Sociodémographique et autopositionnement'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -218,7 +218,26 @@ age = QuestionSaisie.find_or_create_by(nom_technique: 'age') do |question|
   question.type_saisie = 'numerique'
 end
 
-Questionnaire.find_or_create_by(nom_technique: 'sociodemographique_autopositionnement') do |questionnaire|
-  questionnaire.libelle='Sociodémographique et autopositionnement'
+difficultes_informatique = QuestionQcm.find_or_create_by(nom_technique: 'difficultes_informatique') do |question|
+  question.libelle = "Appareils: Difficultés avec l'informatique"
+  question.intitule = "Avez-vous des difficultés avec l'outil informatique (maux de tête, difficultés d'utilisation) ?"
+  question.choix = [
+    Choix.create(nom_technique: 'oui', intitule: 'Oui', type_choix: 'bon'),
+    Choix.create(nom_technique: 'non', intitule: 'Non', type_choix: 'bon')
+  ]
+end
+
+Questionnaire.find_or_create_by(nom_technique: 'sociodemographique') do |questionnaire|
+  questionnaire.libelle = 'Sociodémographique'
   questionnaire.questions = [age, genre, langue_maternelle, lieu_scolarite, niveau_etude, derniere_situation]
 end
+
+questions_autopositionnement = Questionnaire.find_by(nom_technique: 'autopositionnement')
+                                            .questions
+                                            .where(nom_technique: ["bienvenue_1", "bienvenue_2", "bienvenue_3", "bienvenue_4", "bienvenue_5", "bienvenue_6", "bienvenue_7", "bienvenue_8", "bienvenue_10", "bienvenue_15"])
+
+Questionnaire.find_or_create_by(nom_technique: 'sociodemographique_autopositionnement') do |questionnaire|
+  questionnaire.libelle = 'Sociodémographique et autopositionnement'
+  questionnaire.questions = [age, genre, langue_maternelle, lieu_scolarite, niveau_etude, derniere_situation] + questions_autopositionnement[0...-1] + [difficultes_informatique] + [questions_autopositionnement[-1]]
+end
+

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -232,13 +232,7 @@ Questionnaire.find_or_create_by(nom_technique: 'sociodemographique') do |questio
   questionnaire.questions = [age, genre, langue_maternelle, lieu_scolarite, niveau_etude, derniere_situation]
 end
 
-questions_autopositionnement =
-  Questionnaire.find_by(nom_technique: 'autopositionnement')
-  .questions
-  .where(nom_technique: ["concentration", "comprehension", "differencier_objets", "analyse_travail", "tache_longue_et_difficile", "travail_sans_erreur", "dangers", "vue", "entendre", "trouble_dys"])
-
 Questionnaire.find_or_create_by(nom_technique: 'sociodemographique_autopositionnement') do |questionnaire|
   questionnaire.libelle = 'Sociodémographique et autopositionnement'
-  questionnaire.questions = [age, genre, langue_maternelle, lieu_scolarite, niveau_etude, derniere_situation] + questions_autopositionnement[0...-1] + [difficultes_informatique] + [questions_autopositionnement[-1]]
 end
 

--- a/lib/tasks/questionnaire.rake
+++ b/lib/tasks/questionnaire.rake
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+QUESTIONS_AUTO = %w[
+  concentration
+  comprehension
+  differencier_objets
+  analyse_travail
+  tache_longue_et_difficile
+  travail_sans_erreur
+  dangers
+  vue
+  entendre
+  trouble_dys
+].freeze
+
+namespace :questionnaire do
+  desc 'Complete le questionnaire sociodémographique avec les questions de l autopositionnement'
+  task complete_sociodemographique_autopositionnement: :environment do
+    logger = RakeLogger.logger
+
+    questions_auto = recupere_questions_auto
+
+    questions_socio =
+      Questionnaire.find_by(nom_technique: 'sociodemographique')
+                   .questions
+
+    difficultes_informatique = QuestionQcm.find_by(nom_technique: 'difficultes_informatique')
+
+    questionnaire_socio_auto =
+      Questionnaire.find_or_initialize_by(nom_technique: 'sociodemographique_autopositionnement')
+    questionnaire_socio_auto.libelle = 'Sociodémographique et autopositionnement'
+    questionnaire_socio_auto.questions =
+      (questions_socio + questions_auto[0...-1]) << difficultes_informatique << questions_auto[-1]
+    questionnaire_socio_auto.save
+
+    puts "Nombre questions: #{questionnaire_socio_auto.questions.count}"
+    logger.info "c'est fini"
+  end
+end
+
+def recupere_questions_auto
+  Questionnaire.find_by(nom_technique: 'autopositionnement')
+               .questions
+               .where(nom_technique: QUESTIONS_AUTO)
+end


### PR DESCRIPTION
Le questionnaire `autopositionnement` n'est pas accessible depuis les seeds. (cf le ci qui fail dans le deuxième commit) Plutôt que de recréer toutes les questions, j'ai fait une tâche rake qui permet de générer le questionnaire en prod et dans les reviewapps.

Commande à lacer :
`rails db:seed`
`rake questionnaire:complete_sociodemographique_autopositionnement`

Il y a une PR côté front associée pour mette à jour les noms techniques des questions de Bienvenue.