### PR TITLE
💄 Rend visible la zone cliquable sur la preview d'une question clic dans image quand le svg est transparent

### DIFF
--- a/app/assets/stylesheets/admin/pages/_question.scss
+++ b/app/assets/stylesheets/admin/pages/_question.scss
@@ -30,3 +30,10 @@ form.question_saisie .choix {
     }
   }
 }
+.show.admin_questions_clic_dans_image {
+  svg {
+    stroke: $eva_bluegrey;
+    stroke-width: 3px;
+    opacity: 0.3;
+  }
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,6 +46,20 @@ module ApplicationHelper
     image_tag fichier_encode_en_base64(file_content), options
   end
 
+  def inline_svg_content(attachment, options = {})
+    return unless attachment.attached?
+
+    file_content = attachment.download
+    svg_with_class(file_content, options[:class])
+  end
+
+  def svg_with_class(svg_content, css_class)
+    return svg_content if css_class.blank?
+
+    svg_content.sub!('<svg', "<svg class=\"#{css_class}\"")
+    svg_content.html_safe
+  end
+
   def fichier_encode_en_base64(file_content)
     encodage = Base64.strict_encode64 file_content
     "data:image/svg+xml;base64,#{encodage}"

--- a/app/views/admin/questions_clic_dans_image/_show.html.arb
+++ b/app/views/admin/questions_clic_dans_image/_show.html.arb
@@ -16,7 +16,7 @@ panel 'Détails de la question' do
     row :zone_cliquable do
       if resource.zone_cliquable.attached?
         link_to(cdn_for(resource.zone_cliquable), target: '_blank', rel: 'noopener') do
-          svg_attachment_base64(resource.zone_cliquable, class: 'image-preview')
+          raw inline_svg_content(resource.zone_cliquable, class: 'image-preview')
         end
       end
     end


### PR DESCRIPTION
<img width="1040" alt="Capture d’écran 2024-09-25 à 23 02 32" src="https://github.com/user-attachments/assets/26026390-f261-4902-9ac5-3518595ff3f5">
