### PR TITLE
🐛 Convertie les réponses en array avant de les réordonner aléatoirement

### DIFF
--- a/app/models/question_glisser_deposer.rb
+++ b/app/models/question_glisser_deposer.rb
@@ -39,7 +39,7 @@ class QuestionGlisserDeposer < Question
   end
 
   def reponses_fields
-    reponses_non_classees = reponses.order('RANDOM()').map do |reponse|
+    reponses_non_classees = reponses.to_a.shuffle.map do |reponse|
       illustration_url = cdn_for(reponse.illustration) if reponse.illustration.attached?
       reponse.slice(:id, :position).merge(
         'illustration' => illustration_url


### PR DESCRIPTION
Il semblerait qu'il y ait un conflit en utilisant la query `.order('RANDOM()')` avec le `has_many :reponses, -> { order(position: :asc) }` du modèle.
J'ai donc convertis la liste en array avant d'utiliser la méthode .shuffle mais j'ai l'impression que ce n'est pas la bonne façon de faire.
Après en théorie on aura jamais plus que 10 réponses à trier donc c'est peut-être pas si grave.