### PR TITLE
migration des campagnes existantes vers bienvenue2023

### DIFF
--- a/app/models/fabrique_restitution.rb
+++ b/app/models/fabrique_restitution.rb
@@ -3,7 +3,7 @@
 class FabriqueRestitution
   class << self
     def instancie(partie)
-      evenements = Evenement.where(partie: partie.session_id).order(:date)
+      evenements = Evenement.where(partie: partie.session_id).order(:position).order(:date)
       classe_restitution = "Restitution::#{partie.situation.nom_technique.camelize}".constantize
       classe_restitution.new(partie.campagne, evenements)
     end

--- a/app/models/question_saisie.rb
+++ b/app/models/question_saisie.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class QuestionSaisie < Question
+  QUESTION_REDACTION = 'redaction_note'
+
   enum :type_saisie, { redaction: 0, numerique: 1 }
 
   def as_json(_options = nil)

--- a/app/models/restitution/bienvenue.rb
+++ b/app/models/restitution/bienvenue.rb
@@ -3,8 +3,7 @@
 module Restitution
   class Bienvenue < Base
     def questions_reponses
-      @questions_reponses ||= QuestionsReponses.new(evenements,
-                                                    campagne.questionnaire_pour(situation))
+      @questions_reponses ||= QuestionsReponses.new(evenements)
     end
 
     def questions_et_reponses(type_qcm = nil)

--- a/app/models/restitution/livraison.rb
+++ b/app/models/restitution/livraison.rb
@@ -77,8 +77,7 @@ module Restitution
     end
 
     def questions_reponses
-      @questions_reponses ||= QuestionsReponses.new(evenements_situation,
-                                                    campagne.questionnaire_pour(situation))
+      @questions_reponses ||= QuestionsReponses.new(evenements_situation)
     end
 
     def efficience

--- a/app/models/restitution/questions_reponses.rb
+++ b/app/models/restitution/questions_reponses.rb
@@ -2,45 +2,38 @@
 
 module Restitution
   class QuestionsReponses
-    def initialize(evenements, questionnaire)
+    def initialize(evenements)
       @evenements = evenements
-      @questionnaire = questionnaire
     end
 
     def questions_et_reponses(type_qcm = nil)
-      questions_repondues
-        .map { |question| [question, choix_repondu(question)] }
-        .select { |q_et_r| type_qcm.nil? || q_et_r[0].type_qcm == type_qcm.to_s }
+      questions = questions_repondues.index_by(&:id)
+      reponses.map { |reponse| [questions[reponse.donnees['question']], reponse] }
+              .select { |q, _r| type_qcm.nil? || q.type_qcm == type_qcm.to_s }
+              .map { |q, r| [q, choix_repondu(q, r)] }
     end
 
     def questions_redaction
       @questions_redaction ||= questions_et_reponses.select do |q, r|
-        [q, r] if q.is_a?(QuestionSaisie)
+        [q, r] if q.nom_technique == QuestionSaisie::QUESTION_REDACTION
       end
     end
 
     def reponses
-      @evenements.find_all { |e| e.nom == MetriquesHelper::EVENEMENT[:REPONSE] }
+      @reponses ||= @evenements.find_all { |e| e.nom == MetriquesHelper::EVENEMENT[:REPONSE] }
     end
 
-    def questions
-      @questionnaire.questions
+    def choix_repondu(question, evenement_reponse)
+      reponse = evenement_reponse.donnees['reponse']
+      question.is_a?(QuestionQcm) ? question.choix.find { |c| c.id == reponse } : reponse
     end
+
+    private
 
     def questions_repondues
       questions_ids = reponses.collect { |r| r.donnees['question'] }
-      questions.where(id: questions_ids, type: 'QuestionQcm').includes(:choix) +
-        questions.where(id: questions_ids).where.not(type: 'QuestionQcm')
-    end
-
-    def choix_repondu(question)
-      evenement_reponse = reponses.find do |evenement|
-        evenement.donnees['question'] == question.id
-      end
-      return if evenement_reponse.blank?
-
-      reponse = evenement_reponse.donnees['reponse']
-      question.is_a?(QuestionQcm) ? question.choix.detect { |c| c.id == reponse } : reponse
+      Question.where(id: questions_ids, type: 'QuestionQcm').includes(:choix) +
+        Question.where(id: questions_ids).where.not(type: 'QuestionQcm')
     end
   end
 end

--- a/bin/reviewappdeploy.sh
+++ b/bin/reviewappdeploy.sh
@@ -5,3 +5,4 @@ bundle exec rake reviewapp:initdb
 bundle exec rails db:migrate
 bundle exec rails db:seed
 bundle exec rake reviewapp:seed
+bundle exec rake migration:bienvenue2023

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rake_logger'
+
+namespace :migration do
+  desc 'Migre les anciennes campagnes à Bienvenu 2023'
+  task bienvenue2023: :environment do
+    logger = RakeLogger.logger
+
+    questionnaire_socio =
+      Questionnaire.find_by nom_technique: Questionnaire::SOCIODEMOGRAPHIQUE
+    questionnaire_socio_auto = Questionnaire.bienvenue_avec_autopositionnement
+    bienvenue = Situation.find_by nom_technique: Situation::BIENVENUE
+    total = Campagne.count
+    count = 0
+    logger.info "Nombre de campagne : #{total}"
+    Campagne.includes(:situations_configurations).find_each do |campagne|
+      count += 1
+      logger.info "#{count}/#{total} #{campagne.libelle}"
+
+      configure campagne, questionnaire_socio, questionnaire_socio_auto, bienvenue, logger
+    end
+    bienvenue.update(questionnaire: questionnaire_socio)
+    SituationConfiguration.where(situation: bienvenue,
+                                 questionnaire: questionnaire_socio).update(questionnaire_id: nil)
+    logger.info "C'est fini"
+  end
+
+  def configure(campagne, questionnaire_socio, questionnaire_socio_auto, bienvenue, logger)
+    situation_configuration = campagne.situations_configurations.find(&:bienvenue?)
+    if situation_configuration.present?
+      met_a_jour_questionnaire situation_configuration, questionnaire_socio_auto, logger
+    else
+      position = calcule_position campagne
+      campagne.situations_configurations.create situation_id: bienvenue.id,
+                                                questionnaire_id: questionnaire_socio.id,
+                                                position: position
+      logger.info "ajout de bienvenue en position #{position}"
+    end
+  end
+
+  def met_a_jour_questionnaire(situation_configuration, questionnaire_socio_auto, logger)
+    questionnaire = situation_configuration.questionnaire
+    unless questionnaire.nil? || questionnaire.nom_technique == Questionnaire::AUTOPOSITIONNEMENT
+      return
+    end
+
+    situation_configuration.questionnaire = questionnaire_socio_auto
+    situation_configuration.save
+    logger.info 'mise à jour du questionnaire'
+  end
+
+  def calcule_position(campagne)
+    premiere_configuration = campagne.situations_configurations.first
+    if premiere_configuration.present? &&
+       premiere_configuration.situation.nom_technique == Situation::PLAN_DE_LA_VILLE
+      return 2
+    end
+
+    1
+  end
+end


### PR DESCRIPTION
Le script de migration est fait.
    - toutes les campagnes ont maintenant bienvenue
    - Si elle avait l'auto-positionnement, le questionnaire de bienvenue est
      surchargé avec le questionnaire demandant les données
      sociodémographique ainsi que les questions d'auto-positionnement
    - Le questionnaire par défaut de bienvenue est maintenant `sociodemographique`

J'ai modifié le modèle "QuestionsReponses" pour qu'il retourne toutes les réponses (et les questions associées) sans se référer au questionnaire.

