### PR TITLE
Permet la re-création d'une question effacée avec le même nom technique

### DIFF
--- a/db/migrate/20240830024241_update_index_on_questions_nom_technique.rb
+++ b/db/migrate/20240830024241_update_index_on_questions_nom_technique.rb
@@ -1,0 +1,7 @@
+class UpdateIndexOnQuestionsNomTechnique < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :questions, :nom_technique
+
+    add_index :questions, :nom_technique, unique: true, where: "deleted_at IS NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_14_154218) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_30_024241) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -306,7 +306,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_14_154218) do
     t.string "categorie"
     t.index ["deleted_at"], name: "index_questions_on_deleted_at"
     t.index ["libelle"], name: "index_questions_on_libelle"
-    t.index ["nom_technique"], name: "index_questions_on_nom_technique", unique: true
+    t.index ["nom_technique"], name: "index_questions_on_nom_technique", unique: true, where: "(deleted_at IS NULL)"
   end
 
   create_table "questions_frequentes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
Suite à l'erreur 500 lorsqu'on tente de recréer une question effacée avec le même nom technique :
https://app.rollbar.com/a/eva-betagouv/fix/item/eva/958?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification

```
ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_questions_on_nom_technique"
DETAIL:  Key (nom_technique)=(clic) already exists.
```