### PR TITLE
Permet d'activer les tooltips "illettrisme potentiel" au clavier et lisible par les lecteurs d'écran

### DIFF
--- a/app/assets/stylesheets/admin/composants/_ellipse.scss
+++ b/app/assets/stylesheets/admin/composants/_ellipse.scss
@@ -2,34 +2,46 @@ $taille-ellipse: 1.5rem;
 $hauteur-tick: .5rem;
 $largeur-tick: .75rem;
 
+@mixin couleur-ellipse() {
+  &.ellipse--alerte {
+    background-color: $eva_orange;
+  }
+
+  &.ellipse--active {
+    background-color: $eva_light;
+  }
+
+  &.ellipse--desactive {
+    background-color: $eva_bluegrey;
+  }
+
+  &.ellipse--succes {
+    background-color: $eva_green;
+  }
+}
+
+button.ellipse {
+  &:hover {
+    @include couleur-ellipse();
+  }
+
+}
+
 .ellipse {
   width: 1rem;
   height: 1rem;
   border-radius: 50%;
   display: inline-block;
   flex-shrink: 0;
+  border: none;
+  padding: 0;
+  @include couleur-ellipse();
 
   &.ellipse-a-cocher {
     border: 1px solid $eva_dark_blue_grey;
     box-shadow: 0px 0px 8px rgba(30, 65, 106, 0.25);
     width: $taille-ellipse;
     height: $taille-ellipse;
-  }
-
-  &.ellipse--alerte {
-    background: $eva_orange;
-  }
-
-  &.ellipse--active {
-    background: $eva_light;
-  }
-
-  &.ellipse--desactive {
-    background: $eva_bluegrey;
-  }
-
-  &.ellipse--succes {
-    background: $eva_green;
   }
 }
 

--- a/app/assets/stylesheets/admin/pages/dashboard/_bloc_evaluations.scss
+++ b/app/assets/stylesheets/admin/pages/dashboard/_bloc_evaluations.scss
@@ -13,6 +13,6 @@ $largeur_nom: 10.25rem;
     }
   }
   .carte__pastille {
-    left: $largeur_nom + 2rem;
+    left: $largeur_nom + 1rem;
   }
 }

--- a/app/assets/stylesheets/admin/pages/dashboard/_bloc_evaluations.scss
+++ b/app/assets/stylesheets/admin/pages/dashboard/_bloc_evaluations.scss
@@ -1,16 +1,18 @@
+$largeur_nom: 10.25rem;
 .bloc-evaluations {
   .carte-liste {
     .col:last-child {
       flex: 2;
     }
     .carte__nom {
-      padding-right: 1rem;
-      width: 10.25rem;
+      width: $largeur_nom;
     }
-    .carte__pastille {
+    .carte__pastille-place-holder {
       margin-right: 1rem;
       width: 1rem;
-      padding-top: 6px;
     }
+  }
+  .carte__pastille {
+    left: $largeur_nom + 2rem;
   }
 }

--- a/app/components/pastille_component.html.erb
+++ b/app/components/pastille_component.html.erb
@@ -1,7 +1,11 @@
-<span class="ellipse ellipse--<%= @couleur %>"
-      data-toggle=<%= @tooltip_content ? 'tooltip' : 'none' %>
-      data-placement='right'
-      title="<%= @tooltip_content %>">
-</span>
+<% if @tooltip_content and @couleur != "" %>
+  <button type="button"
+          class="ellipse ellipse--<%= @couleur %>"
+          data-toggle='tooltip'
+          data-placement='right'
+          title="<%= @tooltip_content %>"></button>
+<% else %>
+  <span class="ellipse ellipse--<%= @couleur %>"> </span>
+<% end %>
 <%= @etiquette %>
 

--- a/app/components/pastille_component.html.erb
+++ b/app/components/pastille_component.html.erb
@@ -3,6 +3,7 @@
           class="ellipse ellipse--<%= @couleur %>"
           data-toggle='tooltip'
           data-placement='right'
+          onmousedown='event.preventDefault();'
           title="<%= @tooltip_content %>">
           <span class="sr-only"><%= @tooltip_content%></span>
   </button>

--- a/app/components/pastille_component.html.erb
+++ b/app/components/pastille_component.html.erb
@@ -3,7 +3,9 @@
           class="ellipse ellipse--<%= @couleur %>"
           data-toggle='tooltip'
           data-placement='right'
-          title="<%= @tooltip_content %>"></button>
+          title="<%= @tooltip_content %>">
+          <span class="sr-only"><%= @tooltip_content%></span>
+  </button>
 <% else %>
   <span class="ellipse ellipse--<%= @couleur %>"> </span>
 <% end %>

--- a/app/views/admin/dashboard/_bloc_evaluations.html.erb
+++ b/app/views/admin/dashboard/_bloc_evaluations.html.erb
@@ -11,22 +11,28 @@
   </div>
 
   <% evaluations.each do |evaluation| %>
-    <%= render(CarteComponent.new(admin_evaluation_path(evaluation))) do %>
-      <div class='col d-flex'>
-        <span class='carte__nom'><%= render NomAnonymisableComponent.new(evaluation) %></span>
-      </div>
+    <div class="row w-100 no-gutters d-flex align-items-center position-relative">
       <div class='col'>
-        <span class='carte__pastille'>
-          <% if evaluation.illettrisme_potentiel? %>
-            <%= render(PastilleComponent.new(tooltip_content: t('components.pastille.illettrisme_potentiel'), couleur: 'alerte')) %>
-          <% end %>
-        </span>
+        <%= render(CarteComponent.new(admin_evaluation_path(evaluation))) do %>
+          <div class='col d-flex'>
+            <span class='carte__nom'><%= render NomAnonymisableComponent.new(evaluation) %></span>
+          </div>
+          <div class='col'>
+            <span class='carte__pastille-place-holder'>
+            </span>
+          </div>
+          <div class='col d-flex justify-content-end align-items-center'>
+            <span class='carte__date'>
+              <%= l(evaluation.created_at) %>
+            </span>
+          </div>
+        <% end %>
       </div>
-      <div class='col d-flex justify-content-end align-items-center'>
-        <span class='carte__date'>
-          <%= l(evaluation.created_at) %>
-        </span>
+      <div class='col-0 position-absolute carte__pastille'>
+        <% if evaluation.illettrisme_potentiel? %>
+          <%= render(PastilleComponent.new(tooltip_content: t('components.pastille.illettrisme_potentiel'), couleur: 'alerte')) %>
+        <% end %>
       </div>
-    <% end %>
+    </div>
   <% end %>
 </div>


### PR DESCRIPTION
Dans le tableau de bord et dans la page des évaluations.

Ceci est une exigence d'accessibilité (Page 82 du rapport d'audit) : 
7.3 - Bloquant : L’élément déclencheur du tooltip ne fonctionne pas au clavier et se trouve dans le lien
7.1 - Majeur : L’élément déclencheur du tooltip n’a pas d’intitulé
10.13 - Majeur : Le tooltip ne peut être masqué sans déplacer le pointeur de la souris

Problème non corrigé : 
10.13 - Majeur : Le tooltip disparaît au survol de la souris