### PR TITLE
🐛 API evaluation horligne : enregistre les évaluations dans un job

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Contenu:
       "session_id":"54af3010-315c-4755-b268-08c4bf520f64",
       "situation":"bienvenue",
       "nom":"reponse",
-      "donnees": { 
+      "donnees": {
         "question":"f728be21-6f19-4901-ba07-0ac26ad702d7",
         "reponse":"5f5ce41c-a2f0-4512-b266-39a4945dbeba"
       },

--- a/app/controllers/api/evaluations/collections_evenements_controller.rb
+++ b/app/controllers/api/evaluations/collections_evenements_controller.rb
@@ -4,7 +4,6 @@ module Api
   module Evaluations
     class CollectionsEvenementsController < Api::BaseController
       def create
-        # params.permit(evenements: [:date, :donnees, :nom, :position, :session_id, :situation])
         if Evaluation.exists?(permit_params[:evaluation_id])
           PersisteCollectionEvenementsJob.perform_later(
             permit_params[:evaluation_id],
@@ -29,13 +28,6 @@ module Api
                                            :situation,
                                            { donnees: {} }
                                          ])
-      end
-
-      def cree_evenements(evaluation_id, evenements)
-        evenements.each do |parametres|
-          parametres.merge!(evaluation_id: evaluation_id)
-          FabriqueEvenement.new(parametres).call
-        end
       end
     end
   end

--- a/app/controllers/api/evenements_controller.rb
+++ b/app/controllers/api/evenements_controller.rb
@@ -3,12 +3,26 @@
 module Api
   class EvenementsController < Api::BaseController
     def create
-      evenement = FabriqueEvenement.new(params).call
+      evenement = FabriqueEvenement.new(permit_params).call
       if evenement.persisted?
         render json: evenement, status: :created
       else
         render json: evenement.errors.full_messages, status: :unprocessable_entity
       end
+    end
+
+    private
+
+    def permit_params
+      @permit_params ||= params.permit(
+        :date,
+        :nom,
+        :session_id,
+        :position,
+        :situation,
+        :evaluation_id,
+        { donnees: {} }
+      )
     end
   end
 end

--- a/app/controllers/api/evenements_controller.rb
+++ b/app/controllers/api/evenements_controller.rb
@@ -3,11 +3,11 @@
 module Api
   class EvenementsController < Api::BaseController
     def create
-      @evenement = FabriqueEvenement.new(params).call
-      if @evenement.persisted?
-        render json: @evenement, status: :created
+      evenement = FabriqueEvenement.new(params).call
+      if evenement.persisted?
+        render json: evenement, status: :created
       else
-        render json: @evenement.errors.full_messages, status: :unprocessable_entity
+        render json: evenement.errors.full_messages, status: :unprocessable_entity
       end
     end
   end

--- a/app/jobs/persiste_collection_evenements_job.rb
+++ b/app/jobs/persiste_collection_evenements_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class PersisteCollectionEvenementsJob < ApplicationJob
+  queue_as :default
+
+  def perform(evaluation_id, evenements)
+    evenements.each do |parametres|
+      parametres.merge!(evaluation_id: evaluation_id)
+      FabriqueEvenement.new(parametres).call
+    end
+  end
+end

--- a/app/params/evenement_params.rb
+++ b/app/params/evenement_params.rb
@@ -3,15 +3,11 @@
 class EvenementParams
   class << self
     def from(params)
-      permitted = params.permit(
-        :date,
-        :nom,
-        :session_id,
-        :position,
-        donnees: {}
-      )
-      formate!(permitted)
-      permitted
+      evenement_params = params.clone
+      evenement_params.delete(:situation)
+      evenement_params.delete(:evaluation_id)
+      formate!(evenement_params)
+      evenement_params
     end
 
     private
@@ -21,10 +17,10 @@ class EvenementParams
     end
 
     def formate_date!(params)
-      date = params['date']
+      date = params[:date]
       return if date.blank?
 
-      params['date'] = Time.strptime(date.to_s, '%Q')
+      params[:date] = Time.strptime(date.to_s, '%Q')
     end
   end
 end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -8,6 +8,7 @@ fr:
         supprimer: Supprimer
         modifier: Modifier
         voir: Voir
+      inconnue: 'Évaluation non trouvée'
       commun: &commun
         efficience: Efficience
         nombre_erreurs: "Nombre d'erreurs"

--- a/spec/models/fabrique_evenement_spec.rb
+++ b/spec/models/fabrique_evenement_spec.rb
@@ -10,7 +10,7 @@ describe FabriqueEvenement do
   let(:evaluation) { create :evaluation }
   let(:nom_evenement) { 'finSituation' }
   let(:parametres) do
-    ActionController::Parameters.new(
+    {
       date: 1_631_891_703_815,
       donnees: {},
       nom: nom_evenement,
@@ -18,7 +18,7 @@ describe FabriqueEvenement do
       session_id: '184e1079-3bb9-4229-921e-4c2574d94934',
       situation: situation_livraison.nom_technique,
       evaluation_id: evaluation.id
-    )
+    }
   end
 
   describe '#call' do
@@ -75,7 +75,7 @@ describe FabriqueEvenement do
 
     context "quand l'id de l'évaluation est invalide" do
       let(:parametres_invalide) do
-        ActionController::Parameters.new(
+        {
           date: 1_631_891_703_815,
           donnees: {},
           nom: 'finSituation',
@@ -83,7 +83,7 @@ describe FabriqueEvenement do
           session_id: '184e1079-3bb9-4229-921e-4c2574d94934',
           situation: situation_livraison.nom_technique,
           evaluation_id: nil
-        )
+        }
       end
 
       it 'ne crée rien' do
@@ -98,14 +98,14 @@ describe FabriqueEvenement do
 
     context "quand la création de l'évènement échoue" do
       let(:parametres_invalide) do
-        ActionController::Parameters.new(
+        {
           date: nil,
           nom: 'finSituation',
           situation: 'livraison',
           session_id: 'O8j78U2xcb2',
           donnees: donnees,
           evaluation_id: evaluation.id
-        )
+        }
       end
 
       it 'la partie est quand même créée' do

--- a/spec/params/evenement_params_spec.rb
+++ b/spec/params/evenement_params_spec.rb
@@ -12,7 +12,8 @@ describe EvenementParams do
         date: 1_580_743_539_508,
         donnees: {},
         session_id: 'ma session id',
-        autre_param: 'autre paramètre'
+        situation: 'autre paramètre',
+        evaluation_id: 'id'
       )
 
       evenement_params = described_class.from(params)

--- a/spec/requests/evaluations/collections_evenements_spec.rb
+++ b/spec/requests/evaluations/collections_evenements_spec.rb
@@ -9,7 +9,6 @@ describe 'API Collections Evenements', type: :request do
     let(:evenement1) do
       {
         date: 1_631_719_609_975,
-        donnees: {},
         nom: 'demarrage',
         position: 0,
         session_id: 'abbd368d-dc2d-49a4-ae8a-face8fefbc90',
@@ -19,31 +18,36 @@ describe 'API Collections Evenements', type: :request do
     let(:evenement2) do
       {
         date: 1_631_891_672_641,
-        donnees: { contenant: '16' },
         nom: 'ouvertureContenant',
         position: 1,
         session_id: 'abbd368d-dc2d-49a4-ae8a-face8fefbc90',
-        situation: situation_inventaire.nom_technique
+        situation: situation_inventaire.nom_technique,
+        donnees: { contenant: '16' }
       }
     end
     let(:evenement3) do
       {
         date: 1_631_891_703_815,
-        donnees: {},
         nom: 'finSituation',
-        position: 0,
-        session_id: '184e1079-3bb9-4229-921e-4c2574d94934',
+        position: 2,
+        session_id: 'abbd368d-dc2d-49a4-ae8a-face8fefbc90',
         situation: situation_livraison.nom_technique
       }
     end
     let(:donnees_evenements) do
       { evenements: [evenement1, evenement2, evenement3] }
     end
+    let(:donnees_evenements_transmises) do
+      donnees_evenements[:evenements].map(&:to_json).map { |s| JSON.parse(s) }.map do |e|
+        e.transform_values { |value| value.is_a?(Hash) ? value : value.to_s }
+      end
+    end
 
     context 'avec une évaluation inexistante' do
       it do
         post '/api/evaluations/evaluation_inconnue/collections_evenements',
              params: donnees_evenements
+        expect(response.body).to eq '{"message":"Évaluation non trouvée"}'
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
@@ -52,8 +56,13 @@ describe 'API Collections Evenements', type: :request do
       let(:evaluation) { create :evaluation }
 
       it do
-        post "/api/evaluations/#{evaluation.id}/collections_evenements",
-             params: donnees_evenements
+        expect do
+          post "/api/evaluations/#{evaluation.id}/collections_evenements",
+               params: donnees_evenements
+        end
+          .to have_enqueued_job(PersisteCollectionEvenementsJob)
+          .with(evaluation.id, donnees_evenements_transmises)
+          .exactly(1)
         expect(response).to have_http_status(:created)
       end
     end

--- a/spec/requests/evenements_spec.rb
+++ b/spec/requests/evenements_spec.rb
@@ -14,7 +14,7 @@ describe 'Evenement API', type: :request do
         date: 1_551_111_089_238,
         nom: 'ouvertureContenant',
         donnees: donnees,
-        situation: 'inventaire',
+        situation: situation_inventaire.nom_technique,
         position: 58,
         session_id: 'O8j78U2xcb2',
         evaluation_id: evaluation.id
@@ -25,7 +25,7 @@ describe 'Evenement API', type: :request do
       {
         date: nil,
         nom: 'ouvertureContenant',
-        situation: 'inventaire',
+        situation: situation_inventaire.nom_technique,
         session_id: 'O8j78U2xcb2',
         donnees: donnees,
         evaluation_id: evaluation.id


### PR DESCRIPTION
## ❌ Comportement observé

L’API `collections_evenements` attend d’avoir enregistré tous les événements avant de répondre OK au client, mais cela peut prendre plus d’une minute.

Le client reçoit alors une erreur “Timeout” et réessaye. Cela a pour conséquence de bombarder le serveur avec des demandes qui prennent du temps alors que c’est inutile, puisque l’enregistrement c'est en réalité bien passé finalement.

## ✅ Comportement voulu

Effectuer l’enregistrement dans un job et retourner aussi tôt une réponse OK au client.