### PR TITLE
Ajoute le lien « Déconnexion » dans l'encart blanc en haut à droite

### DIFF
--- a/app/assets/stylesheets/admin/layout/_header.scss
+++ b/app/assets/stylesheets/admin/layout/_header.scss
@@ -123,7 +123,7 @@
     box-shadow: 0px 0px 0.5rem rgba(30, 65, 106, 0.25);
 
     &:hover {
-      #utility_compte, #utility_structure, #utility_statistiques {
+      #utility_compte, #utility_structure, #utility_statistiques, #utility_logout {
         display: block;
       }
       #utility_structure_courante::after {
@@ -205,7 +205,7 @@
           background: asset-data-url('roue-dentee.svg') no-repeat center;
         }
       }
-      &_compte, &_statistiques, &_structure {
+      &_compte, &_structure, &_statistiques, &_logout {
         display: none;
         padding-bottom: .5rem;
         background-color: $eva_bluegrey;
@@ -214,7 +214,7 @@
       &_compte {
         padding-top: 1rem;
       }
-      &_statistiques {
+      &_logout {
         padding-bottom: 1rem;
         &:after {
           content: '';

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -256,6 +256,10 @@ ActiveAdmin.setup do |config|
                 send("admin_#{structure.type.underscore}_path", structure, anchor: "bloc-statistiques") if structure
               },
               priority: 5
+      menu.add id: 'utility_logout',
+              label: I18n.t('active_admin.menu_connexion.logout').html_safe,
+              url: proc{ send(config.logout_link_path) },
+              priority: 6
       admin.add_logout_button_to_menu menu
     end
   end

--- a/config/locales/activeadmin.yml
+++ b/config/locales/activeadmin.yml
@@ -69,6 +69,7 @@ fr:
       compte: Voir mon compte
       structure: Voir ma structure
       statistiques: Voir les statistiques
+      logout: Déconnexion
     resource:
       index:
         stats: Afficher les statistiques


### PR DESCRIPTION
Pour faciliter les messages du support, il est plus facile de décrire un lien qu'une icône. Quand on veut demander aux gens de se déconnecter pour pouvoir ensuite trouver le lien « mot de passe oublié »

<img width="355" alt="Capture d’écran 2023-12-21 à 15 19 16" src="https://github.com/betagouv/eva-serveur/assets/298214/d37e9aa7-1bec-4ff5-835b-0a92bd66cb9e">
