### PR TITLE
Ajoute une légende à la restitution des jauges de l'auto-positionnement

### DIFF
--- a/app/assets/stylesheets/admin/pages/restitution_globale/_base.scss
+++ b/app/assets/stylesheets/admin/pages/restitution_globale/_base.scss
@@ -84,6 +84,16 @@
       align-items: center;
     }
 
+    .legende-jauge {
+      position: relative;
+      color: $eva_bluegrey;
+
+      span:last-child {
+        position: absolute;
+        right: 0;
+      }
+    }
+
     .jauge {
       position: relative;
       background-image: asset-data-url('jauge.svg');

--- a/app/assets/stylesheets/admin/pages/restitution_globale/restitution_globale_pdf.scss
+++ b/app/assets/stylesheets/admin/pages/restitution_globale/restitution_globale_pdf.scss
@@ -100,6 +100,13 @@ $grid-gutter-width: 1.25rem;
       margin-top: 1.5rem; // centrage par coïncidence
     }
 
+    .legende-jauge {
+      span:last-child {
+        right: 2rem;
+        white-space: nowrap;
+      }
+    }
+
     .jauge {
       height: 5rem;
     }

--- a/app/views/admin/evaluations/_questionnaire_autopositionnement.arb
+++ b/app/views/admin/evaluations/_questionnaire_autopositionnement.arb
@@ -2,6 +2,15 @@
 
 div class: 'autopositionnement questionnaire' do
   h2 t('.questionnaire-auto-positionnement'), class: 'categorie'
+  div class: 'row mb-1' do
+    div class: 'col intitule-question'
+    div class: 'col' do
+      div class: 'legende-jauge' do
+        span t('.echelle-jauge-min')
+        span t('.echelle-jauge-max')
+      end
+    end
+  end
   auto_positionnement.questions_et_reponses(:jauge).each do |question, reponse|
     div class: 'row' do
       div class: 'col intitule-question' do
@@ -9,7 +18,7 @@ div class: 'autopositionnement questionnaire' do
       end
       div class: 'col' do
         div class: 'jauge' do
-          div reponse.position, class: "position-#{reponse.position} puce"
+          div reponse.position, title: reponse.intitule, class: "position-#{reponse.position} puce"
         end
       end
     end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -12,6 +12,8 @@ fr:
         duree: Durée de passation
       autopositionnement: &autopositionnement
         questionnaire-auto-positionnement: 'Questionnaire d’auto-positionnement'
+        echelle-jauge-min: 'pas du tout'
+        echelle-jauge-max: 'tout à fait'
         non_renseigne: 'Non renseigné'
       questions_reponses_autopositionnement:
         <<: *autopositionnement


### PR DESCRIPTION
Ajoute une légendes au jauges et une info-bulle au survol de la souris
<img width="876" alt="Capture d’écran 2023-07-03 à 16 27 34" src="https://github.com/betagouv/eva-serveur/assets/298214/83463e22-2322-426a-8a82-d3bea60bcaf2">
