### PR TITLE
Fais fonctionner la lecture des audios en preprod

### DIFF
--- a/app/helpers/active_admin/views_helper.rb
+++ b/app/helpers/active_admin/views_helper.rb
@@ -6,5 +6,6 @@ module ActiveAdmin
     include EvaluationHelper
     include ErreurHelper
     include PriseEnMainHelper
+    include TranscriptionHelper
   end
 end

--- a/app/helpers/transcription_helper.rb
+++ b/app/helpers/transcription_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module TranscriptionHelper
+  def tag_audio(transcription)
+    return if transcription.nil? || !transcription.audio.attached?
+
+    audio_tag cdn_for(transcription.audio), controls: true
+  end
+end

--- a/app/views/admin/question_qcms/_show.html.arb
+++ b/app/views/admin/question_qcms/_show.html.arb
@@ -12,14 +12,14 @@ panel 'Détails de la question' do
       div intitule.ecrit if intitule&.ecrit
     end
     row :audio_intitule do
-      audio_tag(url_for(intitule.audio), controls: true) if intitule&.audio&.attached?
+      tag_audio(intitule)
     end
     consigne = question_qcm.transcription_pour(:modalite_reponse)
     row :consigne do
       div consigne.ecrit if consigne&.ecrit
     end
     row :audio_consigne do
-      audio_tag(url_for(consigne.audio), controls: true) if consigne&.audio&.attached?
+      tag_audio(consigne)
     end
     row :metacompetence
     row :type_qcm
@@ -32,7 +32,7 @@ panel 'Choix' do
     column :intitule
     column :type_choix
     column :audio do |transcription|
-      audio_tag(url_for(transcription.audio), controls: true) if transcription.audio.attached?
+      tag_audio(transcription)
     end
   end
 end


### PR DESCRIPTION
Il semble que les assets ne soient pas accessibles en preprod. J'ai repris le même fonctionnement qu'on a utilisé pour les illustrations.