### PR TITLE
🐛 Corrige les liens vers la liste des évènements depuis une évaluation

### DIFF
--- a/app/admin/parties.rb
+++ b/app/admin/parties.rb
@@ -35,7 +35,7 @@ ActiveAdmin.register Partie do
       link_to t('.evenements'),
               admin_campagne_evenements_path(
                 partie.campagne,
-                q: { 'session_id_equals' => partie.session_id }
+                q: { session_id_eq: partie.session_id }
               )
     end
   end

--- a/app/views/admin/evaluations/_parties.html.arb
+++ b/app/views/admin/evaluations/_parties.html.arb
@@ -17,7 +17,7 @@ if can?(:manage, Compte)
           span link_to t('.evenements'),
                        admin_campagne_evenements_path(
                          resource.campagne,
-                         q: { 'session_id_equals' => partie.session_id }
+                         q: { session_id_eq: partie.session_id }
                        )
         end
       end


### PR DESCRIPTION
Le scope Ransack a changé depuis le passage à la dernière version