### PR TITLE
Ne fait pas de relance pour les comptes sans structure

### DIFF
--- a/app/jobs/relance_utilisateur_pour_non_activation_job.rb
+++ b/app/jobs/relance_utilisateur_pour_non_activation_job.rb
@@ -5,7 +5,7 @@ class RelanceUtilisateurPourNonActivationJob < ApplicationJob
 
   def perform(compte_id)
     compte = Compte.find_by id: compte_id
-    return if compte.blank?
+    return if compte.blank? || compte.structure.blank?
 
     campagnes = Campagne.avec_nombre_evaluations_et_derniere_evaluation.where(compte: compte)
     return unless campagnes.map(&:nombre_evaluations).reduce(:+).to_i.zero?

--- a/spec/jobs/relance_utilisateur_pour_non_activation_job_spec.rb
+++ b/spec/jobs/relance_utilisateur_pour_non_activation_job_spec.rb
@@ -35,7 +35,26 @@ describe RelanceUtilisateurPourNonActivationJob, type: :job do
     end
   end
 
+  context 'quand le compte a une campagne sans passations et pas de structure' do
+    let(:campagne) { create :campagne, compte: compte }
+
+    before do
+      compte.update(structure_id: nil)
+    end
+
+    it 'ne fais rien' do
+      expect do
+        RelanceUtilisateurPourNonActivationJob.perform_now(compte.id)
+      end.to change { ActionMailer::Base.deliveries.count }.by(0)
+    end
+  end
+
   context 'quand le compte a été supprimé' do
-    it { RelanceUtilisateurPourNonActivationJob.perform_now(1) }
+    it do
+      id_compte_supprime = 1
+      expect do
+        RelanceUtilisateurPourNonActivationJob.perform_now(id_compte_supprime)
+      end.to change { ActionMailer::Base.deliveries.count }.by(0)
+    end
   end
 end


### PR DESCRIPTION
pour éviter l'erreur rollbar
https://app.rollbar.com/a/eva-betagouv/fix/item/eva/828?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification undefined method `cible_evaluation' for nil:NilClass at
relance(/app/app/mailers/compte_mailer.rb:20)