### PR TITLE
Corrige la mise en action si la qualification ne correspond pas.

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -127,7 +127,13 @@ ActiveAdmin.register Evaluation do
 
   member_action :renseigner_qualification, method: :patch do
     mise_en_action = resource.mise_en_action
-    mise_en_action.update(mise_en_action.questionnaire => params[:reponse])
+    effectuee = params[:effectuee]
+    qualification = params[:qualification]
+    if effectuee == 'true'
+      mise_en_action.update(effectuee: true, remediation: qualification)
+    else
+      mise_en_action.update(effectuee: false, difficulte: qualification)
+    end
   end
 
   controller do

--- a/app/assets/javascripts/evaluation.js
+++ b/app/assets/javascripts/evaluation.js
@@ -63,12 +63,12 @@ function activeBoutonValider() {
 
 function enregistreQualificationMiseEnAction(evaluationId, $bouton, { ignorer }) {
   const effectuee = miseEnActionEffectuee($bouton)
-  const reponse = ignorer ? 'indetermine' : reponseSelectionnee(evaluationId, nomQcm(effectuee));
+  const qualification = ignorer ? 'indetermine' : reponseSelectionnee(evaluationId, nomQcm(effectuee));
 
   $.ajax({
     method: 'PATCH',
     url: `/pro/admin/evaluations/${evaluationId}/renseigner_qualification`,
-    data: { reponse },
+    data: { effectuee, qualification },
     dataType: "json",
     success: function () {
       afficheModificationReponse(effectuee, evaluationId);

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -234,34 +234,41 @@ describe 'Evaluation', type: :request do
     end
 
     describe '#renseigner_qualification' do
-      context 'quand la mise en action est effectuee' do
-        let(:evaluation) { create :evaluation, :avec_mise_en_action, campagne: ma_campagne }
-        let(:remediation) { 'formation_metier' }
+      let(:evaluation) { create :evaluation, :avec_mise_en_action, campagne: ma_campagne }
+      let(:remediation) { 'formation_metier' }
+      let(:difficulte) { 'aucune_offre_formation' }
+      let(:indetermine) { 'indetermine' }
 
-        it 'peut renseigner le dispositif de remédiation' do
-          expect do
-            patch renseigner_qualification_admin_evaluation_path(evaluation),
-                  params: { reponse: remediation }
-          end.to change { evaluation.reload.mise_en_action.remediation }
-             .from(nil)
-            .to(remediation)
-        end
+      it 'peut renseigner le dispositif de remédiation' do
+        patch renseigner_qualification_admin_evaluation_path(evaluation),
+              params: { effectuee: true, qualification: remediation }
+        evaluation.reload
+        expect(evaluation.mise_en_action.effectuee).to eq true
+        expect(evaluation.mise_en_action.remediation).to eq remediation
       end
 
-      context 'quand la mise en action n est pas effectuee' do
-        let(:evaluation) do
-          create :evaluation, :avec_mise_en_action, effectuee: false, campagne: ma_campagne
-        end
-        let(:difficulte) { 'aucune_offre_formation' }
+      it 'peut ignorer le dispositif de remédiation' do
+        patch renseigner_qualification_admin_evaluation_path(evaluation),
+              params: { effectuee: true, qualification: indetermine }
+        evaluation.reload
+        expect(evaluation.mise_en_action.effectuee).to eq true
+        expect(evaluation.mise_en_action.remediation).to eq indetermine
+      end
 
-        it 'peut renseigner la difficulté' do
-          expect do
-            patch renseigner_qualification_admin_evaluation_path(evaluation),
-                  params: { reponse: difficulte }
-          end.to change { evaluation.reload.mise_en_action.difficulte }
-             .from(nil)
-            .to(difficulte)
-        end
+      it 'peut renseigner une difficultée' do
+        patch renseigner_qualification_admin_evaluation_path(evaluation),
+              params: { effectuee: false, qualification: difficulte }
+        evaluation.reload
+        expect(evaluation.mise_en_action.effectuee).to eq false
+        expect(evaluation.mise_en_action.difficulte).to eq difficulte
+      end
+
+      it 'peut ignorer la difficultée' do
+        patch renseigner_qualification_admin_evaluation_path(evaluation),
+              params: { effectuee: false, qualification: indetermine }
+        evaluation.reload
+        expect(evaluation.mise_en_action.effectuee).to eq false
+        expect(evaluation.mise_en_action.difficulte).to eq indetermine
       end
     end
   end


### PR DESCRIPTION
Quand on enregistre la qualification d'une mise en action, normalement, on a précédemment enregistré si la mise en action a été effectuée ou pas. Mais ça arrive parfois qu'il n'y ait pas correspondance. Peut-être à cause d'une erreur réseau ou d'un problème de requêtes qui ne se font pas dans l'ordre qu'on espère.

Cette PR corrige l'erreur rollbar suivante :
https://app.rollbar.com/a/eva-betagouv/fix/item/eva/820?utm_campaign=new_item&utm_medium=email&utm_source=rollbar-notification&utm_content=view-item-button-1