### PR TITLE
📝 Le superadmin peut paramétrer une question glisser deposer

### DIFF
--- a/app/admin/questions_glisser_deposer.rb
+++ b/app/admin/questions_glisser_deposer.rb
@@ -7,6 +7,7 @@ ActiveAdmin.register QuestionGlisserDeposer do
 
   permit_params :libelle, :nom_technique, :description, :illustration, :supprimer_illustration,
                 :supprimer_audio_modalite_reponse, :supprimer_audio_intitule,
+                :zone_depot_url, :supprimer_zone_depot_url,
                 transcriptions_attributes: %i[id categorie ecrit audio _destroy],
                 reponses_attributes: %i[id illustration position type_choix position_client
                                         nom_technique _destroy]

--- a/app/models/question_glisser_deposer.rb
+++ b/app/models/question_glisser_deposer.rb
@@ -7,6 +7,16 @@ class QuestionGlisserDeposer < Question
            dependent: :destroy
   accepts_nested_attributes_for :reponses, allow_destroy: true
 
+  has_many_attached :zones_depot_url
+
+  validates :zones_depot_url,
+            blob: { content_type: 'image/svg+xml' }
+
+  attr_accessor :supprimer_zones_depot_url
+
+  before_save :valide_zones_depot_url_avec_reponse
+  after_update :supprime_zones_depot_url
+
   def as_json(_options = nil)
     json = base_json
     json.merge!(json_audio_fields, reponses_fields)
@@ -31,5 +41,40 @@ class QuestionGlisserDeposer < Question
       )
     end
     { 'reponsesNonClassees' => reponses_non_classees }
+  end
+
+  def supprime_zones_depot_url
+    zones_depot_url.purge_later if zones_depot_url.attached? && supprimer_zones_depot_url == '1'
+  end
+
+  def valide_zones_depot_url_avec_reponse
+    return unless zones_depot_url_attached?
+    return if zones_depot_url_changes_nil?
+
+    attachment_changes['zones_depot_url'].attachable.each do |file|
+      doc = Nokogiri::XML(file.download, nil, 'UTF-8')
+
+      if zones_depot_invalid?(doc)
+        add_invalid_zones_depot_error
+        throw(:abort)
+      end
+    end
+  end
+
+  def zones_depot_url_attached?
+    zones_depot_url.attached?
+  end
+
+  def zones_depot_url_changes_nil?
+    attachment_changes['zones_depot_url'].nil?
+  end
+
+  def zones_depot_invalid?(doc)
+    doc.css('.zone-depot').empty? || doc.css(".zone-depot--#{reponse.nom_technique}").empty?
+  end
+
+  def add_invalid_zones_depot_error
+    errors.add(:zones_depot_url,
+               "doit contenir les classes 'zone-depot' et 'zone-depot--#{reponse.nom_technique}'")
   end
 end

--- a/app/views/admin/questions_glisser_deposer/_form.html.arb
+++ b/app/views/admin/questions_glisser_deposer/_form.html.arb
@@ -7,6 +7,17 @@ active_admin_form_for [:admin, resource] do |f|
     f.input :nom_technique
     f.input :description
     render partial: 'admin/questions/input_illustration', locals: { f: f }
+    f.input :zones_depot_url,
+            as: :file,
+            hint: "L'un des éléments cliquables doit contenir la classe css `zone-depot` " \
+                  'et la classe css `zone-depot--reponse.nom_technique`',
+            input_html: { accept: 'image/svg+xml', multiple: true }
+    if f.object.zones_depot_url.attached? && f.object.errors[:zones_depot_url].blank?
+      f.input :supprimer_zones_depot_url,
+              as: :boolean,
+              label: t('.label.supprimer_zones_depot_url'),
+              hint: svg_attachment_base64(resource.zones_depot_url, class: 'image-preview')
+    end
   end
   f.inputs do
     render partial: 'admin/questions/inputs_avec_transcriptions_audios',

--- a/app/views/admin/questions_glisser_deposer/_show.html.arb
+++ b/app/views/admin/questions_glisser_deposer/_show.html.arb
@@ -13,6 +13,19 @@ panel 'Détails de la question' do
         end
       end
     end
+    row :zones_depot_url do
+      if resource.zones_depot_url.attached?
+        ul do
+          resource.zones_depot_url.each do |file|
+            li do
+              link_to(cdn_for(file), target: '_blank', rel: 'noopener') do
+                svg_attachment_base64(file, class: 'image-preview')
+              end
+            end
+          end
+        end
+      end
+    end
     intitule = question_glisser_deposer.transcription_intitule
     row :intitule do
       div intitule.ecrit if intitule&.ecrit

--- a/docs/tech-dive-in/EVA-186-le-superadmin-peut-parametrer-un-masque-des-zones-deposables/readme.md
+++ b/docs/tech-dive-in/EVA-186-le-superadmin-peut-parametrer-un-masque-des-zones-deposables/readme.md
@@ -1,0 +1,31 @@
+<!-- 📄 Standard : https://www.notion.so/captive/Le-cadrage-technique-dbb611e45f114737a6b14745caa584e9?pvs=4 -->
+# Le superadmin peut paramétrer une question glisser deposer
+
+> [EVA-186](https://captive-team.atlassian.net/browse/EVA-186)
+
+## Backend
+
+1. Rajouter une `has_many_attached :zones_depot_url` de type svg dans `QuestionGlisserDeposer`
+2. Rajouter une validation de presence sur ce model pour la zone sur ce model
+3. Vérifier que le svg contient la class `bonne-reponse` avant sa sauvegarde en bdd
+```ruby
+def valide_zones_depot_url_avec_reponse
+  return unless zones_depot_url.attached?
+  return if attachment_changes['zones_depot_url'].nil?
+
+  attachment_changes['zones_depot_url'].attachable.each do |file|
+    doc = Nokogiri::XML(file.download, nil, 'UTF-8')
+    
+    elements_zone_depot = doc.css(".zone-depot")
+    elements_technique = doc.css(".zone-depot--#{reponse.nom_technique}")
+
+    if elements_zone_depot.empty? || elements_technique.empty?
+      errors.add(:zones_depot_url, "doit contenir les classes 'zone-depot' et 'zone-depot--#{reponse.nom_technique}'")
+      throw(:abort)
+    end
+  end
+end
+```
+5. Ajouter un `supprimer_zones_depot_url` de la même manière que zone cliquable
+6. Afficher un preview du svg dans la show de `QuestionGlisserDeposer` + un hint pour le format
+''

--- a/spec/models/question_glisser_deposer_spec.rb
+++ b/spec/models/question_glisser_deposer_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 describe QuestionGlisserDeposer, type: :model do
   it { is_expected.to have_many(:reponses).with_foreign_key(:question_id) }
+  it { is_expected.to have_many_attached(:zones_depot_url) }
 
   let(:question) do
     create(:question_glisser_deposer,
@@ -39,6 +40,36 @@ describe QuestionGlisserDeposer, type: :model do
         expect(json['reponsesNonClassees'].first['illustration']).to_not be(nil)
         expect(json['reponsesNonClassees'].first['position']).to eql(1)
         expect(json['reponsesNonClassees'].first['position_client']).to eql(2)
+      end
+    end
+  end
+
+  describe 'validations' do
+    let(:question) do
+      build(:question_glisser_deposer)
+    end
+
+    context 'avec un attachment au format svg' do
+      it 'est valide' do
+        question.zones_depot_url.attach(
+          io: Rails.root.join('spec/support/accessibilite-sans-reponse.svg').open,
+          filename: 'valid.svg',
+          content_type: 'image/svg+xml'
+        )
+        expect(question).to be_valid
+      end
+    end
+
+    context "avec un attachement d'un autre format" do
+      it "n'est pas valide" do
+        question.zones_depot_url.attach(
+          io: Rails.root.join('spec/support/programme_tele.png').open,
+          filename: 'invalid.png',
+          content_type: 'image/png'
+        )
+        expect(question).not_to be_valid
+        erreur = question.errors[:zones_depot_url]
+        expect(erreur).to include("n'est pas un format de fichier valide")
       end
     end
   end


### PR DESCRIPTION
Le readme peut être consulté ici : https://github.com/betagouv/eva-serveur/blob/3763782f702865e48907910221caf2c4ab1749fd/docs/tech-dive-in/EVA-186-le-superadmin-peut-parametrer-un-masque-des-zones-deposables/readme.md