### PR TITLE
Augmente le contraste de la pagination des pages index

### DIFF
--- a/app/assets/stylesheets/admin/composants/_tables.scss
+++ b/app/assets/stylesheets/admin/composants/_tables.scss
@@ -99,3 +99,13 @@ table.index_table {
 .attributes_table table th {
   text-shadow: none;
 }
+
+.pagination {
+  a {
+    box-shadow: none;
+    background-image: none;
+  }
+}
+.pagination_information {
+  color: $couleur-texte;
+}


### PR DESCRIPTION
avant : 
<img width="987" alt="Capture d’écran 2024-10-21 à 18 08 24" src="https://github.com/user-attachments/assets/ff676ede-2b67-4aec-8d69-733056399dc2">

après : 
<img width="1005" alt="Capture d’écran 2024-10-21 à 18 08 12" src="https://github.com/user-attachments/assets/b1e78419-0e94-46e8-8cf8-199448f25123">
