### PR TITLE
Accessibilité : rends accessible au clavier les questionnaires de remédiation

### DIFF
--- a/app/assets/javascripts/evaluation.js
+++ b/app/assets/javascripts/evaluation.js
@@ -107,4 +107,7 @@ document.addEventListener('DOMContentLoaded', () => {
     enregistreQualificationMiseEnAction(evaluationId, $bouton, { ignorer: true })
   });
   activeBoutonValider();
+  $("input[name=reponse_qcm]").on('focus', function(event) {
+    $(event.currentTarget).click();
+  });
 });

--- a/app/assets/stylesheets/admin/composants/_qcm.scss
+++ b/app/assets/stylesheets/admin/composants/_qcm.scss
@@ -6,9 +6,12 @@
 
   li {
     margin-top: 0.25rem;
-    &:last-child {
-      margin-top: 1rem;
-    }
+  }
+
+  input[type="radio"] {
+    appearance: none;
+    outline: none;
+    position: absolute;
   }
 
   input:checked + .tag { @include tag-couleur($success-425, $success-950); }

--- a/app/components/qcm.html.erb
+++ b/app/components/qcm.html.erb
@@ -1,23 +1,25 @@
 <div class="qcm w-100 <%= "questions-#{@questionnaire.nom}" %> <%= @qcm_affiche ? '' : 'hidden' %>" style="z-index: <%= @priorite %>;">
-  <p><%= @questionnaire.question %></p>
-  <form class="mt-3">
-    <ul style="list-style-type: none" class="m-0 p-0">
-      <% @questionnaire.reponses.each_value do |option| %>
-        <li>
-          <label>
-            <input type="radio" name="reponse_qcm" value="<%= option %>" class="hidden" autocomplete="off">
-            <%= render(Tag.new(t("activerecord.attributes.mise_en_action.#{@questionnaire.nom}.#{option}"))) %>
-          </label>
-        </li>
-      <% end %>
-      <li class="d-flex justify-content-end">
-        <button type="button" class="bouton-secondaire petit-bouton bouton-fermer mr-1">
-          <%= t('.action_fermer') %>
-        </button>
-        <button type="button" class="bouton valide-qcm mr-0 bouton--desactive">
-          <%= t('.action_valider') %>
-        </button>
-      </li>
-    </ul>
+  <form>
+    <fieldset class="mb-0">
+      <legend><%= @questionnaire.question %></legend>
+      <ul class="mt-3 p-0">
+        <% @questionnaire.reponses.each_value do |option| %>
+          <li>
+            <label>
+              <input type="radio" name="reponse_qcm" value="<%= option %>" autocomplete="off">
+              <%= render(Tag.new(t("activerecord.attributes.mise_en_action.#{@questionnaire.nom}.#{option}"))) %>
+            </label>
+          </li>
+        <% end %>
+      </ul>
+    </fieldset>
+    <div class="mt-3 d-flex justify-content-end">
+      <button type="button" class="bouton-secondaire petit-bouton bouton-fermer mr-1">
+        <%= t('.action_fermer') %>
+      </button>
+      <button type="button" class="bouton petit-bouton valide-qcm mr-0 bouton--desactive">
+        <%= t('.action_valider') %>
+      </button>
+    </div>
   </form>
 </div>


### PR DESCRIPTION
11.5 - Majeur : Absence de regroupement de champs
7.3 - Bloquant : Présence d’un élément ne fonctionnant pas au clavier

<img width="648" alt="Capture d’écran 2024-10-16 à 17 28 29" src="https://github.com/user-attachments/assets/db77cfb8-edae-4894-b3ac-53238b770f66">
