### PR TITLE
Permet aux conseillers de filtrer les campagnes par comptes

### DIFF
--- a/app/admin/campagnes.rb
+++ b/app/admin/campagnes.rb
@@ -18,8 +18,7 @@ ActiveAdmin.register Campagne do
          fields: %i[email nom prenom],
          display_name: 'display_name',
          minimum_input_length: 2,
-         order_by: 'email_asc',
-         if: proc { can? :manage, Compte }
+         order_by: 'email_asc'
   filter :situations
   filter :created_at
 

--- a/spec/features/admin/campagne_spec.rb
+++ b/spec/features/admin/campagne_spec.rb
@@ -25,9 +25,9 @@ describe 'Admin - Campagne', type: :feature do
         expect(page).not_to have_content 'Rouen 30 mars'
       end
 
-      it 'ne permet pas de filtrer par compte' do
+      it 'permet de filtrer par compte' do
         within '#filters_sidebar_section' do
-          expect(page).not_to have_content 'Compte'
+          expect(page).to have_content 'Compte'
         end
       end
     end


### PR DESCRIPTION
Cela lui est utile pour retrouver ses propres campagnes dans les structures qui ont beaucoup de conseillers.

<img width="1309" alt="Capture d’écran 2024-05-02 à 11 01 46" src="https://github.com/betagouv/eva-serveur/assets/298214/1cc734c2-a15d-4269-bfbc-38e1bc3c549d">
