### PR TITLE
On peut refuser tous les comptes, du moment qu'il reste un admin non-refusé

### DIFF
--- a/config/locales/models/compte.yml
+++ b/config/locales/models/compte.yml
@@ -48,11 +48,11 @@ fr:
       models:
         compte:
           attributes:
+            statut_validation:
+              structure_doit_avoir_un_admin: La structure doit avoir au moins un administrateur autorisé
             role:
-              structure_doit_avoir_un_admin: 'La structure doit avoir au moins un administrateur'
+              structure_doit_avoir_un_admin: La structure doit avoir au moins un administrateur
               inclusion: n'est pas inclus dans la liste
-              comptes_refuses: |
-                ce compte ne peut pas avoir le rôle %<value>s en étant refusé. Uniquement conseiller ou compte générique
   formtastic:
     actions:
       compte:

--- a/spec/features/admin/compte_spec.rb
+++ b/spec/features/admin/compte_spec.rb
@@ -65,20 +65,6 @@ describe 'Admin - Compte', type: :feature do
       it { expect(collegue.reload.validation_refusee?).to be true }
     end
 
-    describe 'Refuser un admin' do
-      before do
-        visit edit_admin_compte_path(collegue)
-        select 'Admin'
-        choose 'Refusé'
-        click_on 'Modifier'
-      end
-
-      it 'ne permet pas de refuser un admin' do
-        expect(page).to have_content('ce compte ne peut pas avoir le rôle admin en étant ' \
-                                     'refusé. Uniquement conseiller ou compte générique')
-      end
-    end
-
     describe 'Je vois les informations d\'un collègue' do
       it do
         visit admin_compte_path(collegue)
@@ -168,20 +154,6 @@ describe 'Admin - Compte', type: :feature do
       end
 
       it { expect(collegue.reload.validation_refusee?).to be true }
-    end
-
-    describe 'Refuser un admin' do
-      before do
-        visit edit_admin_compte_path(collegue)
-        select 'Admin'
-        choose 'Refusé'
-        click_on 'Modifier'
-      end
-
-      it 'ne permet pas de refuser un admin' do
-        expect(page).to have_content('ce compte ne peut pas avoir le rôle admin en étant ' \
-                                     'refusé. Uniquement conseiller ou compte générique')
-      end
     end
 
     describe "modifier le mot de passe d'un collègue" do

--- a/spec/integrations/compte_spec.rb
+++ b/spec/integrations/compte_spec.rb
@@ -126,6 +126,7 @@ describe Compte, type: :integration do
       let!(:compte_admin_sans_structure) { create :compte_admin, structure: nil }
       let!(:compte_admin) { create :compte_admin, structure: structure }
       let!(:compte_admin2) { create :compte_admin, structure: structure }
+      let!(:compte_admin_refuse) { create :compte_admin, :refusee, structure: structure }
       let!(:compte_superadmin) { create :compte_superadmin, structure: structure }
       let(:autre_structure) { create :structure }
       let!(:autre_admin) { create :compte_admin, structure: autre_structure }

--- a/spec/models/compte_spec.rb
+++ b/spec/models/compte_spec.rb
@@ -141,6 +141,13 @@ describe Compte do
         compte.valid?
         expect(compte.errors[:role]).to include 'La structure doit avoir au moins un administrateur'
       end
+
+      it 'ne peut pas refuser cet admin' do
+        compte.statut_validation = 'refusee'
+        compte.valid?
+        expect(compte.errors[:statut_validation])
+          .to include 'La structure doit avoir au moins un administrateur autorisé'
+      end
     end
 
     context "quand il n'y a pas d'admin dans la structure" do


### PR DESCRIPTION
Cette PR corrige l'erreur rollbar qui surgissait si on essayait de refuser un compte CMR

https://app.rollbar.com/a/eva-betagouv/fix/item/eva/1020?utm_campaign=new_item&utm_medium=email&utm_source=rollbar-notification&utm_content=view-item-button-1


<img width="977" alt="Capture d’écran 2024-10-14 à 18 29 43" src="https://github.com/user-attachments/assets/7742b82d-81b2-4aa9-ac8e-fcad29fa45a3">

