### PR TITLE
Accessibilité : ajout le lien de l'asterisque des solutions de remediation

### DIFF
--- a/app/assets/stylesheets/admin/pages/restitution_globale/_base.scss
+++ b/app/assets/stylesheets/admin/pages/restitution_globale/_base.scss
@@ -75,6 +75,9 @@
     .intitule-question {
       display: flex;
       align-items: center;
+      p {
+        margin: 0;
+      }
     }
 
     .jauge {

--- a/app/views/admin/evaluations/_questionnaire_autopositionnement.arb
+++ b/app/views/admin/evaluations/_questionnaire_autopositionnement.arb
@@ -5,7 +5,7 @@ div class: 'autopositionnement questionnaire' do
   auto_positionnement.questions_et_reponses(:jauge).each do |question, reponse|
     div class: 'row' do
       div class: 'col intitule-question' do
-        div question.transcription_intitule&.ecrit
+        para question.transcription_intitule&.ecrit
       end
       div class: 'col' do
         div class: 'jauge' do

--- a/app/views/components/_banniere_solutions_illettrisme.html.erb
+++ b/app/views/components/_banniere_solutions_illettrisme.html.erb
@@ -1,7 +1,9 @@
 <div class="banniere-solutions-illettrisme d-flex">
   <%= image_tag 'information.svg', class: 'mr-3', alt: '' unless asterisque %>
   <div class="banniere__description font-italic">
-    <%= '*' if asterisque %>
+    <% if asterisque %>
+      <span id="asterisque">*</span>
+    <% end %>
     <%= t('.description') %>
     <a href="<%= t('.lien') %>" target="_blank"><%= t('.lien') %></a>
   </div>

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -204,7 +204,7 @@ fr:
 
             D'après nos enquêtes, seulement **25% des personnes en illettrisme potentiel réussissent à entrer en formation.**
 
-            **Avez-vous été en mesure d’orienter cette personne vers une solution d’accompagnement adaptée* ?**
+            **Avez-vous été en mesure d’orienter cette personne vers une solution d’accompagnement adaptée<a href="#asterisque" class="lien-secondaire" title="aller à la description pistes de solutions"><sup>*</sup></a> ?**
       parties:
         titre: Administration
         rapport: Rapport


### PR DESCRIPTION
10.9 - Majeur : les notes de bas de page de type (1) ou * sont seulement signalées par la forme
<img width="701" alt="Capture d’écran 2024-11-15 à 16 27 23" src="https://github.com/user-attachments/assets/0e21b0b2-1892-46f7-929c-d47f24b44b6a">

Au passage, j'ai aussi ajouté une balise paragraphe aux intitulés des questions
(8.9 - Mineur : Absence de balise à valeur sémantique)