### PR TITLE
Supprime tous les comptes en attente de la structure de démo ANLCI

### DIFF
--- a/app/helpers/structure_helper.rb
+++ b/app/helpers/structure_helper.rb
@@ -12,4 +12,25 @@ module StructureHelper
       [traduction_type_structure(type_structure), type_structure]
     end
   end
+
+  def cree_structure_demo
+    StructureLocale.transaction do
+      StructureLocale.where(nom: Eva::STRUCTURE_DEMO).first_or_create do |s|
+        s.type_structure = :autre
+        s.code_postal = '69003'
+      end
+    end
+  end
+
+  def vide_compte(compte)
+    Campagne.with_deleted.where(compte: compte).find_each do |campagne|
+      logger.info "destruction de la campagne #{campagne.libelle}"
+      Evaluation.with_deleted.where(campagne: campagne).find_each do |evaluation|
+        b = evaluation.beneficiaire
+        evaluation.really_destroy!
+        b.really_destroy! unless Evaluation.with_deleted.exists?(beneficiaire: b)
+      end
+      campagne.really_destroy!
+    end
+  end
 end

--- a/app/jobs/nettoyage_comptes_structure_demo_job.rb
+++ b/app/jobs/nettoyage_comptes_structure_demo_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class NettoyageComptesStructureDemoJob < ApplicationJob
+  include StructureHelper
+  queue_as :default
+
+  def perform
+    logger.info 'création de la structure de démo si nécessaire'
+    structure_demo = cree_structure_demo
+
+    logger.info 'Recherche et nettoyage des comptes en attente existants'
+    Compte.where(structure: structure_demo, statut_validation: :en_attente).find_each do |compte|
+      next if compte.email == Eva::EMAIL_DEMO_EN_ATTENTE
+
+      ActiveRecord::Base.transaction { vide_compte compte }
+      compte.really_destroy!
+    end
+  end
+end

--- a/app/jobs/reinitialise_compte_demo_job.rb
+++ b/app/jobs/reinitialise_compte_demo_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ReinitialiseCompteDemoJob < ApplicationJob
+  include StructureHelper
   queue_as :default
 
   def perform
@@ -19,27 +20,6 @@ class ReinitialiseCompteDemoJob < ApplicationJob
   end
 
   private
-
-  def cree_structure_demo
-    StructureLocale.transaction do
-      StructureLocale.where(nom: Eva::STRUCTURE_DEMO).first_or_create do |s|
-        s.type_structure = :autre
-        s.code_postal = '69003'
-      end
-    end
-  end
-
-  def vide_compte(compte)
-    Campagne.with_deleted.where(compte: compte).find_each do |campagne|
-      logger.info "destruction de la campagne #{campagne.libelle}"
-      Evaluation.with_deleted.where(campagne: campagne).find_each do |evaluation|
-        b = evaluation.beneficiaire
-        evaluation.really_destroy!
-        b.really_destroy! unless Evaluation.with_deleted.exists?(beneficiaire: b)
-      end
-      campagne.really_destroy!
-    end
-  end
 
   def verifie_ou_cree_admin(structure)
     Compte.where(role: :admin, structure: structure).first_or_create do |c|

--- a/app/lib/eva.rb
+++ b/app/lib/eva.rb
@@ -6,6 +6,7 @@ module Eva
   EMAIL_SUPPORT = 'support@eva.beta.gouv.fr'
   EMAIL_DEMO = 'demo@eva.beta.gouv.fr'
   STRUCTURE_DEMO = 'Structure démo ANLCI'
+  EMAIL_DEMO_EN_ATTENTE = 'nouveau.anlci@yopmail.fr'
   LIEN_LIVESTORM = 'https://app.livestorm.co/eva-diagnostic-cptc/presentation-et-demonstration-eva-session?type=detailed'
   LIEN_DEMANDE_ACCOMPAGNEMENT_ILLETTRISME = 'https://evabetagouv.typeform.com/to/oWr4IPEq'
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -20,3 +20,8 @@
       class: ReinitialiseCompteDemoJob
       description: Efface les campagnes, évaluations et bénéficiaires du compte de démo (job exécuté chaque jour)
       enabled: true
+    nettoyage_comptes_structure_demo_job:
+      cron: '30 1 * * *'
+      class: NettoyageComptesStructureDemoJob
+      description: Efface les comptes en attente dans la structure de démo ANLCI
+      enabled: true

--- a/spec/jobs/nettoyage_comptes_structure_demo_job_spec.rb
+++ b/spec/jobs/nettoyage_comptes_structure_demo_job_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe NettoyageComptesStructureDemoJob, type: :job do
+  it "Créé la structure si elle n'existe pas" do
+    described_class.perform_now
+
+    structure = Structure.find_by(nom: Eva::STRUCTURE_DEMO)
+    expect(structure).not_to be_nil
+  end
+
+  it 'Supprime les comptes en attentes de cette structure' do
+    structure = create :structure_locale, nom: Eva::STRUCTURE_DEMO
+    create :compte_admin, structure: structure
+    compte_existant = create :compte_conseiller,
+                             structure: structure,
+                             statut_validation: :en_attente
+    campagne = create :campagne, compte: compte_existant
+    beneficiaire = create :beneficiaire, nom: 'nom'
+    create :evaluation, nom: 'eval1', campagne: campagne, beneficiaire: beneficiaire
+    create :evaluation, nom: 'eval4', campagne: campagne, beneficiaire: beneficiaire,
+                        deleted_at: Time.zone.now
+    create :evaluation, nom: 'eval2', campagne: campagne, beneficiaire: beneficiaire
+    create :evaluation, nom: 'eval3', campagne: campagne, deleted_at: Time.zone.now
+    create :campagne, libelle: 'c supprimée', compte: compte_existant, deleted_at: Time.zone.now
+
+    described_class.perform_now
+
+    comptes_en_attente = Compte.where(structure: structure, statut_validation: :en_attente)
+    expect(comptes_en_attente.with_deleted.count).to eq(0)
+    expect(Evaluation.with_deleted.count).to eq(0)
+    expect(Beneficiaire.with_deleted.count).to eq(0)
+    expect(Campagne.with_deleted.count).to eq(0)
+
+    comptes_pas_en_attente = Compte.where(structure: structure)
+                                   .where.not(statut_validation: :en_attente)
+    expect(comptes_pas_en_attente.with_deleted.count).to eq(1)
+  end
+
+  it 'Ne supprime le comptes nouveau.anlci@yopmail.fr' do
+    structure = create :structure_locale, nom: Eva::STRUCTURE_DEMO
+    create :compte_admin, structure: structure
+    create :compte_conseiller, structure: structure,
+                               email: Eva::EMAIL_DEMO_EN_ATTENTE,
+                               statut_validation: :en_attente
+
+    described_class.perform_now
+
+    comptes_en_attente = Compte.where(structure: structure, statut_validation: :en_attente)
+    expect(comptes_en_attente.with_deleted.count).to eq(1)
+  end
+end

--- a/spec/jobs/reinitialise_compte_demo_job_spec.rb
+++ b/spec/jobs/reinitialise_compte_demo_job_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe ReinitialiseCompteDemoJob, type: :job do
   it "Créé la structure et le compte de démo si rien n'existe" do
-    ReinitialiseCompteDemoJob.perform_now
+    described_class.perform_now
 
     compte_demo = Compte.find_by(email: Eva::EMAIL_DEMO)
     expect(compte_demo).not_to be_nil
@@ -14,7 +14,7 @@ describe ReinitialiseCompteDemoJob, type: :job do
   it 'Ne re-créé pas la structure si elle existe déjà' do
     structure = create :structure_locale, nom: Eva::STRUCTURE_DEMO
 
-    ReinitialiseCompteDemoJob.perform_now
+    described_class.perform_now
 
     compte_demo = Compte.find_by(email: Eva::EMAIL_DEMO)
     expect(compte_demo.structure).to eq(structure)
@@ -24,7 +24,7 @@ describe ReinitialiseCompteDemoJob, type: :job do
     structure = create :structure_locale, nom: Eva::STRUCTURE_DEMO
     create :compte_admin, structure: structure
 
-    ReinitialiseCompteDemoJob.perform_now
+    described_class.perform_now
 
     expect(Compte.where(role: :admin).count).to eq(1)
   end
@@ -33,7 +33,7 @@ describe ReinitialiseCompteDemoJob, type: :job do
     structure = create :structure_locale, nom: 'autre structure'
     create :compte_admin, structure: structure
 
-    ReinitialiseCompteDemoJob.perform_now
+    described_class.perform_now
 
     expect(Compte.where(role: :admin).count).to eq(2)
   end
@@ -51,7 +51,7 @@ describe ReinitialiseCompteDemoJob, type: :job do
     create :evaluation, nom: 'eval3', campagne: campagne, deleted_at: Time.zone.now
     create :campagne, libelle: 'c supprimée', compte: compte_existant, deleted_at: Time.zone.now
 
-    ReinitialiseCompteDemoJob.perform_now
+    described_class.perform_now
 
     compte_demo = Compte.find_by(email: Eva::EMAIL_DEMO)
     expect(compte_demo.id).to eq(compte_existant.id)


### PR DESCRIPTION
Des comptes en attente s’accumulent dans la structure démo.

Ajouter dans le nettoyage automatique quotidien pour la structure démo la suppression des comptes en attente.

https://eva.beta.gouv.fr/pro/admin/structures_locales/0679e708-408f-418a-b8f3-715b1b2cf128#bloc-membres


A l’exception de Luke Skywalker (https://eva.beta.gouv.fr/pro/admin/comptes/8d1a7584-c9e5-488d-81e2-31cb2a9b2a85) → compte utilisé en formation