### PR TITLE
Corrige le messages des regles de mot de passe pour les superadmins et CMR

### DIFF
--- a/config/locales/models/compte.yml
+++ b/config/locales/models/compte.yml
@@ -80,5 +80,5 @@ fr:
     demande_acceptation: "Veuillez en prendre connaissance et les accepter pour pouvoir vous inscrire."
     regles_mot_de_passe: Votre mot de passe doit comporter au moins %{longueur_mot_de_passe} caractères.
     regles_mot_de_passe_anlci: |
-      doit contenir au moins 12 caractères dont une majuscule, une minuscule, un chiffre et un symbol.
+      Votre mot de passe doit contenir au moins 12 caractères dont une majuscule, une minuscule, un chiffre et un symbole.
       Nous vous recommandons l'utilisation d'un générateur de mot de passe fort.

--- a/lib/tasks/reviewapp.rake
+++ b/lib/tasks/reviewapp.rake
@@ -66,7 +66,7 @@ namespace :reviewapp do
     cree_campagnes_socio
 
     Compte.find_each do |compte|
-      compte.encrypted_password = '$2a$11$d.kf40n..7zqTGgCPANFlOiLvwGH35EPh0OsY6euJaje3Us20KIWO'
+      compte.encrypted_password = '$2a$11$TE.U8c5Rka9PqDk5uL31xePkHnlp0EYsY7RuDyuhJEODObxoNGq/y'
       compte.save!(validate: false)
     end
   end


### PR DESCRIPTION
<img width="749" alt="Capture d’écran 2024-01-19 à 11 46 23" src="https://github.com/betagouv/eva-serveur/assets/298214/da2ceafd-1e8b-4da0-ab5d-e57a2fc0e5bb">

De plus, cette PR change le mot de passe des comptes des reviewapps