### PR TITLE
Accessibilité : titres des tableaux de la page de login dans des h2

### DIFF
--- a/app/assets/stylesheets/admin/pages/_logged_out.scss
+++ b/app/assets/stylesheets/admin/pages/_logged_out.scss
@@ -115,18 +115,14 @@ body.logged_out {
           padding: 1.5rem;
         }
         .panel-header {
-          height: 4rem;
-          border-radius: 0.5rem 0.5rem 0 0;
           display: flex;
           align-items: center;
-          p {
-            font-family: $font-titre;
-            font-size: 1rem;
-            font-weight: 700;
-            color: $eva_light;
-            padding-left: 1.5rem;
-            margin: 0;
-          }
+          height: 4rem;
+          border-radius: 0.5rem 0.5rem 0 0;
+          font-size: 1rem;
+          color: $eva_light;
+          padding-left: 1.5rem;
+          margin: 0;
         }
       }
       form {

--- a/app/views/active_admin/devise/sessions/new.html.erb
+++ b/app/views/active_admin/devise/sessions/new.html.erb
@@ -4,9 +4,7 @@
 <div class="panels-login">
   <div class="colonne-1">
     <div class="panel panel--connexion">
-      <div class="panel-header">
-        <%= md t('active_admin.devise.login.header_title') -%>
-      </div>
+      <h2 class="panel-header"><%= t('active_admin.devise.login.header_title') -%></h2>
 
       <div class="panel-content">
         <div class="espace-inclusion-connect">
@@ -58,9 +56,7 @@
 
   <div class="colonne-2">
     <div class="panel panel--evaluation">
-      <div class="panel-header">
-        <%= md t('active_admin.devise.login.evaluations.header_title') -%>
-      </div>
+      <h2 class="panel-header"><%= t('active_admin.devise.login.evaluations.header_title') -%></h2>
       <div class="panel-content">
         <div class="panel-description">
           <%= md t('active_admin.devise.login.evaluations.content') -%>


### PR DESCRIPTION
Corrige la remarque suivante du rapport d'audit de audit-web

16.2. Titres simulés
Problème :
● 9.1 - Majeur : Présence d’un titre de hiérarchie simulé