### PR TITLE
Eva 230 le superadmin peut parametrer un ecran drag and drop de cafe de la place

### DIFF
--- a/app/admin/questions_glisser_deposer.rb
+++ b/app/admin/questions_glisser_deposer.rb
@@ -9,7 +9,7 @@ ActiveAdmin.register QuestionGlisserDeposer do
                 :supprimer_audio_modalite_reponse, :supprimer_audio_intitule,
                 :supprimer_zone_depot, :zone_depot, :supprimer_audio_consigne,
                 transcriptions_attributes: %i[id categorie ecrit audio _destroy],
-                reponses_attributes: %i[id illustration position type_choix position_client
+                reponses_attributes: %i[id illustration intitule position type_choix position_client
                                         nom_technique _destroy]
 
   filter :libelle

--- a/app/models/question_glisser_deposer.rb
+++ b/app/models/question_glisser_deposer.rb
@@ -41,7 +41,7 @@ class QuestionGlisserDeposer < Question
   def reponses_fields
     reponses_non_classees = reponses.map do |reponse|
       illustration_url = cdn_for(reponse.illustration) if reponse.illustration.attached?
-      reponse.slice(:id, :position, :nom_technique, :position_client).merge(
+      reponse.slice(:id, :position, :nom_technique, :position_client, :intitule).merge(
         'illustration' => illustration_url
       )
     end

--- a/app/views/admin/questions_glisser_deposer/_form.html.arb
+++ b/app/views/admin/questions_glisser_deposer/_form.html.arb
@@ -26,6 +26,7 @@ active_admin_form_for [:admin, resource] do |f|
                         heading: t('.reponses') do |r|
     r.input :id, as: :hidden
     r.input :nom_technique
+    r.input :intitule
     r.input :position_client
     r.input :type_choix, as: :hidden, input_html: { value: :bon }
     label = r.object.illustration.attached? ? t('.label_illustration') : true

--- a/db/migrate/20241114121952_cree_question_glisser_deposer_cafe.rb
+++ b/db/migrate/20241114121952_cree_question_glisser_deposer_cafe.rb
@@ -1,0 +1,68 @@
+class CreeQuestionGlisserDeposerCafe < ActiveRecord::Migration[7.0]
+  class ::Questionnaire < ApplicationRecord; end
+  class ::QuestionnaireQuestion < ApplicationRecord; end
+  class ::Question < ApplicationRecord; end
+  class ::Transcription < ApplicationRecord; end
+  class ::Choix < ApplicationRecord;end
+
+  def up
+    litteratie = Questionnaire.find_or_create_by(nom_technique: 'litteratie_2024') do |q|
+      q.libelle = "Littératie 2024"
+    end
+    question = Question.find_or_create_by(nom_technique: 'hpar_1') do |q|
+      q.libelle = "HPar1"
+      q.type = 'QuestionGlisserDeposer'
+      q.description = 'Vous avez placé tous les blocs de texte !\nVous pouvez toujours modifier leur ordre directement dans la page du journal.'
+    end
+    Transcription.find_or_create_by(categorie: :intitule, question_id: question.id) do |t|
+      t.ecrit = "Si l’ordre vous convient, cliquez sur « Valider »."
+    end
+    choix = [
+    {
+      nom_technique: 'hpar_1R1',
+      position: 7,
+      position_client: 1,
+      intitule: "Durant leur séjour à l'hôpital, ils auront tout loisir de se raconter leurs petites histoires..."
+    }, {
+      nom_technique: 'hpar_1R2',
+      position: 2,
+      position_client: 2,
+      intitule: "En effet, il est 8 h 45 quand le jeune David G. s'apprête à traverser la chaussée."
+    }, {
+      nom_technique: 'hpar_1R3',
+      position: 3,
+      position_client: 3,
+      intitule: "Un de ses copains de classe, Rémi P. qui était déjà devant l'école, se met lui aussi à traverser la chaussée pour aller à sa rencontre."
+    }, {
+      nom_technique: 'hpar_1R4',
+      position: 6,
+      position_client: 4,
+      intitule: "Les deux amis, blessés au visage pour l'un et à la jambe pour l'autre, ont été transportés à l'hôpital tout proche."
+    }, {
+      nom_technique: 'hpar_1R5',
+      position: 4,
+      position_client: 5,
+      intitule: "Les deux garçons se dirigent l'un vers l'autre sans regarder la circulation."
+    }, {
+      nom_technique: 'hpar_1R6',
+      position: 1,
+      position_client: 6,
+      intitule: "Ce matin, alors que les enfants arrivaient à proximité de l'école, deux garçons particulièrement distraits ont provoqué un accident sur la voie publique près de l'école Jules Ferry."
+    }, {
+      nom_technique: 'hpar_1R7',
+      position: 5,
+      position_client: 7,
+      intitule: "Deux voitures qui arrivaient en sens contraire, ont chacune projeté violemment un garçon à terre provoquant la frayeur des témoins."
+    }
+  ]
+    choix.each do |data|
+      Choix.find_or_create_by(nom_technique: data[:nom_technique], question_id: question.id) do |c|
+      c.position = data[:position]
+      c.position_client = data[:position_client]
+      c.intitule = data[:intitule]
+      c.type_choix = 'bon'
+      end
+    end
+    QuestionnaireQuestion.find_or_create_by(questionnaire_id: litteratie.id, question_id: question.id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_08_040153) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_14_121952) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/lib/tasks/questions.rake
+++ b/lib/tasks/questions.rake
@@ -54,6 +54,9 @@ constantes = {
     sous_consigne_HPfb_1: 'terrasse_cafe',
     sous_consigne_HPfb_2: 'telephone_email'
   },
+  NOM_TECHNIQUES_GLISSER_DEPOSER: {
+    hpar_1: 'journal_vide'
+  },
   DOSSIER_ID: 'DOSSIER_ID',
   TYPE_QUESTION: 'TYPE_QUESTION'
 }
@@ -82,6 +85,8 @@ namespace :questions do
       attache_assets(NOM_TECHNIQUES_QCM)
     when 'SOUS_CONSIGNE'
       attache_assets(NOM_TECHNIQUES_CONSIGNES)
+    when 'GLISSER_DEPOSER'
+      attache_assets(NOM_TECHNIQUES_GLISSER_DEPOSER)
     end
   end
 end
@@ -102,6 +107,7 @@ def attache_assets(nom_techniques)
     recupere_fichier(question, "#{nom_illustration}.png")
     recupere_fichier(question, "#{question.nom_technique}.mp3", question.transcription_intitule)
     attach_audio_choix(question) if nom_techniques == NOM_TECHNIQUES_QCM
+    attach_images_reponses(question) if nom_techniques == NOM_TECHNIQUES_GLISSER_DEPOSER
   end
 end
 
@@ -120,6 +126,12 @@ end
 def attach_audio_choix(question)
   question.choix.each do |choix|
     recupere_fichier(question, "#{choix.nom_technique}.mp3", choix)
+  end
+end
+
+def attach_images_reponses(question)
+  question.reponses.each do |choix|
+    recupere_fichier(question, "#{choix.nom_technique}.png", choix)
   end
 end
 


### PR DESCRIPTION
Au final, une réponse avait déjà un champs `intitule`.
Donc à la place d'avoir des images, on peut garder le texte pour les réponses de la question glisser déposer de café de la place. Si on rajoute des illustrations au xréponses, ça ne les affichera rien.

Le fonctionnement reste inchangé pour place du marché.