### PR TITLE
Corrige la recherche d'une partie à l'enregistrement d'un évenement

### DIFF
--- a/app/controllers/api/evenements_controller.rb
+++ b/app/controllers/api/evenements_controller.rb
@@ -4,7 +4,10 @@ module Api
   class EvenementsController < Api::BaseController
     def create
       evenement = FabriqueEvenement.new(permit_params).call
-      if evenement.persisted?
+      if evenement.blank?
+        logger.warn "Echec recherche partie, evenement ignoré : #{permit_params}"
+        render json: {}, status: :ok
+      elsif evenement.persisted?
         render json: evenement, status: :created
       else
         render json: evenement.errors.full_messages, status: :unprocessable_entity

--- a/app/models/fabrique_evenement.rb
+++ b/app/models/fabrique_evenement.rb
@@ -9,6 +9,8 @@ class FabriqueEvenement
 
   def call
     partie = recupere_partie
+    return if partie.blank?
+
     param = EvenementParams.from(parametres).merge(partie: partie)
     Evenement.new(param).tap do |evenement|
       next unless evenement.save
@@ -21,13 +23,22 @@ class FabriqueEvenement
 
   def recupere_partie
     situation = Situation.find_by(nom_technique: parametres[:situation])
-    partie = begin
-      Partie.find_or_create_by(session_id: parametres[:session_id],
-                               situation: situation,
-                               evaluation_id: parametres[:evaluation_id])
-    rescue ActiveRecord::RecordNotUnique
-      retry
+    partie = find_or_create_partie_atomic(parametres[:session_id],
+                                          situation,
+                                          parametres[:evaluation_id])
+    if partie.situation != situation || partie.evaluation_id != parametres[:evaluation_id]
+      return nil
     end
+
     partie.persisted? ? partie : nil
+  end
+
+  def find_or_create_partie_atomic(session_id, situation, evaluation_id)
+    Partie.find_or_create_by(session_id: session_id) do |p|
+      p.situation = situation
+      p.evaluation_id = evaluation_id
+    end
+  rescue ActiveRecord::RecordNotUnique
+    retry
   end
 end

--- a/spec/controllers/evenements_controller_spec.rb
+++ b/spec/controllers/evenements_controller_spec.rb
@@ -4,15 +4,16 @@ require 'rails_helper'
 
 describe Api::EvenementsController, type: :controller do
   describe 'POST create' do
+    let(:evaluation) { create :evaluation }
+    let(:situation) { create :situation_inventaire }
+
     context "quand la création de l'évènement échoue" do
       it 'renvoie une erreur unprocessable_entity' do
-        evaluation = create :evaluation
-        create :situation_inventaire
         params = {
           date: 1_551_111_089_238,
           nom: nil,
           donnees: {},
-          situation: 'inventaire',
+          situation: situation.nom_technique,
           position: 58,
           session_id: 'O8j78U2xcb2',
           evaluation_id: evaluation.id
@@ -20,6 +21,23 @@ describe Api::EvenementsController, type: :controller do
 
         post :create, params: params
         expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'quand la recherche de la partie échoue' do
+      it "journalise l'erreur mais renvoie OK" do
+        params = {
+          date: 1_551_111_089_238,
+          nom: 'demarrage',
+          donnees: {},
+          situation: situation.nom_technique,
+          position: 58,
+          session_id: 'O8j78U2xcb2',
+          evaluation_id: nil
+        }
+
+        post :create, params: params
+        expect(response).to have_http_status(:ok)
       end
     end
   end


### PR DESCRIPTION
Cette correction nous protège des clients qui réussisent à redémarrer une évaluation dans un onglet alors qu'une partie est en cours dans un autre.