### PR TITLE
Le superadmin peut consulter le score final du niveau d'un joueur

### DIFF
--- a/app/decorators/evenement_place_du_marche.rb
+++ b/app/decorators/evenement_place_du_marche.rb
@@ -2,7 +2,7 @@
 
 class EvenementPlaceDuMarche < SimpleDelegator
   PREFIX_QUESTIONS = {
-    N1P: 'N1P',
+    N1: 'N1',
     NumeratieN2: 'NumeratieN2',
     NumeratieN3: 'NumeratieN3'
   }.freeze

--- a/app/models/restitution/evacob/score_module.rb
+++ b/app/models/restitution/evacob/score_module.rb
@@ -3,11 +3,66 @@
 module Restitution
   module Evacob
     class ScoreModule
-      def calcule(evenements, nom_module)
-        evenements_filtres = MetriquesHelper.filtre_evenements_reponses(evenements) do |e|
+      NUMERATIE_METRIQUES = {
+        'N1Pse' => nil,
+        'N1Prn' => 'N1Rrn',
+        'N1Pde' => 'N1Rde',
+        'N1Pes' => 'N1Res',
+        'N1Pon' => 'N1Ron',
+        'N1Poa' => 'N1Roa',
+        'N1Pos' => 'N1Ros',
+        'N1Pvn' => nil
+      }.freeze
+
+      def calcule(evenements, nom_module, avec_rattrapage: false)
+        evenements_reponse = MetriquesHelper.filtre_evenements_reponses(evenements) do |e|
           e.module?(nom_module)
         end
-        evenements_filtres.sum(&:score_reponse) if evenements_filtres.present?
+
+        return if evenements_reponse.empty?
+
+        e_filtres = avec_rattrapage ? filtre_rattrapage(evenements_reponse) : evenements_reponse
+        e_filtres.sum(&:score_reponse)
+      end
+
+      private
+
+      def filtre_rattrapage(evenements_reponse)
+        scores_totaux = calcule_scores_totaux(evenements_reponse)
+        scores_max = recupere_score_max(scores_totaux)
+
+        scores_max.flat_map do |metrique|
+          evenements_reponse.select do |e|
+            e.donnees['question'].start_with?(metrique)
+          end
+        end
+      end
+
+      def calcule_scores_totaux(evenements_reponse)
+        scores_totaux = Hash.new(0)
+
+        NUMERATIE_METRIQUES.each do |question_initiale, rattrapage|
+          scores_totaux[question_initiale] =
+            calcule_score_total_par_metrique(evenements_reponse, question_initiale)
+          scores_totaux[rattrapage] =
+            calcule_score_total_par_metrique(evenements_reponse, rattrapage)
+        end
+
+        scores_totaux
+      end
+
+      def calcule_score_total_par_metrique(evenements_reponse, metrique)
+        return 0 unless metrique
+
+        evenements_reponse
+          .select { |e| e.donnees['question'].start_with?(metrique) }
+          .sum(&:score_reponse)
+      end
+
+      def recupere_score_max(score_totaux)
+        NUMERATIE_METRIQUES.keys.map do |question|
+          [question, NUMERATIE_METRIQUES[question]].max_by { |metrique| score_totaux[metrique] }
+        end
       end
     end
   end

--- a/app/models/restitution/place_du_marche.rb
+++ b/app/models/restitution/place_du_marche.rb
@@ -10,7 +10,7 @@ module Restitution
     end
 
     def score_niveau1
-      Evacob::ScoreModule.new.calcule(evenements, :N1P)
+      Evacob::ScoreModule.new.calcule(evenements, :N1, avec_rattrapage: true)
     end
 
     def score_niveau2

--- a/docs/tech-dive-in/EVA-166-le-superadmin-peut-consulter-le-score-final-du-niveau-dun-joueur/readme.md
+++ b/docs/tech-dive-in/EVA-166-le-superadmin-peut-consulter-le-score-final-du-niveau-dun-joueur/readme.md
@@ -1,0 +1,83 @@
+<!-- 📄 Standard : https://www.notion.so/captive/Le-cadrage-technique-dbb611e45f114737a6b14745caa584e9?pvs=4 -->
+# Le superadmin peut consulter le score final du niveau d'un joueur
+
+> [KRJ-110](https://captive-team.atlassian.net/browse/EVA-166)
+
+## Prérequis
+
+## Backend
+
+- Modifier la méthode de calcul du score final d'un niveau dans le fichier `/eva-serveur/app/models/restitution/evacob/score_module.rb`
+
+
+La méthode initial ajoute le scores de tous les évènements réponses
+
+```ruby
+  def calcule(evenements, nom_module)
+    evenements_filtres = MetriquesHelper.filtre_evenements_reponses(evenements) do |e|
+      e.module?(nom_module)
+    end
+    evenements_filtres.sum(&:score_reponse) if evenements_filtres.present?
+  end
+```
+
+On va vouloir modifier l'algo pour comparer les questions initial et les question de rattrapage correspondantes pour ne garder que les évènements dont le score total au sein d'un même module est le plus élevé
+
+```ruby
+  # Créer un mapping de correspondances pour chaque paire question initial/rattrapage
+
+  MAPPING = {
+  'N1Prn' => 'N1Rrn',
+  'N1Pde' => 'N1Rde',
+  'N1Pes' => 'N1Res',
+  'N1Pon' => 'N1Ron',
+  'N1Poa' => 'N1Roa',
+  'N1Pos' => 'N1Ros'
+  }.freeze
+
+  # Modifier la méthode initiale pour filtrer les rattrapage si il y en a
+
+  def calcule(evenements, nom_module, rattrapage = false)
+    evenements_reponse = MetriquesHelper.filtre_evenements_reponses(evenements) do |e|
+      e.module?(nom_module)
+    end
+
+    return if evenements_reponse.empty?
+
+    evenements_filtres = filtre_rattrapage(evenements_reponse) if rattrapage
+    evenements_filtres.sum(&:score_reponse)
+  end
+
+  # Ajoute une nouvelle méthode filtre_rattrapage
+
+  def filtre_rattrapage(evenements_reponse)
+    score_totaux = Hash.new(0)
+    evenements_groupes = Hash.new { |hash, key| hash[key] = [] }
+
+    # Calcul des scores pour chaque paire question/rattrapage
+    MAPPING.each do |question, rattrapage|
+      evenements_groupes[question] = evenements_reponse.select { |e| e.donnees['question'].start_with?(question) }
+      evenements_groupes[rattrapage] = evenements_reponse.select { |e| e.donnees['question'].start_with?(rattrapage) }
+      score_totaux[question] = evenements_groupes[question].sum(&:score_reponse)
+      score_totaux[rattrapage] = evenements_groupes[rattrapage].sum(&:score_reponse)
+    end
+
+    # Trouver la clé avec le score le plus élevé pour chaque paire
+    max_score_questions = MAPPING.keys.map do |question|
+      [question, MAPPING[question]].max_by { |key| score_totaux[key] }
+    end
+
+    # Filtrer les événements pour ne conserver que ceux des catégories avec le score le plus élevé
+    max_score_questions.flat_map { |key| evenements_groupes[key] }
+  end
+end
+```
+
+Ajouter la paramètre rattrapage true pour place du marche
+
+```ruby
+    def score_niveau1
+      Evacob::ScoreModule.new.calcule(evenements, :N1P, rattrapage = true)
+    end
+```
+

--- a/spec/models/restitution/evacob/score_module_spec.rb
+++ b/spec/models/restitution/evacob/score_module_spec.rb
@@ -53,4 +53,68 @@ describe Restitution::Evacob::ScoreModule do
       it { expect(metrique_score_reponse_orientation).to eq(nil) }
     end
   end
+
+  describe 'metrique score_numeratie' do
+    let(:metrique_score_reponse_numeratie) do
+      described_class.new.calcule(evenements_decores(evenements, :place_du_marche), :N1,
+                                  avec_rattrapage: true)
+    end
+    let(:question_initiale1) { 'N1Pes1' }
+    let(:question_rattrapage1) { 'N1Res1' }
+    let(:question_initiale2) { 'N1Pes2' }
+    let(:question_rattrapage2) { 'N1Res2' }
+
+    context 'sans réponses au rattapage' do
+      let(:evenements_reponses) do
+        [build(:evenement_reponse, donnees: { question: question_initiale1, score: 1 })]
+      end
+
+      it do
+        expect(metrique_score_reponse_numeratie).to eq(1)
+      end
+    end
+
+    context 'avec réponses au rattapage' do
+      context 'lorsque le score total du rattrapage est meilleur' do
+        let(:evenements_reponses) do
+          [
+            build(:evenement_reponse, donnees: { question: question_initiale1, score: 1 }),
+            build(:evenement_reponse, donnees: { question: question_initiale2, score: 0 }),
+            build(:evenement_reponse, donnees: { question: question_rattrapage1, score: 1 }),
+            build(:evenement_reponse, donnees: { question: question_rattrapage2, score: 1 })
+          ]
+        end
+
+        it do
+          expect(metrique_score_reponse_numeratie).to eq(2)
+        end
+      end
+
+      context 'lorsque le score total initial est meilleur' do
+        let(:evenements_reponses) do
+          [
+            build(:evenement_reponse, donnees: { question: question_initiale1, score: 1 }),
+            build(:evenement_reponse, donnees: { question: question_initiale2, score: 1 }),
+            build(:evenement_reponse, donnees: { question: question_rattrapage1, score: 0 }),
+            build(:evenement_reponse, donnees: { question: question_rattrapage2, score: 1 })
+          ]
+        end
+
+        it do
+          expect(metrique_score_reponse_numeratie).to eq(2)
+        end
+      end
+    end
+  end
+
+  context 'sans evenements réponses' do
+    let(:metrique_score) do
+      described_class.new.calcule(evenements_decores(evenements, :place_du_marche), :N1)
+    end
+    let(:evenements_reponses) { [] }
+
+    it 'retourne nil' do
+      expect(metrique_score).to eq(nil)
+    end
+  end
 end

--- a/spec/models/restitution/place_du_marche_spec.rb
+++ b/spec/models/restitution/place_du_marche_spec.rb
@@ -15,7 +15,7 @@ describe Restitution::PlaceDuMarche do
                                                     donnees: { question: 'question' }),
                           build(:evenement_reponse,
                                 donnees: { succes: true,
-                                           question: 'N1PQ2',
+                                           question: 'N1Prn1',
                                            score: 1 },
                                 partie: partie),
                           build(:evenement_reponse,
@@ -43,8 +43,70 @@ describe Restitution::PlaceDuMarche do
   end
 
   describe '#score_niveau1' do
-    it 'retourne le score du niveau 1' do
-      expect(restitution.score_niveau1).to eq 1
+    context 'sans rattrapage' do
+      let(:restitution) do
+        described_class.new(campagne,
+                            [
+                              build(:evenement_demarrage, partie: partie),
+                              build(:evenement_reponse,
+                                    donnees: { succes: true,
+                                               question: 'N1Pse1',
+                                               score: 1 },
+                                    partie: partie),
+                              build(:evenement_reponse,
+                                    donnees: { succes: true,
+                                               question: 'N1Pvn1',
+                                               score: 1 },
+                                    partie: partie),
+                              build(:evenement_reponse,
+                                    donnees: { succes: true,
+                                               question: 'N1Prn1',
+                                               score: 1 },
+                                    partie: partie),
+                              build(:evenement_reponse,
+                                    donnees: { succes: true,
+                                               question: 'N2',
+                                               score: 0.5 },
+                                    partie: partie)
+                            ])
+      end
+
+      it 'retourne le score du niveau 1' do
+        expect(restitution.score_niveau1).to eq 3
+      end
+    end
+
+    context 'avec du rattrapage' do
+      let(:restitution) do
+        described_class.new(campagne,
+                            [
+                              build(:evenement_demarrage, partie: partie),
+                              build(:evenement_reponse, donnees: { succes: true,
+                                                                   question: 'N1Pse1',
+                                                                   score: 1 },
+                                                        partie: partie),
+                              build(:evenement_reponse, donnees: { succes: true,
+                                                                   question: 'N1Pvn1',
+                                                                   score: 1 },
+                                                        partie: partie),
+                              build(:evenement_reponse, donnees: { succes: true,
+                                                                   question: 'N1Prn1',
+                                                                   score: 1 },
+                                                        partie: partie),
+                              build(:evenement_reponse, donnees: { succes: true,
+                                                                   question: 'N1Rrn1',
+                                                                   score: 2 },
+                                                        partie: partie),
+                              build(:evenement_reponse, donnees: { succes: true,
+                                                                   question: 'N2',
+                                                                   score: 0.5 },
+                                                        partie: partie)
+                            ])
+      end
+
+      it 'retourne le score du niveau 1' do
+        expect(restitution.score_niveau1).to eq 4
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require_relative '../app/decorators/evenement_securite'
 require_relative '../app/decorators/evenement_livraison'
 require_relative '../app/decorators/evenement_objets_trouves'
 require_relative '../app/decorators/evenement_evacob'
+require_relative '../app/decorators/evenement_place_du_marche'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
@@ -48,7 +49,8 @@ RSpec.configure do |config|
     securite: EvenementSecurite,
     livraison: EvenementLivraison,
     objets_trouves: EvenementObjetsTrouves,
-    evacob: EvenementEvacob
+    evacob: EvenementEvacob,
+    place_du_marche: EvenementPlaceDuMarche
   }.freeze
 
   def se_connecter_comme_superadmin


### PR DESCRIPTION
## Résultat du score total d'une évaluation place du marché

<img width="385" alt="Capture d’écran 2024-07-16 à 18 49 48" src="https://github.com/user-attachments/assets/f23ff1b4-8174-4215-9537-edb29cbc9c3c">

## Liste des évènements réponses associés avec scores

<img width="749" alt="Capture d’écran 2024-07-16 à 19 00 21" src="https://github.com/user-attachments/assets/20387666-d8ec-45c0-8f1d-3ad69106bb28">

En jaune, les scores qu'on garde pour calculer le score total car répond à l'une des 3 conditions suivantes :
- score d'un module pour lequel aucun rattrapage n'est disponible de base (ex: N1Pse et N1Pvn)
- score d'un module initial pour lequel le rattrapage n'a pas été passé car taux de réussite > 100% (ex: N1Pde)
- score d'un module dont la valeur totale > à la valeur du module correspondant (ex: N1Pon et N1Ron)


