### PR TITLE
Remet en place l'autofocus pour le formulaire de login eva

### DIFF
--- a/app/views/active_admin/devise/sessions/new.html.erb
+++ b/app/views/active_admin/devise/sessions/new.html.erb
@@ -92,6 +92,7 @@
 <script>
   function basculer_login_eva() {
     $(".espace-connexion").toggleClass("hidden");
+    $(".espace-connexion").find('#compte_email').select();
     $(".espace-inscription").toggleClass("hidden");
     $(".espace-inclusion-connect").toggleClass("hidden");
   }


### PR DESCRIPTION
En effet, l'autofocus HTML 5 ne fonctionne bien qu'au moment du chargement de la page. Avec le nouveau formulaire en deux étapes, il faut sélectionner le champ e-mail en JS