### PR TITLE
🐛  Corrige la restitution des question-saisie sans choix

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -34,6 +34,10 @@ class Question < ApplicationRecord
     transcriptions.find_by(categorie: categorie)
   end
 
+  def restitue_reponse(reponse)
+    reponse
+  end
+
   private
 
   def reject_transcriptions(attributes)

--- a/app/models/question_qcm.rb
+++ b/app/models/question_qcm.rb
@@ -10,6 +10,10 @@ class QuestionQcm < Question
 
   accepts_nested_attributes_for :choix, allow_destroy: true
 
+  def restitue_reponse(reponse)
+    choix.find { |c| c.nom_technique == reponse }.intitule
+  end
+
   def as_json(_options = nil)
     intitule = Transcription.find_by(categorie: :intitule, question_id: id)
     modalite = Transcription.find_by(categorie: :modalite_reponse, question_id: id)

--- a/app/views/admin/evaluations/_donnees_sociodemographiques.arb
+++ b/app/views/admin/evaluations/_donnees_sociodemographiques.arb
@@ -7,12 +7,10 @@ h2 t(".#{categorie}"), class: 'categorie'
 bienvenue.questionnaires_questions_pour(categorie).each do |config|
   div config.question.transcription_ecrite_pour(:intitule)
   reponse = donnee_sociodemographique&.read_attribute(config.question.nom_technique)
-  if reponse.present?
-    if config.question.respond_to? :choix
-      reponse = config.question.choix.find { |c| c.nom_technique == reponse }.intitule
-    end
-  else
-    reponse = t('admin.evaluations.autopositionnement.non_renseigne')
-  end
+  reponse = if reponse.present?
+              config.question.restitue_reponse(reponse)
+            else
+              t('admin.evaluations.autopositionnement.non_renseigne')
+            end
   div reponse, class: 'reponse'
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -2,11 +2,49 @@
 
 require 'rails_helper'
 
-RSpec.describe Question, type: :model do
+describe Question, type: :model do
   it { is_expected.to validate_presence_of :libelle }
   it { is_expected.to validate_presence_of :nom_technique }
   it { is_expected.to validate_uniqueness_of :nom_technique }
   it { is_expected.to have_many(:transcriptions).dependent(:destroy) }
   it { is_expected.to accept_nested_attributes_for(:transcriptions).allow_destroy(true) }
   it { is_expected.to have_one_attached(:illustration) }
+
+  describe '#restitue_reponse' do
+    context "quand la question saisie n'a pas de choix" do
+      let(:question) { create :question_saisie }
+
+      it 'retourne la réponse' do
+        expect(question.restitue_reponse('35')).to eq '35'
+      end
+    end
+
+    context 'quand la question saisie a un choix' do
+      let(:choix1) do
+        create :choix,
+               :bon,
+               nom_technique: 'choix_1',
+               intitule: 'intitule'
+      end
+      let(:question) { create :question_saisie, choix: choix1 }
+
+      it 'retourne la réponse' do
+        expect(question.restitue_reponse('35')).to eq '35'
+      end
+    end
+
+    context "quand la reponse est un des choix d'un qcm" do
+      let(:choix1) do
+        create :choix,
+               :bon,
+               nom_technique: 'choix_1',
+               intitule: 'intitule'
+      end
+      let(:question) { create :question_qcm, choix: [choix1] }
+
+      it "retourne l'intitulé de la réponse" do
+        expect(question.reload.restitue_reponse('choix_1')).to eq 'intitule'
+      end
+    end
+  end
 end


### PR DESCRIPTION
❌ Comportement observé
Sur la préprod, l'évaluation `337108d9-56c7-4a99-af52-2cb19aa0b22a` fait une erreur 500 quand on essaie de la consulter. L'erreur surgit quand on essaie de restituer la réponse à la question Age de bienvenue.

✅ Comportement voulu
Afficher la restitution de l'age et les libellés des réponses aux QCM de bienvenue.