### PR TITLE
Reconnaît les e-mails InclusionConnect indépendamment de la casse

### DIFF
--- a/app/helpers/inclusion_connect_helper.rb
+++ b/app/helpers/inclusion_connect_helper.rb
@@ -72,11 +72,12 @@ module InclusionConnectHelper
     end
 
     def cree_ou_recupere_compte(user_info)
+      email = user_info['email'].strip.downcase
       compte = Compte.find_by(id_inclusion_connect: user_info['sub'])
-      if compte.present? && compte.email != user_info['email']
-        compte = actualise_email_compte_existant(compte, user_info['email'])
+      if compte.present? && compte.email != email
+        compte = actualise_email_compte_existant(compte, email)
       end
-      compte ||= Compte.find_or_create_by(email: user_info['email'])
+      compte ||= Compte.find_or_create_by(email: email)
       actualise_autres_champs(compte, user_info)
       compte.save!
       compte

--- a/spec/helpers/inclusion_connect_helper_spec.rb
+++ b/spec/helpers/inclusion_connect_helper_spec.rb
@@ -68,7 +68,80 @@ describe InclusionConnectHelper do
       end
     end
 
-    context 'le compte existe déjà en base avec id inclusion connect' do
+    context 'le compte existe déjà en base sans id inclusion connect, email avec majuscule' do
+      before do
+        create :compte_admin, email: email
+      end
+
+      it do
+        Timecop.freeze(aujourdhui) do
+          compte = described_class.cree_ou_recupere_compte({
+                                                             'sub' => id_ic,
+                                                             'email' => 'toto@eva.beta.gouv.FR',
+                                                             'given_name' => 'prénom',
+                                                             'family_name' => 'nom'
+                                                           })
+          expect(compte).not_to be_nil
+          expect(compte.email).to eq(email)
+          expect(compte.prenom).to eq('prénom')
+          expect(compte.nom).to eq('nom')
+          expect(compte.confirmed_at).to eq(aujourdhui)
+          expect(compte.password).to be_nil
+          expect(compte.id_inclusion_connect).to eq(id_ic)
+        end
+      end
+    end
+
+    context 'le compte existe déjà en base même email, mais effacé' do
+      before do
+        create :compte_admin, email: email, confirmed_at: hier, deleted_at: hier
+      end
+
+      it do
+        Timecop.freeze(aujourdhui) do
+          compte = described_class.cree_ou_recupere_compte({
+                                                             'sub' => id_ic,
+                                                             'email' => email,
+                                                             'given_name' => 'prénom',
+                                                             'family_name' => 'nom'
+                                                           })
+          expect(compte).not_to be_nil
+          expect(compte.prenom).to eq('prénom')
+          expect(compte.nom).to eq('nom')
+          expect(compte.email).to eq(email)
+          expect(compte.confirmed_at).to eq(aujourdhui)
+          expect(compte.password).not_to be_nil
+          expect(compte.id_inclusion_connect).to eq(id_ic)
+          expect(compte.id).not_to eq(Compte.only_deleted.find_by(email: email).id)
+        end
+      end
+    end
+
+    context 'le compte existe déjà en base avec id inclusion connect, même email' do
+      before do
+        create :compte_admin, email: email, confirmed_at: hier, id_inclusion_connect: id_ic
+      end
+
+      it do
+        Timecop.freeze(aujourdhui) do
+          compte = described_class.cree_ou_recupere_compte({
+                                                             'sub' => id_ic,
+                                                             'email' => email,
+                                                             'given_name' => 'prénom',
+                                                             'family_name' => 'nom'
+                                                           })
+          expect(compte).not_to be_nil
+          expect(compte.prenom).to eq('prénom')
+          expect(compte.nom).to eq('nom')
+          expect(compte.email).to eq(email)
+          expect(compte.confirmed_at).to eq(hier)
+          expect(compte.password).to be_nil
+          expect(compte.id_inclusion_connect).to eq(id_ic)
+        end
+      end
+    end
+
+    context 'le compte existe déjà en base avec id inclusion connect, email différent' do
       before do
         create :compte_admin, email: ancien_email, confirmed_at: hier, id_inclusion_connect: id_ic
       end


### PR DESCRIPTION
https://app.rollbar.com/a/eva-betagouv/fix/item/eva/850

Cas d'un compte existant dans eva, mais enregistré chez inclusion connect avec une casse différente.