### PR TITLE
Autorise les conseillers à supprimer des campagnes contenant des évaluations

### DIFF
--- a/app/models/ability_utilisateur.rb
+++ b/app/models/ability_utilisateur.rb
@@ -18,7 +18,7 @@ class AbilityUtilisateur
   def droit_campagne(compte)
     can :create, Campagne
     can %i[update read], Campagne, comptes_de_meme_structure(compte) if compte.validation_acceptee?
-    can %i[update read], Campagne, compte_id: compte.id
+    can %i[update read destroy], Campagne, compte_id: compte.id
     can(:destroy, Campagne) { |c| Evaluation.where(campagne: c).empty? }
   end
 

--- a/app/models/campagne.rb
+++ b/app/models/campagne.rb
@@ -10,7 +10,7 @@ class Campagne < ApplicationRecord
   has_many :situations_configurations, lambda {
                                          order(position: :asc)
                                        }, dependent: :destroy
-  has_many :evaluations, dependent: :restrict_with_error
+  has_many :evaluations, dependent: :destroy
   belongs_to :compte
   belongs_to :parcours_type, optional: true
 

--- a/config/locales/models/campagne.yml
+++ b/config/locales/models/campagne.yml
@@ -44,3 +44,4 @@ fr:
         delete_model: Supprimer
         new_model: Nouvelle campagne
         edit_model: Modification de la campagne
+        delete_confirmation: Attention, supprimer cette campagne supprimera toutes les évaluations qu'elle contient.

--- a/spec/integrations/ability_spec.rb
+++ b/spec/integrations/ability_spec.rb
@@ -46,7 +46,7 @@ describe Ability do
     it { is_expected.to be_able_to(:manage, Beneficiaire) }
 
     it 'avec une campagne qui a des évaluations' do
-      expect(subject).not_to be_able_to(:destroy, campagne_superadmin)
+      expect(subject).to be_able_to(:destroy, campagne_superadmin)
     end
 
     it "avec une campagne qui n'a pas d'évaluation" do
@@ -245,7 +245,7 @@ describe Ability do
     end
 
     it 'avec une campagne qui a des évaluations' do
-      expect(subject).not_to be_able_to(:destroy, campagne_conseiller)
+      expect(subject).to be_able_to(:destroy, campagne_conseiller)
     end
 
     it { is_expected.not_to be_able_to(:manage, :all) }
@@ -281,6 +281,7 @@ describe Ability do
     it { is_expected.to be_able_to(:read, evenement_conseiller) }
     it { is_expected.to be_able_to(%i[update read], Campagne.new(compte: compte)) }
     it { is_expected.to be_able_to(:destroy, Campagne.new(compte: compte)) }
+    it { is_expected.not_to be_able_to(:destroy, campagne_superadmin) }
     it { is_expected.to be_able_to(:read, Questionnaire.new) }
     it { is_expected.to be_able_to(:read, Situation.new) }
     it { is_expected.to be_able_to(:manage, Restitution::Base.new(campagne_conseiller, nil)) }


### PR DESCRIPTION
Il ne peut supprimer que ses propres campagnes (même s'il est admin).
<img width="1296" alt="Capture d’écran 2024-04-25 à 22 02 44" src="https://github.com/betagouv/eva-serveur/assets/298214/d5031402-e850-4430-ac34-89279395a404">
