### PR TITLE
Affiche aussi la page 404 pour les évaluations supprimées 

### DIFF
--- a/app/controllers/erreurs_controller.rb
+++ b/app/controllers/erreurs_controller.rb
@@ -1,10 +1,19 @@
 # frozen_string_literal: true
 
-class ErreursController < ApplicationController
-  layout 'erreurs'
+# rubocop:disable Rails/ApplicationController
+class ErreursController < ActionController::Base
+  # rubocop:enable Rails/ApplicationController
   helper ::ActiveAdmin::ViewHelpers
 
   def not_found
-    render '404', status: :not_found
+    render 'erreur', formats: :html, status: :not_found
+  end
+
+  def internal_serveur_error
+    render 'erreur', formats: :html, status: :internal_server_error
+  end
+
+  def unprocessable_entity
+    render 'erreur', formats: :html, status: :unprocessable_entity
   end
 end

--- a/app/views/erreurs/404.html.erb
+++ b/app/views/erreurs/404.html.erb
@@ -1,6 +1,0 @@
-<% content_for :title, t('.title') %>
-
-<h1><%= t('.titre') %></h1>
-<p>
-<%= t('.description') %>
-</p>

--- a/app/views/erreurs/erreur.html.erb
+++ b/app/views/erreurs/erreur.html.erb
@@ -1,0 +1,4 @@
+<% content_for :title, t(".#{response.status}.title") %>
+
+<h1><%= t(".#{response.status}.titre") %></h1>
+<%= md(t(".#{response.status}.description")) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,7 @@ require "sprockets/railtie"
 require "rails/test_unit/railtie"
 require 'view_component'
 require 'view_component/storybook'
+require './lib/custom_exceptions_app_wrapper'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -37,6 +38,7 @@ module EvaServeur
     config.middleware.use ActionDispatch::Flash
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use ActionDispatch::Session::CookieStore
+    config.exceptions_app = CustomExceptionsAppWrapper.new(exceptions_app: routes)
 
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid

--- a/config/locales/views/erreurs.yml
+++ b/config/locales/views/erreurs.yml
@@ -4,7 +4,18 @@ fr:
       message-accueil: Oups…
       retour-accueil: Retour à l'accueil
   erreurs:
-    404:
-      title: 404
-      titre: Erreur 404
-      description: La page demandée n'existe pas
+    erreur:
+      404:
+        title: 404
+        titre: Erreur 404
+        description: La page demandée n'existe pas.
+      500:
+        title: 500
+        titre: Erreur 500
+        description: Une erreur est survenue.
+      422:
+        title: 422
+        titre: Erreur 422
+        description: |
+          Le serveur n'a pas pu traiter votre demande.  
+          Veuillez réessayer.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,9 @@ Rails.application.routes.draw do
       resources :evenements
     end
 
-    get '*path', to: 'erreurs#not_found', constraints: lambda { |_req| Rails.env.production? }
+    match '404', via: :all, to: 'erreurs#not_found'
+    match '500', via: :all, to: 'erreurs#internal_serveur_error'
+    match '422', via: :all, to: 'erreurs#unprocessable_entity'
   end
+
 end

--- a/lib/custom_exceptions_app_wrapper.rb
+++ b/lib/custom_exceptions_app_wrapper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CustomExceptionsAppWrapper
+  def initialize(exceptions_app:)
+    @exceptions_app = exceptions_app
+  end
+
+  def call(env)
+    request = ActionDispatch::Request.new(env)
+
+    fallback_to_html_format_if_invalid_mime_type(request)
+
+    @exceptions_app.call(env)
+  end
+
+  private
+
+  def fallback_to_html_format_if_invalid_mime_type(request)
+    request.formats
+  rescue ActionDispatch::Http::MimeNegotiation::InvalidType
+    request.set_header 'CONTENT_TYPE', 'text/html'
+  end
+end

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -7,4 +7,24 @@ describe 'Index', type: :feature do
     visit '/'
     expect(page.current_url).to eql(new_compte_session_url)
   end
+
+  it 'Redirige vers la page 404' do
+    expect { visit '/page_inconnue' }
+      .to raise_error(ActionController::RoutingError)
+  end
+
+  it 'Render page 404' do
+    visit '/pro/404'
+    expect(page).to have_content "La page demandée n'existe pas."
+  end
+
+  it 'Render page 500' do
+    visit '/pro/500'
+    expect(page).to have_content 'Une erreur est survenue'
+  end
+
+  it 'Render page 422' do
+    visit '/pro/422'
+    expect(page).to have_content 'Veuillez réessayer'
+  end
 end

--- a/spec/requests/campagnes_spec.rb
+++ b/spec/requests/campagnes_spec.rb
@@ -20,7 +20,7 @@ describe 'Campagne API', type: :request do
     end
 
     it "retourne une 404 lorsqu'elle n'existe pas" do
-      get '/api/campagnes/404'
+      get '/api/campagnes/inconnue'
 
       expect(response).to have_http_status(:not_found)
     end


### PR DESCRIPTION
<img width="868" alt="Capture d’écran 2024-04-03 à 17 22 02" src="https://github.com/betagouv/eva-serveur/assets/298214/a250eee4-3ba0-48d7-a0cf-8be180cca880">

Ajoute aussi la mise en forme des pages 500 et 422 :

<img width="663" alt="Capture d’écran 2024-04-03 à 17 21 40" src="https://github.com/betagouv/eva-serveur/assets/298214/586bac40-bfa6-420e-a024-50b959186636">
<img width="684" alt="Capture d’écran 2024-04-03 à 17 22 29" src="https://github.com/betagouv/eva-serveur/assets/298214/d967cbb3-018e-4620-8419-7e4c4c37654e">
