### PR TITLE
N'affiche plus les statistiques par défaut pour les structures locales et les comptes

### DIFF
--- a/app/admin/comptes.rb
+++ b/app/admin/comptes.rb
@@ -48,14 +48,13 @@ ActiveAdmin.register Compte do
          if: proc { can? :manage, Compte }
 
   def filtrer_par_activation_structure(statut_activation, options = {})
-    options.merge!({ if: -> { can? :manage, Compte } })
+    options.merge!({ if: -> { params[:stats] && can?(:manage, Compte) } })
     scope statut_activation, options do |scope|
       scope.where(structure: Structure.send(statut_activation))
     end
   end
 
-  scope :all, { default: true, if: -> { can? :manage, Compte } }
-
+  scope :all, { default: true, if: -> { params[:stats] && can?(:manage, Compte) } }
   filtrer_par_activation_structure(:pas_vraiment_utilisatrices)
   filtrer_par_activation_structure(:non_activees)
   filtrer_par_activation_structure(:actives)
@@ -79,6 +78,19 @@ ActiveAdmin.register Compte do
     end
     actions
   end
+
+  action_item :stats, only: :index, if: -> { can? :manage, Compte } do
+    if params[:stats]
+      link_to t('.sans_stats'), admin_comptes_path
+    else
+      link_to t('.stats'), admin_comptes_path(stats: true)
+    end
+  end
+
+  sidebar :aide_filtres,
+          partial: 'admin/structures_locales/aide_filtres_sidebar',
+          only: :index,
+          if: -> { params[:stats] && can?(:manage, Compte) }
 
   form do |f|
     f.inputs do
@@ -105,11 +117,6 @@ ActiveAdmin.register Compte do
       annulation_formulaire(f)
     end
   end
-
-  sidebar :aide_filtres,
-          partial: 'admin/structures_locales/aide_filtres_sidebar',
-          only: :index,
-          if: -> { can? :manage, Compte }
 
   csv do
     column :prenom

--- a/app/admin/structures_locales.rb
+++ b/app/admin/structures_locales.rb
@@ -16,13 +16,23 @@ ActiveAdmin.register StructureLocale do
          collection: proc { Structure.distinct.order(:region).pluck(:region) }
   filter :created_at
 
-  scope :all, default: true
-  scope :sans_campagne
-  scope :pas_vraiment_utilisatrices
-  scope :non_activees
-  scope :actives
-  scope :inactives
-  scope :abandonnistes
+  scope :all, default: true, if: -> { params[:stats] }
+  scope :sans_campagne, if: -> { params[:stats] }
+  scope :pas_vraiment_utilisatrices, if: -> { params[:stats] }
+  scope :non_activees, if: -> { params[:stats] }
+  scope :actives, if: -> { params[:stats] }
+  scope :inactives, if: -> { params[:stats] }
+  scope :abandonnistes, if: -> { params[:stats] }
+
+  action_item :stats, only: :index do
+    if params[:stats]
+      link_to t('.sans_stats'), admin_structures_locales_path
+    else
+      link_to t('.stats'), admin_structures_locales_path(stats: true)
+    end
+  end
+
+  sidebar :aide_filtres, only: :index, if: -> { params[:stats] }
 
   index do
     column :nom
@@ -66,8 +76,6 @@ ActiveAdmin.register StructureLocale do
   show do
     render partial: 'admin/structures/show', locals: { structure: resource }
   end
-
-  sidebar :aide_filtres, only: :index
 
   form partial: 'form'
 

--- a/app/models/compte.rb
+++ b/app/models/compte.rb
@@ -36,7 +36,6 @@ class Compte < ApplicationRecord
 
   accepts_nested_attributes_for :structure
 
-
   def display_name
     nom_complet.presence || email
   end

--- a/app/models/compte.rb
+++ b/app/models/compte.rb
@@ -2,15 +2,20 @@
 
 class Compte < ApplicationRecord
   DELAI_RELANCE_NON_ACTIVATION = 30.days
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :trackable,
-         :recoverable, :rememberable, :validatable, :registerable, :confirmable
   ROLES = %w[superadmin charge_mission_regionale admin conseiller compte_generique].freeze
   ROLES_STRUCTURE = %w[admin conseiller].freeze
   ADMIN_ROLES = %w[superadmin admin compte_generique].freeze
   ANLCI_ROLES = %w[superadmin charge_mission_regionale].freeze
+
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :trackable,
+         :recoverable, :rememberable, :validatable, :registerable, :confirmable
+
+  acts_as_paranoid
+
   include Comptes::EnvoieEmails
+
   validates :role, inclusion: { in: ROLES }
   enum :role, ROLES.zip(ROLES).to_h
   validates :statut_validation, presence: true
@@ -31,7 +36,6 @@ class Compte < ApplicationRecord
 
   accepts_nested_attributes_for :structure
 
-  acts_as_paranoid
 
   def display_name
     nom_complet.presence || email

--- a/config/locales/activeadmin.yml
+++ b/config/locales/activeadmin.yml
@@ -71,6 +71,8 @@ fr:
       statistiques: Voir les statistiques
     resource:
       index:
+        stats: Afficher les statistiques
+        sans_stats: Masquer les statistiques
         rapport: Rapport
         evenements: Évenements
     sidebars:


### PR DESCRIPTION
Pour une question de performance, on n'affiche plus les statistiques par défaut sur les pages comptes et structures locales.

## Pour les comptes

<img width="1404" alt="Capture d’écran 2023-12-13 à 17 08 54" src="https://github.com/betagouv/eva-serveur/assets/298214/3cf9b602-8618-441b-9678-f7e2c304e8fd">
<img width="1405" alt="Capture d’écran 2023-12-13 à 17 09 04" src="https://github.com/betagouv/eva-serveur/assets/298214/d9c92f45-8444-42c2-9233-4b5eb47eb691">

## Pour les structures
<img width="1280" alt="Capture d’écran 2023-12-13 à 17 09 43" src="https://github.com/betagouv/eva-serveur/assets/298214/941314e1-3791-4472-8873-6d21a25a1010">
<img width="1256" alt="Capture d’écran 2023-12-13 à 17 09 52" src="https://github.com/betagouv/eva-serveur/assets/298214/00c58c58-f89c-4e4b-9378-72a717511fb1">
