### PR TITLE
Donne le droit aux comptes admin et génériques de supprimer des comptes conseiller de leur structure

### DIFF
--- a/app/models/ability_utilisateur.rb
+++ b/app/models/ability_utilisateur.rb
@@ -105,6 +105,7 @@ class AbilityUtilisateur
     can :update, Compte, structure_id: compte.structure_id
     can :edit_role, Compte, structure_id: compte.structure_id
     cannot :edit_role, compte if compte.compte_generique?
+    can :destroy, Compte, structure_id: compte.structure_id, role: :conseiller
   end
 
   def droits_validation_comptes(compte)

--- a/spec/integrations/ability_spec.rb
+++ b/spec/integrations/ability_spec.rb
@@ -173,6 +173,7 @@ describe Ability do
 
     context 'peut gérer mes collègues' do
       let(:mon_collegue) { create :compte, role: :conseiller, structure: compte.structure }
+      let(:pas_collegue) { compte_conseiller }
       let(:campagne_collegue) { create :campagne, compte: mon_collegue }
       let(:evaluation_collegue) { create :evaluation, campagne: campagne_collegue }
 
@@ -182,12 +183,15 @@ describe Ability do
       it { is_expected.to be_able_to(:destroy, evaluation_collegue) }
       it { is_expected.to be_able_to(:autoriser, mon_collegue) }
       it { is_expected.to be_able_to(:refuser, mon_collegue) }
+      it { is_expected.to be_able_to(:destroy, mon_collegue) }
+      it { is_expected.not_to be_able_to(:destroy, pas_collegue) }
       it { is_expected.not_to be_able_to(:read, Beneficiaire) }
 
       context 'quand un compte est admin' do
         before { mon_collegue.update(role: :admin) }
 
         it { is_expected.not_to be_able_to(:refuser, mon_collegue) }
+        it { is_expected.not_to be_able_to(:destroy, mon_collegue) }
       end
     end
 


### PR DESCRIPTION
🌟 Enjeux

Faciliter le nettoyage des comptes erronés ou obsolètes.

🎯 Résultats à atteindre

Qu’un admin de structure ait le droit de supprimer un compte conseiller, à condition que ce dernier n’ait pas de campagne rattachée (même situation que les super admin)

<img width="950" alt="Capture d’écran 2023-11-10 à 16 34 38" src="https://github.com/betagouv/eva-serveur/assets/298214/5d9c5ff6-5194-4315-8dc8-c43fbece6127">
