### PR TITLE
Actualise l'email de conctact et supprime contact@beta.gouv.fr

### DIFF
--- a/app/lib/eva.rb
+++ b/app/lib/eva.rb
@@ -2,7 +2,7 @@
 
 module Eva
   DOCUMENT_PRISE_EN_MAIN = 'https://docs.google.com/presentation/d/e/2PACX-1vRbrOAP6ojsMldL0YZaLLWH_nrluOd9kkp_0XACQsn7lateomMATUC5uEn_CZMLni--pjpfSJ366ppf/pub?start=true&loop=false&delayms=3000'
-  EMAIL_CONTACT = 'contact@eva.beta.gouv.fr'
+  EMAIL_CONTACT = 'eva@anlci.gouv.fr'
   EMAIL_SUPPORT = 'support@eva.beta.gouv.fr'
   EMAIL_DEMO = 'demo@eva.beta.gouv.fr'
   STRUCTURE_DEMO = 'Structure démo ANLCI'

--- a/app/views/admin/structures_locales/_form.html.arb
+++ b/app/views/admin/structures_locales/_form.html.arb
@@ -14,7 +14,7 @@ div class: 'panel nouvelle_structure' do
         f.input :parent_id, as: :select, collection: StructureAdministrative.all
       end
     end
-    text_node md t('.verifier_information_structure')
+    text_node md t('.verifier_information_structure', email_contact: Eva::EMAIL_CONTACT)
     f.actions do
       f.action :submit
       annulation_formulaire(f) if current_compte.structure.present?

--- a/app/views/nouvelles_structures/show.html.erb
+++ b/app/views/nouvelles_structures/show.html.erb
@@ -45,7 +45,7 @@
     <%= recaptcha_tags %>
   </div>
   <div class="panel">
-    <%= md t('.actions.validation') %>
+    <%= md t('.actions.validation', email_contact: Eva::EMAIL_CONTACT) %>
     <%= compte.actions do %>
       <%= compte.action :submit, label: t('.creer_structure'), wrapper_html: { class: 'd-flex justify-content-end' } %>
     <% end %>

--- a/config/locales/views/structures.yml
+++ b/config/locales/views/structures.yml
@@ -34,7 +34,7 @@ fr:
           modification: Modification de la structure
         verifier_information_structure: |
           **Veuillez vérifier les informations saisies avant de valider cette création.**
-          Si vous avez des difficultés, vous pouvez nous contacter à : [contact@beta.gouv.fr](mailto:contact@beta.gouv.fr)
+          Si vous avez des difficultés, vous pouvez nous contacter à : [%{email_contact}](mailto:%{email_contact})
   nouvelles_structures:
     modal_mise_en_garde:
       titre: Mise en garde
@@ -59,6 +59,6 @@ fr:
       actions:
         validation: |
           **Veuillez vérifier les informations saisies avant de valider votre inscription.**
-          Si vous avez des difficultés, vous pouvez nous contacter à : [contact@beta.gouv.fr](mailto:contact@beta.gouv.fr)
+          Si vous avez des difficultés, vous pouvez nous contacter à : [%{email_contact}](mailto:%{email_contact})
       creer_structure: Valider la création de mon compte
       lien_retour: Rechercher ma structure


### PR DESCRIPTION
Cette PR corrige l'utilisation erronée de l'adresse de contact de beta.gouv (et non eva.beta.gouv) et modifie au passage l'adresse email de contact pour eva@anlci.beta.gouv pour tous les mails envoyés par l'admin.

C'était l'email de contact de beta, pas celle d'eva !

Sur l'écran de modification d'une structure : 
<img width="925" alt="Capture d’écran 2024-11-15 à 12 22 53" src="https://github.com/user-attachments/assets/0648976e-de8f-4737-853a-bf40f3182c7a">

Et sur l'écran de création de structure :
<img width="675" alt="Capture d’écran 2024-11-15 à 12 24 02" src="https://github.com/user-attachments/assets/3e8578f9-6a89-4d48-afa3-1f91612ee9fb">

Exemple de mail. Début du mail envoyé à la création du compte : 
<img width="951" alt="Capture d’écran 2024-11-15 à 12 26 48" src="https://github.com/user-attachments/assets/68fece8a-8394-4f17-b617-4f6f04b845bf">

