### PR TITLE
Recherche la région à partir du département plutôt que du code postal

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,13 +264,17 @@ Contenu:
 
 ## Géolocalisation
 
-Nous utilisons deux services de géolocalisation :
+Nous utilisons plusieurs services de géolocalisation :
 * Nominatim (openstreetmap) pour la doc chercher Nominatim dans cette page https://github.com/alexreisner/geocoder/blob/master/README_API_GUIDE.md
+* geo.api.gouv.fr/communes (https://api.gouv.fr/les-api/api-geo)
+* geo.api.gouv.fr/departements (https://api.gouv.fr/les-api/api-geo)
 * geo.api.gouv.fr/communes (https://api.gouv.fr/les-api/api-geo)
 
 Le premier service est utilisé pour rechercher la position GPS du code postal
 d'une structure, le second service pour valider les codes postaux et rechercher
 leurs informations au moment de la recherche de structure par code postal.
+Les deux derniers services sont utilisés pour retrouver la region.
+
 
 ## Structure des données
 

--- a/app/models/geoloc_helper.rb
+++ b/app/models/geoloc_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class GeolocHelper
+  class << self
+    def cherche_region(code_postal)
+      departement = code_postal.match(/^97|^98/) ? code_postal[0, 3] : code_postal[0, 2]
+      departement = '2A' if departement == '20'
+      begin
+        reponse = RestClient.get("https://geo.api.gouv.fr/departements/#{departement}")
+        code_region = JSON.parse(reponse)['codeRegion']
+        reponse = RestClient.get("https://geo.api.gouv.fr/regions/#{code_region}")
+        JSON.parse(reponse)['nom']
+      rescue RestClient::NotFound
+        Rails.logger.warn "Region introuvable pour le code postal #{code_postal}"
+      end
+    end
+  end
+end

--- a/app/models/structure.rb
+++ b/app/models/structure.rb
@@ -14,7 +14,7 @@ class Structure < ApplicationRecord
 
   geocoded_by :code_postal, state: :region, params: { countrycodes: 'fr' } do |obj, resultats|
     if (resultat = resultats.first)
-      obj.region = cherche_region(obj.code_postal)
+      obj.region = GeolocHelper.cherche_region(obj.code_postal)
       obj.latitude = resultat.latitude
       obj.longitude = resultat.longitude
     end
@@ -76,18 +76,5 @@ class Structure < ApplicationRecord
     RelanceStructureSansCampagneJob
       .set(wait: 7.days)
       .perform_later(id)
-  end
-
-  def self.cherche_region(code_postal)
-    departement = code_postal.match(/^97|^98/) ? code_postal[0, 3] : code_postal[0, 2]
-    departement = '2A' if departement == '20'
-    begin
-      reponse = RestClient.get("https://geo.api.gouv.fr/departements/#{departement}")
-      code_region = JSON.parse(reponse)['codeRegion']
-      reponse = RestClient.get("https://geo.api.gouv.fr/regions/#{code_region}")
-      JSON.parse(reponse)['nom']
-    rescue RestClient::NotFound
-      Rails.logger.warn "Region introuvable pour le code postal #{code_postal}"
-    end
   end
 end

--- a/spec/jobs/structure/assigne_job_spec.rb
+++ b/spec/jobs/structure/assigne_job_spec.rb
@@ -7,14 +7,12 @@ describe Structure::AssigneRegionJob, type: :job do
 
   before do
     structure.update(region: nil)
-    Geocoder::Lookup::Test.add_stub(
-      '92100', [
-        {
-          'coordinates' => [40.7143528, -74.0059731],
-          'state' => 'Île-de-France'
-        }
-      ]
-    )
+    allow(RestClient).to receive(:get)
+      .with('https://geo.api.gouv.fr/departements/92')
+      .and_return({ codeRegion: 11 }.to_json)
+    allow(RestClient).to receive(:get)
+      .with('https://geo.api.gouv.fr/regions/11')
+      .and_return({ nom: 'Île-de-France' }.to_json)
     Structure::AssigneRegionJob.perform_now
     structure.reload
   end

--- a/spec/models/structure_spec.rb
+++ b/spec/models/structure_spec.rb
@@ -103,7 +103,7 @@ describe Structure, type: :model do
 
   describe 'à la création' do
     it 'programme un mail de relance' do
-      expect { create :structure, :avec_admin }
+      expect { create :structure }
         .to have_enqueued_job(RelanceStructureSansCampagneJob).exactly(1)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,10 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-  config.before { allow(Truemail).to receive(:valid?).and_return(true) }
+  config.before do
+    allow(Truemail).to receive(:valid?).and_return(true)
+    allow(RestClient).to receive(:get).and_raise(RestClient::NotFound.new)
+  end
 
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
   # have no way to turn it off -- the option exists only for backwards


### PR DESCRIPTION
Pour résoudre le problème de la création de structure avec le code postal 34080 qui ont une région vide.

Au passage, cette PR fait gagner 5 secondes de temps d'exécution des tests.