### PR TITLE
Accessibilité : explicite les liens retour des pages hors connexion

### DIFF
--- a/app/assets/stylesheets/admin/pages/_logged_out.scss
+++ b/app/assets/stylesheets/admin/pages/_logged_out.scss
@@ -70,6 +70,8 @@ body.logged_out {
         line-height: 1.875rem;
         font-weight: bold;
         margin-top: 3rem;
+        max-width: 17rem;
+        text-align: center;
         + h2 {
           margin-top: 1rem;
         }
@@ -241,6 +243,7 @@ body.logged_out {
     a {
       color: $eva_main_blue;
       float: none;
+      margin: 0;
     }
   }
 
@@ -293,7 +296,6 @@ body.logged_out {
     margin-bottom: 1.5rem;
     p {
       margin-bottom: 1rem;
-      padding-right: 1.5rem;
     }
   }
 }

--- a/app/assets/stylesheets/admin/pages/login/_structures.scss
+++ b/app/assets/stylesheets/admin/pages/login/_structures.scss
@@ -1,7 +1,7 @@
 .index {
   .lien-retour {
     position: absolute;
-    left: -8rem;
+    left: -8.5rem;
   }
 }
 
@@ -14,7 +14,7 @@
   .conteneur-elargi {
     .lien-retour {
       position: absolute;
-      left: -12.313rem;
+      left: -13rem;
     }
   }
 }

--- a/app/views/active_admin/devise/passwords/edit.html.erb
+++ b/app/views/active_admin/devise/passwords/edit.html.erb
@@ -2,8 +2,11 @@
   <% content_for :titre do %>
     <%= t('active_admin.devise.change_password.title') -%>
   <% end %>
-  <%= link_to t('.lien_retour'), new_compte_session_path, class: 'lien-retour' %>
   <div id="login" class="panel">
+    <%= link_to t('.lien_retour'),
+                new_compte_session_path,
+                class: 'lien-retour',
+                aria: { label: t('.description_lien_retour') } %>
     <div class='mot-de-passe-instruction'>
       <p class='mot-de-passe-instruction--consigne'><%= t('.consigne') %></p>
       <p><%= t(@regles_mot_de_passe, scope: 'creation_compte', longueur_mot_de_passe: Devise.password_length.first)%></p>

--- a/app/views/active_admin/devise/passwords/new.html.erb
+++ b/app/views/active_admin/devise/passwords/new.html.erb
@@ -2,9 +2,11 @@
   <% content_for :titre do %>
     <%= t('active_admin.devise.reset_password.title') -%>
   <% end %>
-
-  <%= link_to t('.lien_retour'), new_compte_session_path, class: 'lien-retour' %>
   <div id="login" class="panel">
+    <%= link_to t('.lien_retour'),
+                new_compte_session_path,
+                class: 'lien-retour',
+                aria: { label: t('.description_lien_retour') } %>
     <%= render partial: "active_admin/devise/shared/messages_erreurs_generales", resource: resource, locals: { champs_affiches: [:email] } %>
     <%= active_admin_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
       if params[:token_invalide]

--- a/app/views/active_admin/devise/registrations/new.html.erb
+++ b/app/views/active_admin/devise/registrations/new.html.erb
@@ -8,13 +8,14 @@
   <% content_for :sous_titre do %>
     <%= resource.structure&.nom -%>
   <% end %>
-  <%= link_to t('.lien_retour'),
-              structures_path(
-                code_postal: params[:code_postal],
-                ville_ou_code_postal: params[:ville_ou_code_postal]
-              ),
-              class: 'lien-retour' %>
   <div id="login" class="panel">
+    <%= link_to t('.lien_retour'),
+                structures_path(
+                  code_postal: params[:code_postal],
+                  ville_ou_code_postal: params[:ville_ou_code_postal]
+                ),
+                class: 'lien-retour',
+                aria: { label: t('.description_lien_retour') } %>
     <h3><%= t('.instruction') -%></h3>
     <p><%= t('.description') -%></p>
 

--- a/app/views/nouvelles_structures/show.html.erb
+++ b/app/views/nouvelles_structures/show.html.erb
@@ -14,7 +14,10 @@
   <%= compte.semantic_errors *champs_non_affiches(compte.object.errors.messages.keys,[:prenom, :nom, :telephone, :email, :password, :password_confirmation, :"structure.nom", :"structure.code_postal", :"structure.type_structure"]) %>
   <%= compte.semantic_fields_for :structure do |structure| %>
     <div class="panel">
-      <%= link_to t('.lien_retour'), structures_path, class: 'lien-retour' %>
+      <%= link_to t('.lien_retour'),
+                  structures_path,
+                  class: 'lien-retour',
+                  aria: { label: t('.description_lien_retour') } %>
       <h3><%= t('.compte.titre') %></h3>
       <%= compte.inputs do %>
         <%= compte.input :prenom %>

--- a/app/views/structures/index.html.erb
+++ b/app/views/structures/index.html.erb
@@ -5,7 +5,10 @@
       <%= t('.titre') -%>
     <% end %>
 
-    <%= link_to t('.lien_retour'), new_compte_session_path, class: 'lien-retour' %>
+    <%= link_to t('.lien_retour'),
+                new_compte_session_path,
+                class: 'lien-retour',
+                aria: { label: t('.description_lien_retour') } %>
     <%= md t('.description')%>
     <%= render(@recherche_structure_component) %>
   </div>

--- a/config/locales/activeadmin.yml
+++ b/config/locales/activeadmin.yml
@@ -49,11 +49,14 @@ fr:
           description: Nous enverons un email à la personne admininstratrice de votre structure pour qu'elle vous autorise l'accès complet.
           nouvelle_structure_html: Si vous ne trouvez pas votre structure, <a href="%{lien}">enregistrez-la ici</a>
           lien_retour: Rechercher ma structure
+          description_lien_retour: Retour à la recherche de structure
       passwords:
         new:
           lien_retour: Se connecter
+          description_lien_retour: Retour à la page de connexion
         edit:
           lien_retour: Se connecter
+          description_lien_retour: Retour à la page de connexion
           consigne: Saisissez et confirmez votre nouveau mot de passe ci-dessous.
           token_invalide: Votre lien de réinitialisation n’est pas valide.
           submit: Valider mon nouveau mot de passe

--- a/config/locales/components/recheche_structure.yml
+++ b/config/locales/components/recheche_structure.yml
@@ -3,5 +3,4 @@ fr:
     aucun_resultat: "Nous n'avons pas trouvé de structure référencée dans eva pour cette recherche."
     bouton_recherche_structure: Chercher
     label_champ_recherche: Entrez la localisation de la structure
-    lien_retour: Se connecter
     placeholder_recherche: Code postal ou ville

--- a/config/locales/views/structures.yml
+++ b/config/locales/views/structures.yml
@@ -6,6 +6,8 @@ fr:
       description: |
         **Vous souhaitez créer un compte conseiller eva.**
         Dans un premier temps merci de regarder si votre structure est déjà enregistrée.
+      lien_retour: Se connecter
+      description_lien_retour: Retour à la page de connexion
   admin:
     structures:
       show:
@@ -62,3 +64,4 @@ fr:
           Si vous avez des difficultés, vous pouvez nous contacter à : [%{email_contact}](mailto:%{email_contact})
       creer_structure: Valider la création de mon compte
       lien_retour: Rechercher ma structure
+      description_lien_retour: Retour à la recherche de structure


### PR DESCRIPTION

<img width="719" alt="Capture d’écran 2024-11-25 à 16 15 23" src="https://github.com/user-attachments/assets/0da725fd-bebf-4794-83b8-c08de4ae0831">


Au passage, cette PR répare aussi un peu la mise en forme des formulaires de mots de passe.
Exemple ici avec « mot de passe oublié » : 
Avant :
<img width="721" alt="Capture d’écran 2024-11-25 à 16 13 47" src="https://github.com/user-attachments/assets/752a006d-c472-4ca4-b329-3a7536c69cc7">

Après :
<img width="706" alt="Capture d’écran 2024-11-25 à 16 13 53" src="https://github.com/user-attachments/assets/09d63c58-0911-4397-8d7b-8e4d2648f8c6">
