### PR TITLE
🐛 Corrige le nom du bouton de la fenêtre d'inscription

### DIFF
--- a/app/views/active_admin/devise/registrations/new.html.erb
+++ b/app/views/active_admin/devise/registrations/new.html.erb
@@ -35,7 +35,7 @@
         <%= f.input :cgu_acceptees, label: t('creation_compte.cgu_acceptees'), required: true %>
       <% end %>
       <%= f.actions do
-        f.action :submit, label: t('active_admin.devise.login.submit'), button_html: { value: t('active_admin.devise.sign_up.submit'), wrapper_html: { class: 'd-flex justify-content-end' } }
+        f.action :submit, label: t('active_admin.devise.sign_up.submit'), wrapper_html: { class: 'd-flex justify-content-end' }
       end %>
     <% end %>
   </div>


### PR DESCRIPTION
Au moment où l'on valide le formulaire, ActiveAdmin désactive le bouton pour éviter le spam click.
Quand le bouton passe dans cet état, il change de label pour la valeur de l'attribut `data-disable-with`

Ce commit corrige la valeur inscrite dans cet attribut qui était « Se connecter » au lieu de « S'inscrire ».

Vidéo du bug : 
![bug_bouton_inscrire](https://github.com/user-attachments/assets/9ab43c2f-448d-4332-8fe9-13d28997fe53)

