### PR TITLE
Accessibilité : ajout une description alternatives aux images de la page aide

### DIFF
--- a/app/views/admin/aide/_contact.html.arb
+++ b/app/views/admin/aide/_contact.html.arb
@@ -7,7 +7,7 @@ div class: 'aide__contact' do
   end
   div class: 'contact__support' do
     div class: 'support__titre' do
-      text_node image_tag 'eva-logo-dark.svg', class: 'support__logo'
+      text_node image_tag 'eva-logo-dark.svg', class: 'support__logo', alt: ''
       h4 t('.support.titre')
     end
     div do

--- a/app/views/admin/aide/_menu_sidebar.html.arb
+++ b/app/views/admin/aide/_menu_sidebar.html.arb
@@ -23,5 +23,5 @@ div class: 'menu-transverse' do
     end
   end
 
-  text_node image_tag 'avatar_pouce_leve.svg', class: 'avatar-pouce-leve'
+  text_node image_tag 'avatar_pouce_leve.svg', class: 'avatar-pouce-leve', alt: ''
 end


### PR DESCRIPTION
<img width="564" alt="Capture d’écran 2024-10-31 à 17 04 49" src="https://github.com/user-attachments/assets/6e6d5be6-97f6-4a9d-a48e-3f83b520135a">
