### PR TITLE
Resoud une erreur rollbar

### DIFF
--- a/app/controllers/eva/devise/sessions_controller.rb
+++ b/app/controllers/eva/devise/sessions_controller.rb
@@ -41,7 +41,8 @@ module Eva
       def check_compte_confirmation
         return unless params.key?(:compte)
 
-        compte = Compte.find_by email: params[:compte][:email].strip
+        compte = Compte.find_by(email: params[:compte][:email]&.strip)
+
         return if compte.blank?
 
         redirect_to new_compte_confirmation_path unless compte.active_for_authentication?


### PR DESCRIPTION
```
NoMethodError undefined method `strip' for nil:NilClass

        compte = Compte.find_by email: params[:compte][:email].strip
```
https://app.rollbar.com/a/eva-betagouv/fix/item/eva/933?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification