### PR TITLE
Reduire la liste des droits de la configuration rack-cors pour reveni…

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -11,7 +11,6 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource '*',
       headers: :any,
-      methods: [:get, :post, :put, :patch, :delete, :options, :head],
-      expose: ['X-Total-Count']
+      methods: [:get, :post, :patch]
   end
 end


### PR DESCRIPTION
…r à la configuration initiale

La configuration presente initialement à la racine config/application.rb a été isolé dans un initializer pour respecter le standard de la gem rack-cors