### PR TITLE
♿️ Hiérarchie des titres de la page « recherche structure »

### DIFF
--- a/app/assets/stylesheets/admin/composants/_recherche_structure.scss
+++ b/app/assets/stylesheets/admin/composants/_recherche_structure.scss
@@ -19,8 +19,12 @@
       background-image: image-url('punaise-recherche.svg');
     }
   }
-  .description-liste-structures {
+
+  h3.description-liste-structures {
+    @include texte;
     margin-bottom: 1rem;
     color: $eva_main_blue;
+    font-family: $font-texte;
+    font-weight: normal;
   }
 }

--- a/app/assets/stylesheets/admin/composants/_rejoindre_structure.scss
+++ b/app/assets/stylesheets/admin/composants/_rejoindre_structure.scss
@@ -9,7 +9,7 @@
   .infos {
     max-width: 16.25rem;
     .sous-infos {
-      margin-top: .75rem;
+      margin: .75rem 0 0 0;
       font-size: .75rem;
     }
   }

--- a/app/assets/stylesheets/admin/pages/_logged_out.scss
+++ b/app/assets/stylesheets/admin/pages/_logged_out.scss
@@ -6,6 +6,28 @@ body.logged_out {
   font-size: .875rem;
   background-color: $eva_light;
 
+  h2 {
+    padding: 0;
+    margin: 0 0 1.125rem;;
+    font-size: 1.125rem;
+    font-family: $font-titre;
+    text-shadow: none;
+    box-shadow: none;
+    color: $grey-50;
+    background: none;
+  }
+
+  h3 {
+    @include titre-carte;
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+    margin-bottom: 1.25rem;
+    padding: 0;
+    + .description {
+      margin-bottom: 0;
+    }
+  }
+
   #wrapper {
     flex-direction: column;
     display: flex;
@@ -78,30 +100,6 @@ body.logged_out {
       }
       h2 {
         font-size: 1rem;
-      }
-    }
-
-    h2 {
-      padding: 0;
-      margin: 0 0 1.125rem;;
-      font-size: 1.125rem;
-      font-family: $font-titre;
-      text-shadow: none;
-      border-top-left-radius: 0.5rem;
-      border-top-right-radius: 0.5rem;
-      box-shadow: none;
-      color: $grey-50;
-      background: none;
-    }
-
-    h3 {
-      @include titre-carte;
-      font-size: 1.25rem;
-      line-height: 1.5rem;
-      margin-bottom: 1.25rem;
-      padding: 0;
-      + .description {
-        margin-bottom: 0;
       }
     }
 

--- a/app/components/recherche_structure_component.html.erb
+++ b/app/components/recherche_structure_component.html.erb
@@ -10,7 +10,7 @@
 
   <% if @ville_ou_code_postal.present? %>
     <% if @structures_code_postal.present? %>
-      <p class="description-liste-structures mt-4"><%= @structures_code_postal.size %> résultat(s) pour <%= @code_postal %></p>
+      <h3 class="description-liste-structures mt-4"><%= t('.titre_resultats', count: @structures_code_postal.size, code_postal: @code_postal) %></h3>
       <% @structures_code_postal.each do |structure| %>
         <%= render(RejoindreStructureComponent.new(structure, @current_compte)) %>
       <% end %>
@@ -19,7 +19,7 @@
     <% end %>
 
     <% if @structures.present? %>
-      <p class="description-liste-structures mt-4">Structures à proximité</p>
+      <h3 class="description-liste-structures mt-4"><%= t('.titre_resultats_proches', count: @structures.size) %></h3>
       <% @structures.each do |structure| %>
         <%= render(RejoindreStructureComponent.new(structure, @current_compte)) %>
       <% end %>

--- a/app/components/rejoindre_structure_component.html.erb
+++ b/app/components/rejoindre_structure_component.html.erb
@@ -1,7 +1,7 @@
 <div class="rejoindre-structure">
   <div class="infos" id="<%= @structure.id %>" >
     <h4><%= @structure.nom %></h4>
-    <div class="sous-infos"><strong><%= t('.code_postal') %></strong><%= @structure.code_postal %></div>
+    <p class="sous-infos"><strong><%= t('.code_postal') %></strong><%= @structure.code_postal %></p>
   </div>
   <% if @current_compte.present? %>
     <%= link_to t('.rejoindre_structure'),

--- a/app/views/active_admin/devise/registrations/new.html.erb
+++ b/app/views/active_admin/devise/registrations/new.html.erb
@@ -9,7 +9,7 @@
     <%= resource.structure&.nom -%>
   <% end %>
   <div id="login" class="panel">
-    <%= link_to t('.lien_retour'),
+    <%= link_to t('structures.index.title'),
                 structures_path(
                   code_postal: params[:code_postal],
                   ville_ou_code_postal: params[:ville_ou_code_postal]

--- a/app/views/admin/recherche_structure/_recherche_structure.html.erb
+++ b/app/views/admin/recherche_structure/_recherche_structure.html.erb
@@ -1,5 +1,4 @@
 <div class="col col-8 panel">
-  <h2><%= t('.titre') %></h2>
   <p><%= t('.message_accueil') %></p>
   <%= render(@recherche_structure_component) %>
 </div>

--- a/app/views/structures/index.html.erb
+++ b/app/views/structures/index.html.erb
@@ -4,6 +4,9 @@
     <% content_for :titre do %>
       <%= t('.titre') -%>
     <% end %>
+    <% content_for :sous_titre do %>
+      <%= t('.title') -%>
+    <% end %>
 
     <%= link_to t('.lien_retour'),
                 new_compte_session_path,

--- a/config/locales/components/recheche_structure.yml
+++ b/config/locales/components/recheche_structure.yml
@@ -4,3 +4,11 @@ fr:
     bouton_recherche_structure: Chercher
     label_champ_recherche: Entrez la localisation de la structure
     placeholder_recherche: Code postal ou ville
+    titre_resultats:
+      zero: ""
+      one: "1 résultat pour %{code_postal}"
+      other: "%{count} résultats pour %{code_postal}"
+    titre_resultats_proches:
+      zero: ""
+      one: Structure à proximité
+      other: Structures à proximité

--- a/config/locales/views/recherche_structure.yml
+++ b/config/locales/views/recherche_structure.yml
@@ -2,5 +2,4 @@ fr:
   admin:
     recherche_structure:
       recherche_structure:
-        titre: Quelle est votre structure ?
         message_accueil: Avant de pouvoir commencer à utiliser eva en tant que conseiller ou conseillère, vous devez retrouver votre structure pour la rejoindre.

--- a/config/locales/views/structures.yml
+++ b/config/locales/views/structures.yml
@@ -63,5 +63,4 @@ fr:
           **Veuillez vérifier les informations saisies avant de valider votre inscription.**
           Si vous avez des difficultés, vous pouvez nous contacter à : [%{email_contact}](mailto:%{email_contact})
       creer_structure: Valider la création de mon compte
-      lien_retour: Rechercher ma structure
       description_lien_retour: Retour à la recherche de structure


### PR DESCRIPTION
9.1 - Majeur : Présence d’un titre de hiérarchie simulé
8.9 - Mineur : Absence de balise à valeur sémantique

<img width="684" alt="Capture d’écran 2024-12-02 à 15 57 47" src="https://github.com/user-attachments/assets/3f193503-5c8b-4a92-a165-814740e5ea07">

<img width="733" alt="Capture d’écran 2024-12-02 à 15 58 25" src="https://github.com/user-attachments/assets/186a2022-f3b3-4f29-9c41-d071c918c408">

<img width="921" alt="Capture d’écran 2024-12-02 à 16 00 22" src="https://github.com/user-attachments/assets/43d10ac7-f4f1-4f3b-b948-23eaa1c269ef">
