### PR TITLE
Corrige le formulaire de modification de structure

### DIFF
--- a/app/models/structure.rb
+++ b/app/models/structure.rb
@@ -24,6 +24,7 @@ class Structure < ApplicationRecord
     end
   end
 
+  before_validation :retire_espaces_siret
   after_validation :geocode, if: ->(s) { s.code_postal.present? and s.code_postal_changed? }
   after_create :programme_email_relance
 
@@ -89,5 +90,11 @@ class Structure < ApplicationRecord
     return if siret.size == 14 || siret.size == 9
 
     errors.add(:siret, :invalid)
+  end
+
+  def retire_espaces_siret
+    return if siret.blank?
+
+    self.siret = siret.gsub(/[[:space:]]/, '')
   end
 end

--- a/app/views/admin/structures_locales/_form.html.arb
+++ b/app/views/admin/structures_locales/_form.html.arb
@@ -2,7 +2,7 @@
 
 render partial: 'nouvelles_structures/modal_mise_en_garde' if params[:mise_en_garde] == 'affiche'
 div class: 'panel nouvelle_structure' do
-  h2 t('.titre')
+  h2 t(resource.new_record? ? '.titre.nouveau' : '.titre.modification')
   active_admin_form_for [:admin, resource] do |f|
     f.inputs do
       f.object.code_postal = params[:code_postal]&.delete('^0-9') if f.object.code_postal.blank?

--- a/config/locales/views/structures.yml
+++ b/config/locales/views/structures.yml
@@ -29,7 +29,9 @@ fr:
         voir: Voir
     structures_locales:
       form:
-        titre: Création d'une nouvelle structure
+        titre:
+          nouveau: Création d'une nouvelle structure
+          modification: Modification de la structure
         verifier_information_structure: |
           **Veuillez vérifier les informations saisies avant de valider cette création.**
           Si vous avez des difficultés, vous pouvez nous contacter à : [contact@beta.gouv.fr](mailto:contact@beta.gouv.fr)

--- a/spec/models/structure_spec.rb
+++ b/spec/models/structure_spec.rb
@@ -128,6 +128,17 @@ describe Structure, type: :model do
       it { expect(structure.errors[:siret]).to be_blank }
     end
 
+    context 'quand il est un siret valide avec des espaces' do
+      let(:structure) { build :structure, siret: '1234567890 1234' }
+
+      before { structure.valid? }
+
+      it do
+        expect(structure.errors[:siret]).to be_blank
+        expect(structure.siret).to eq('12345678901234')
+      end
+    end
+
     context 'quand il est un siret valide (14 chiffres)' do
       let(:structure) { build :structure, siret: '12345678901234' }
 


### PR DESCRIPTION
- Corrige le titre du formulaire ;
- Supprime les espaces saisis dans le numéro de siret ;

<img width="948" alt="Capture d’écran 2024-11-13 à 17 51 20" src="https://github.com/user-attachments/assets/b53db6a4-a96d-4f7b-8ff4-513225c2f84e">
