### PR TITLE
🐛 N'attribue le niveau 2 que quand on a commencé le niveau 2

### DIFF
--- a/app/models/restitution/place_du_marche.rb
+++ b/app/models/restitution/place_du_marche.rb
@@ -49,6 +49,7 @@ module Restitution
         profil_numeratie: profil_numeratie }
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def niveau_numeratie
       niveau = 0
       n1 = pourcentage_de_reussite_pour(:N1)
@@ -58,12 +59,13 @@ module Restitution
       n3 = pourcentage_de_reussite_pour(:N3)
 
       niveau = 1
-      niveau = 2 if n1 > SEUIL_MINIMUM
-      niveau = 3 if n2 && n2 > SEUIL_MINIMUM
+      niveau = 2 if n2 && n1 > SEUIL_MINIMUM
+      niveau = 3 if n3 && n2 > SEUIL_MINIMUM
       niveau = 4 if n3 && n3 > SEUIL_MINIMUM
 
       niveau
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     def profil_numeratie
       return ::Competence::NIVEAU_INDETERMINE if niveau_numeratie.zero?

--- a/spec/models/restitution/place_du_marche_spec.rb
+++ b/spec/models/restitution/place_du_marche_spec.rb
@@ -202,7 +202,7 @@ describe Restitution::PlaceDuMarche do
         allow(restitution).to receive(:pourcentage_de_reussite_pour).with(:N2).and_return nil
       end
 
-      it { expect(restitution.niveau_numeratie).to eq 2 }
+      it { expect(restitution.niveau_numeratie).to eq 1 }
     end
 
     context 'quand le pourcentage de réussite pour N2 est inférieur à 70 et N3 est nil' do


### PR DESCRIPTION
car le pourcentage ne se fait pas forcement sur toute les questions.

Par exemple, je répond à une question correctement et que je m'arrête, j'ai un pourcentage de 100 au niveau 1