### PR TITLE
🐛 Corrige erreur 500 Quand l'intitulé ou la modalité d'une question est vide

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -45,6 +45,17 @@ class Question < ApplicationRecord
     end
   end
 
+  def json_audio_fields
+    return {} if sans_audios?
+    return { 'audio_url' => transcription_intitule.audio_url } if transcription_intitule&.complete?
+    if modalite_complete_sans_audio_intitule?
+      return { 'audio_url' => transcription_modalite_reponse.audio_url }
+    end
+
+    { 'audio_url' => transcription_modalite_reponse&.audio_url,
+      'intitule_audio' => transcription_intitule&.audio_url }
+  end
+
   private
 
   def reject_transcriptions(attributes)
@@ -59,5 +70,13 @@ class Question < ApplicationRecord
 
   def supprime_illustration?
     illustration.attached? && supprimer_illustration == '1'
+  end
+
+  def sans_audios?
+    transcription_intitule&.audio_url.blank? && transcription_modalite_reponse&.audio_url.blank?
+  end
+
+  def modalite_complete_sans_audio_intitule?
+    transcription_intitule&.audio_url.blank? && transcription_modalite_reponse&.complete?
   end
 end

--- a/app/models/question_clic_dans_image.rb
+++ b/app/models/question_clic_dans_image.rb
@@ -12,13 +12,13 @@ class QuestionClicDansImage < Question
   after_update :supprime_zone_cliquable
 
   def as_json(_options = nil)
-    json = base_json_object
-    json.merge!(additional_json_fields(transcription_intitule, transcription_modalite_reponse))
+    json = base_json
+    json.merge!(json_audio_fields, additional_json_fields)
   end
 
   private
 
-  def base_json_object
+  def base_json
     slice(:id, :nom_technique).tap do |json|
       json['type'] = 'clic-dans-image'
       json['illustration'] = cdn_for(illustration) if illustration.attached?
@@ -27,20 +27,9 @@ class QuestionClicDansImage < Question
     end
   end
 
-  def additional_json_fields(intitule, modalite)
-    fields = { 'intitule' => intitule&.ecrit,
-               'modalite_reponse' => modalite&.ecrit,
-               'audio_url' => question_audio_principal(intitule, modalite) }
-    fields['intitule_audio'] = intitule&.audio_url if intitule&.ecrit.blank? && intitule&.audio_url
-    fields
-  end
-
-  def question_audio_principal(intitule, modalite)
-    if intitule&.ecrit.present? && intitule.audio.attached?
-      intitule.audio_url
-    elsif modalite&.ecrit.present? && modalite.audio.attached?
-      modalite.audio_url
-    end
+  def additional_json_fields
+    { 'intitule' => transcription_intitule&.ecrit,
+      'modalite_reponse' => transcription_modalite_reponse&.ecrit }
   end
 
   def supprime_zone_cliquable

--- a/app/models/question_glisser_deposer.rb
+++ b/app/models/question_glisser_deposer.rb
@@ -9,7 +9,7 @@ class QuestionGlisserDeposer < Question
 
   def as_json(_options = nil)
     json = base_json
-    json.merge!(audio_fields, reponses_fields)
+    json.merge!(json_audio_fields, reponses_fields)
   end
 
   private
@@ -21,17 +21,6 @@ class QuestionGlisserDeposer < Question
       json['modalite_reponse'] = transcription_modalite_reponse&.ecrit
       json['intitule'] = transcription_intitule&.ecrit
     end
-  end
-
-  def audio_fields
-    return { 'audio_url' => transcription_intitule.audio_url } if transcription_intitule&.complete?
-
-    if transcription_modalite_reponse&.complete?
-      return { 'audio_url' => transcription_modalite_reponse.audio_url,
-               'intitule_url' => transcription_intitule&.audio_url }
-    end
-
-    {}
   end
 
   def reponses_fields

--- a/app/models/question_saisie.rb
+++ b/app/models/question_saisie.rb
@@ -8,13 +8,13 @@ class QuestionSaisie < Question
   accepts_nested_attributes_for :bonne_reponse, allow_destroy: true
 
   def as_json(_options = nil)
-    json = base_json_object
-    json.merge!(additional_json_fields(transcription_intitule, transcription_modalite_reponse))
+    json = base_json
+    json.merge!(json_audio_fields, additional_json_fields)
   end
 
   private
 
-  def base_json_object
+  def base_json
     slice(:id, :nom_technique, :suffix_reponse, :description,
           :illustration).tap do |json|
       json['type'] = 'saisie'
@@ -25,24 +25,13 @@ class QuestionSaisie < Question
     end
   end
 
-  def additional_json_fields(intitule, modalite)
-    if bonne_reponse.present?
+  def additional_json_fields
+    if bonne_reponse
       reponse = { 'textes' => bonne_reponse.intitule,
                   'bonneReponse' => bonne_reponse.type_choix == 'bon' }
     end
-    fields = { 'intitule' => intitule&.ecrit,
-               'modalite_reponse' => modalite&.ecrit,
-               'audio_url' => question_audio_principal(intitule, modalite),
-               'reponse' => reponse }
-    fields['intitule_audio'] = intitule&.audio_url if intitule&.audio_url && intitule&.ecrit.blank?
-    fields
-  end
-
-  def question_audio_principal(intitule, modalite)
-    if intitule&.ecrit.present? && intitule.audio.attached?
-      intitule.audio_url
-    elsif modalite&.ecrit.present? && modalite.audio.attached?
-      modalite.audio_url
-    end
+    { 'intitule' => transcription_intitule&.ecrit,
+      'modalite_reponse' => transcription_modalite_reponse&.ecrit,
+      'reponse' => reponse }
   end
 end

--- a/app/models/transcription.rb
+++ b/app/models/transcription.rb
@@ -17,6 +17,8 @@ class Transcription < ApplicationRecord
   end
 
   def audio_url
+    return unless audio.attached?
+
     cdn_for(audio)
   end
 

--- a/spec/models/question_clic_dans_image_spec.rb
+++ b/spec/models/question_clic_dans_image_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe QuestionClicDansImage, type: :model do
+describe QuestionClicDansImage, type: :model do
   it { is_expected.to have_one_attached(:zone_cliquable) }
 
   describe '#as_json' do
@@ -39,26 +39,6 @@ RSpec.describe QuestionClicDansImage, type: :model do
                                        ))
       expect(json['modalite_reponse']).to eql(modalite.ecrit)
       expect(json['zone_cliquable']).to start_with('data:image/svg+xml;base64,')
-    end
-
-    context "quand il n'y a pas d'intitulé écrit" do
-      let!(:intitule) do
-        create(:transcription, :avec_audio, question_id: question_clic_dans_image.id, ecrit: '')
-      end
-
-      it "retourne l'audio de la modalité de réponse comme audio de la question" do
-        json = question_clic_dans_image.as_json
-        expect(json['audio_url']).to eql(Rails.application.routes.url_helpers.url_for(
-                                           modalite.audio
-                                         ))
-      end
-
-      it "retourne l'audio de l'intitulé comme audio secondaire" do
-        json = question_clic_dans_image.as_json
-        expect(json['intitule_audio']).to eql(Rails.application.routes.url_helpers.url_for(
-                                                intitule.audio
-                                              ))
-      end
     end
   end
 

--- a/spec/models/question_glisser_deposer_spec.rb
+++ b/spec/models/question_glisser_deposer_spec.rb
@@ -25,7 +25,7 @@ describe QuestionGlisserDeposer, type: :model do
     it 'serialise les champs' do
       expect(json.keys).to match_array(%w[id intitule audio_url nom_technique
                                           description illustration modalite_reponse type
-                                          reponsesNonClassees intitule_url])
+                                          reponsesNonClassees])
       expect(json['type']).to eql('glisser-deposer-billets')
       expect(json['modalite_reponse']).to eql(modalite.ecrit)
       expect(json['illustration']).to eql(Rails.application.routes.url_helpers.url_for(
@@ -39,50 +39,6 @@ describe QuestionGlisserDeposer, type: :model do
         expect(json['reponsesNonClassees'].first['illustration']).to_not be(nil)
         expect(json['reponsesNonClassees'].first['position']).to eql(1)
         expect(json['reponsesNonClassees'].first['position_client']).to eql(2)
-      end
-    end
-  end
-
-  describe 'les audios' do
-    context 'quand il y a une modalité de réponse compléte' do
-      context 'avec un intitulé complet' do
-        let!(:intitule) do
-          create(:transcription, :avec_audio, question_id: question.id,
-                                              ecrit: 'Mon Intitulé')
-        end
-        it do
-          expect(json['audio_url']).to eql(Rails.application.routes.url_helpers.url_for(
-                                             intitule.audio
-                                           ))
-          expect(json['intitule']).to eql('Mon Intitulé')
-          expect(json['intitule_url']).to eql(nil)
-        end
-      end
-
-      context 'sans intitulé' do
-        it do
-          expect(json['audio_url']).to eql(Rails.application.routes.url_helpers.url_for(
-                                             modalite.audio
-                                           ))
-          expect(json['intitule']).to eql(nil)
-          expect(json['intitule_url']).to eql(nil)
-        end
-      end
-
-      context 'avec un intitulé incomplet' do
-        let!(:intitule) do
-          create(:transcription, :avec_audio, question_id: question.id,
-                                              ecrit: nil)
-        end
-        it do
-          expect(json['audio_url']).to eql(Rails.application.routes.url_helpers.url_for(
-                                             modalite.audio
-                                           ))
-          expect(json['intitule']).to eql(nil)
-          expect(json['intitule_url']).to eql(Rails.application.routes.url_helpers.url_for(
-                                                intitule.audio
-                                              ))
-        end
       end
     end
   end

--- a/spec/models/question_qcm_spec.rb
+++ b/spec/models/question_qcm_spec.rb
@@ -40,25 +40,5 @@ RSpec.describe QuestionQcm, type: :model do
                                                    ))
       expect(json['modalite_reponse']).to eql(modalite.ecrit)
     end
-
-    context "quand il n'y a pas d'intitulé écrit" do
-      let!(:intitule) do
-        create(:transcription, :avec_audio, question_id: question_qcm.id, ecrit: '')
-      end
-
-      it "retourne l'audio de la modalité de réponse comme audio de la question" do
-        json = question_qcm.as_json
-        expect(json['audio_url']).to eql(Rails.application.routes.url_helpers.url_for(
-                                           modalite.audio
-                                         ))
-      end
-
-      it "retourne l'audio de l'intitulé comme audio secondaire" do
-        json = question_qcm.as_json
-        expect(json['intitule_audio']).to eql(Rails.application.routes.url_helpers.url_for(
-                                                intitule.audio
-                                              ))
-      end
-    end
   end
 end

--- a/spec/models/question_saisie_spec.rb
+++ b/spec/models/question_saisie_spec.rb
@@ -47,35 +47,6 @@ describe QuestionSaisie, type: :model do
                                           ))
     end
 
-    context "quand il n'y a pas d'intitulé écrit" do
-      before do
-        Transcription.find_by(categorie: :intitule,
-                              question_id: question_saisie.id).update(ecrit: '')
-        json
-      end
-
-      it "retourne l'audio de la consigne en audio principal" do
-        expect(json['audio_url']).to eql(Rails.application.routes.url_helpers.url_for(
-                                           modalite.audio
-                                         ))
-      end
-
-      it "retourne l'audio de l'intitulé en audio secondaire" do
-        expect(json['intitule_audio']).to eql(Rails.application.routes.url_helpers.url_for(
-                                                question_saisie.transcriptions.first.audio
-                                              ))
-      end
-    end
-
-    context 'quand il y a un intitulé écrit' do
-      it "retourne l'audio de l'intitulé en audio principal" do
-        json
-        expect(json['audio_url']).to eql(Rails.application.routes.url_helpers.url_for(
-                                           question_saisie.transcriptions.first.audio
-                                         ))
-      end
-    end
-
     context "quand il n'y a pas de réponse" do
       it 'ne retourne pas de reponse' do
         reponse.destroy


### PR DESCRIPTION
Erreur rollbar :
https://app.rollbar.com/a/eva-betagouv/fix/item/eva/960

Vidéo pour démontrer qu'on peut lancer une campagne avec numératie et des questions clic dans image sans intitulé
question 1 : sans intitulé écrit ni audio, avec consigne écrit et audio
question 2 : avec intitulé écrit ni audio, sans consigne écrit et audio
question 3 : sans intitulé écrit avec intitulé audio, sans consigne écrit et audio
question 4 : sans rien sauf intitulé audio
question 5 : sans rien


https://github.com/user-attachments/assets/9ed972dc-be0f-409f-b210-b8544169d691



La démo se fait avec QuestionClicDansImage mais le refacto et les tests permettent de vérifier qu'elle s'applique à tous les types de questions.
