### PR TITLE
Force les CMR a changer de mot de passe s'il n'est pas conforme

### DIFF
--- a/app/controllers/eva/devise/passwords_controller.rb
+++ b/app/controllers/eva/devise/passwords_controller.rb
@@ -5,18 +5,29 @@ module Eva
     class PasswordsController < ActiveAdmin::Devise::PasswordsController
       # rubocop:disable Rails/LexicallyScopedActionFilter
       before_action :validate_reset_password_token, only: :edit
+      before_action :trouve_regles_mot_de_passe, only: :edit
       # rubocop:enable Rails/LexicallyScopedActionFilter
 
       private
 
+      def trouve_regles_mot_de_passe
+        @regles_mot_de_passe = compte&.anlci? ? 'regles_mot_de_passe_anlci' : 'regles_mot_de_passe'
+      end
+
       def validate_reset_password_token
-        token = ::Devise.token_generator.digest(resource_class, :reset_password_token,
-                                                params[:reset_password_token])
-        recoverable = resource_class.find_by(reset_password_token: token)
-        return if recoverable&.reset_password_period_valid?
+        return if compte&.reset_password_period_valid?
 
         flash[:error] = t('active_admin.devise.passwords.edit.token_invalide')
         redirect_to new_compte_password_path(token_invalide: true)
+      end
+
+      def compte
+        @compte ||= resource_class
+                    .find_by(reset_password_token: ::Devise.token_generator.digest(
+                      resource_class,
+                      :reset_password_token,
+                      params[:reset_password_token]
+                    ))
       end
     end
   end

--- a/app/models/password_validator.rb
+++ b/app/models/password_validator.rb
@@ -5,12 +5,12 @@ class PasswordValidator < ActiveModel::Validator
     value = compte.password
     return if value.blank?
     return unless compte.anlci?
-    return if est_avec_12_maj_min_num_et_symbol?(value)
+    return if PasswordValidator.est_avec_12_maj_min_num_et_symbol?(value)
 
     compte.errors.add(:password, I18n.t('.creation_compte.regles_mot_de_passe_anlci'))
   end
 
-  def est_avec_12_maj_min_num_et_symbol?(value)
+  def self.est_avec_12_maj_min_num_et_symbol?(value)
     value.length >= 12 &&
       value =~ /[A-Z]/ &&
       value =~ /[a-z]/ &&

--- a/app/models/password_validator.rb
+++ b/app/models/password_validator.rb
@@ -7,7 +7,7 @@ class PasswordValidator < ActiveModel::Validator
     return unless compte.anlci?
     return if est_avec_12_maj_min_num_et_symbol?(value)
 
-    compte.errors.add(:password, I18n.t('.creation_compte.regles_mot_de_passe'))
+    compte.errors.add(:password, I18n.t('.creation_compte.regles_mot_de_passe_anlci'))
   end
 
   def est_avec_12_maj_min_num_et_symbol?(value)

--- a/app/views/active_admin/devise/passwords/edit.html.erb
+++ b/app/views/active_admin/devise/passwords/edit.html.erb
@@ -6,7 +6,7 @@
   <div id="login">
     <div class='mot-de-passe-instruction'>
       <p class='mot-de-passe-instruction--consigne'><%= t('.consigne') %></p>
-      <p><%= t('.caracteristique')%></p>
+      <p><%= t(@regles_mot_de_passe, scope: 'creation_compte', longueur_mot_de_passe: Devise.password_length.first)%></p>
     </div>
     <%= render partial: "active_admin/devise/shared/messages_erreurs_generales", resource: resource, locals: { champs_affiches: [:password, :password_confirmation] } %>
     <%= active_admin_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|

--- a/app/views/admin/dashboard/_modal_validation_comptes_en_attente.html.erb
+++ b/app/views/admin/dashboard/_modal_validation_comptes_en_attente.html.erb
@@ -6,7 +6,7 @@
           <%= md t('.info_comptes_en_attente') %>
         </div>
         <div class='actions'>
-          <a class="bouton bouton-outline--light" data-dismiss="modal">Plus tard</a>
+          <a class="bouton bouton-outline--light" href="#" data-dismiss="modal">Plus tard</a>
           <% structure = current_compte.structure %>
           <%= link_to 'Voir les demandes',
                       send("admin_#{structure.type.underscore}_path", structure, anchor: "bloc-membres"),

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,6 +1,6 @@
 <p>Bonjour <%= @resource.email %> !</p>
 
-<p>Vous avez demandé à changer le mot de passe de votre compte eva.<br/>
+<p>Le mot de passe de votre compte est périmé ou vous l'avez oublié ?<br/>
 Pour changer ce mot de passe, cliquez sur le lien suivant :</p>
 
 <div class="text-center" style="margin: 2rem 0;">

--- a/config/locales/activeadmin.yml
+++ b/config/locales/activeadmin.yml
@@ -6,6 +6,7 @@ fr:
     sessions:
       compte:
         signed_in_but_unconfirmed: ""
+        mot_de_passe_faible: Votre mot de passe est trop faible veuillez en choisir un nouveau
   active_admin:
     recherche_structure: Rechercher ma structure
     devise:

--- a/config/locales/activeadmin.yml
+++ b/config/locales/activeadmin.yml
@@ -51,7 +51,6 @@ fr:
         edit:
           lien_retour: Se connecter
           consigne: Saisissez et confirmez votre nouveau mot de passe ci-dessous.
-          caracteristique: Votre mot de passe doit comporter au moins 6 caractères.
           token_invalide: Votre lien de réinitialisation n’est pas valide.
           submit: Valider mon nouveau mot de passe
       change_password:

--- a/config/locales/activeadmin.yml
+++ b/config/locales/activeadmin.yml
@@ -6,7 +6,7 @@ fr:
     sessions:
       compte:
         signed_in_but_unconfirmed: ""
-        mot_de_passe_faible: Votre mot de passe est trop faible veuillez en choisir un nouveau
+        mot_de_passe_faible: Votre mot de passe n'est pas conforme aux nouvelles exigences de sécurité. Un mail de réinitialisation vous a été envoyé, veuillez suivre ses instructions pour définir un nouveau mot de passe. N'hésitez pas à contacter le support si vous rencontrez des difficultés.
   active_admin:
     recherche_structure: Rechercher ma structure
     devise:

--- a/config/locales/models/compte.yml
+++ b/config/locales/models/compte.yml
@@ -78,6 +78,7 @@ fr:
     cgu_tool_tip: "Veuillez accepter les CGU"
     information_cgu: "Les conditions générales d'utilisation sont consultables ici :"
     demande_acceptation: "Veuillez en prendre connaissance et les accepter pour pouvoir vous inscrire."
-    regles_mot_de_passe: |
+    regles_mot_de_passe: Votre mot de passe doit comporter au moins %{longueur_mot_de_passe} caractères.
+    regles_mot_de_passe_anlci: |
       doit contenir au moins 12 caractères dont une majuscule, une minuscule, un chiffre et un symbol.
       Nous vous recommandons l'utilisation d'un générateur de mot de passe fort.

--- a/spec/features/admin/session_spec.rb
+++ b/spec/features/admin/session_spec.rb
@@ -4,6 +4,15 @@ require 'rails_helper'
 
 describe 'Session', type: :feature do
   describe 'Connexion Espace Pro' do
+    context 'Quand tout va bien' do
+      let!(:compte) { create :compte }
+
+      it "Se connect à l'application" do
+        connecte(compte)
+        expect(page).to have_current_path(admin_dashboard_path)
+      end
+    end
+
     context "Quand le compte n'existe pas" do
       before do
         connecte_email email: 'invalid@email.com'
@@ -11,6 +20,22 @@ describe 'Session', type: :feature do
 
       it "Renvoie un message d'erreur" do
         expect(page).to have_content('Email ou mot de passe incorrect')
+      end
+    end
+
+    context 'Quand mon compte anlci a un mot de passe faible car les règles ont été remforcées' do
+      let!(:compte) do
+        compte = create :compte, role: :superadmin
+        # rubocop:disable Rails/SkipsModelValidations
+        compte.update_attribute(:password, '123')
+        # rubocop:enable Rails/SkipsModelValidations
+        compte
+      end
+
+      it "Refuse la connexion et renvoie un message d'erreur" do
+        connecte(compte)
+        expect(page).to have_current_path(new_compte_session_path)
+        expect(page).to have_content("Votre mot de passe n'est pas conforme")
       end
     end
 


### PR DESCRIPTION
Au moment de se connecter, si le mot de passe est trop faible, on affiche l'écran suivant :
<img width="978" alt="Capture d’écran 2024-01-11 à 16 49 54" src="https://github.com/betagouv/eva-serveur/assets/298214/c3c337e9-c1c3-4592-acd0-ec1457c4e494">

Puis le mail (légèrement modifié)
<img width="964" alt="Capture d’écran 2024-01-11 à 16 50 05" src="https://github.com/betagouv/eva-serveur/assets/298214/453dae27-ea55-4f64-89f1-b27215687e6b">

Et enfin, les deux fenêtres de réinitialisation de mot de passe ont été mise à jour avec la description de la règle de chacun.
Pour les conseillers :
<img width="702" alt="Capture d’écran 2023-12-22 à 19 13 55" src="https://github.com/betagouv/eva-serveur/assets/298214/9f0f4ecb-120b-4292-8410-03d7da71f1ad">
Pour les super-admins et CMR :
<img width="749" alt="Capture d’écran 2023-12-22 à 19 14 00" src="https://github.com/betagouv/eva-serveur/assets/298214/3ea8abb7-96c1-4388-8336-cf6a716888cd">
