### PR TITLE
 🐛 Corrige l'affichage des titres avec aide illettrisme

### DIFF
--- a/app/views/admin/controle_syntheses_restitutions/index.html.erb
+++ b/app/views/admin/controle_syntheses_restitutions/index.html.erb
@@ -30,7 +30,7 @@
           <h2>Synthèses de pré-positionnement</h2>
           <% @syntheses_pre_positionnement.each do |synthese| -%>
             <div class="panel">
-              <div id="francais_mathematiques" class="francais-mathematiques marges-page">
+              <div class="marges-page">
                 <div id="lettrisme" class="page">
                   <%= render 'admin/evaluations/litteratie_numeratie_synthese',
                     synthese: synthese,

--- a/app/views/admin/evaluations/_francais_mathematique.arb
+++ b/app/views/admin/evaluations/_francais_mathematique.arb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-div id: 'francais_mathematiques', class: 'francais-mathematiques marges-page' do
+div class: 'marges-page' do
   render 'demande_aide_illettrisme' if !pdf && resource.illettrisme_potentiel?
 
   render 'litteratie_numeratie_synthese',

--- a/app/views/admin/evaluations/_restitution_globale.arb
+++ b/app/views/admin/evaluations/_restitution_globale.arb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 niveaux_competences = restitution_globale.niveaux_competences
-if restitution_globale.synthese_positionnement == 'illettrisme_potentiel'
-  titre_avec_aide_illettrisme_litteratie = 'titre--avec-aide-illettrisme'
-end
-if restitution_globale.synthese_positionnement_numeratie == 'illettrisme_potentiel'
-  titre_avec_aide_illettrisme_numeratie = 'titre--avec-aide-illettrisme'
-end
 
 div class: 'evaluation__restitution-globale' do
   render 'deroulement_passation' unless resource.campagne.parcours_type.blank? || pdf
@@ -115,8 +109,8 @@ div class: 'evaluation__restitution-globale' do
       end
     else
       div id: 'francais_mathematiques', class: 'page' do
-        h2 t('titre', scope: 'admin.restitutions.cefr'),
-           class: titre_avec_aide_illettrisme_litteratie.to_s
+        class_titre = resource.illettrisme_potentiel? ? 'titre--avec-aide-illettrisme' : ''
+        h2 t('titre', scope: 'admin.restitutions.cefr'), class: class_titre
 
         div class: 'panel panel--avec-references' do
           render 'francais_mathematique', pdf: pdf,
@@ -145,8 +139,11 @@ div class: 'evaluation__restitution-globale' do
       if pdf
         h2 t('titre', scope: 'admin.restitutions.lettrisme'), class: 'text-center mt-5 mb-4'
       else
-        h2 t('titre', scope: 'admin.restitutions.lettrisme'),
-           class: titre_avec_aide_illettrisme_litteratie.to_s
+        class_titre = ''
+        if restitution_globale.synthese_positionnement == 'illettrisme_potentiel'
+          class_titre = 'titre--avec-aide-illettrisme'
+        end
+        h2 t('titre', scope: 'admin.restitutions.lettrisme'), class: class_titre
       end
 
       render partial: 'lettrisme',
@@ -165,8 +162,11 @@ div class: 'evaluation__restitution-globale' do
       if pdf
         h2 t('titre', scope: 'admin.restitutions.numeratie'), class: 'text-center mt-5 mb-4'
       else
-        h2 t('titre', scope: 'admin.restitutions.numeratie'),
-           class: titre_avec_aide_illettrisme_numeratie.to_s
+        class_titre = ''
+        if restitution_globale.synthese_positionnement_numeratie == 'illettrisme_potentiel'
+          class_titre = 'titre--avec-aide-illettrisme'
+        end
+        h2 t('titre', scope: 'admin.restitutions.numeratie'), class: class_titre
       end
 
       render partial: 'numeratie',


### PR DESCRIPTION
Cette PR corrige une régression sur l'affichage du panneau d'aide illettrisme dans le cas des restitutions de pré-positionnement : 
<img width="951" alt="Capture d’écran 2024-09-04 à 16 36 56" src="https://github.com/user-attachments/assets/c10538bc-587a-42b0-b4e6-d8a75fd9c707">

Cela continue de marcher pour une restitution café de la place : 
<img width="963" alt="Capture d’écran 2024-09-04 à 17 15 49" src="https://github.com/user-attachments/assets/f4666846-02fc-4d3f-98b2-74876a17c12d">

Je n'ai pas testé pour numératie evacob car je n'ai pas de données.

Au passage, j'ai supprimé un id="francais_mathematiques" qui apparaissait en double dans la page et la class css `francais-mathematiques` qui n'était pas utilisée.