### PR TITLE
Garde le meilleure score entre le module normal et le rattrapage du niveau 2 et 3 si rattrapage il y a

### DIFF
--- a/app/models/restitution/evacob/score_module.rb
+++ b/app/models/restitution/evacob/score_module.rb
@@ -12,8 +12,25 @@ module Restitution
         'N1Poa' => 'N1Roa',
         'N1Pos' => 'N1Ros',
         'N1Pvn' => nil,
-        'N2' => nil,
-        'N3' => nil
+        'N2Plp' => 'N2Rlp',
+        'N2Ppe' => 'N2Rpe',
+        'N2Psu' => 'N2Rsu',
+        'N2Pom' => 'N2Rom',
+        'N2Pon' => 'N2Ron',
+        'N2Pod' => 'N2Rod',
+        'N2Put' => 'N2Rut',
+        'N2Prh' => 'N2Rrh',
+        'N2Ptg' => 'N2Rtg',
+        'N2Ppl' => 'N2Rpl',
+        'N3Ppl' => 'N3Rpl',
+        'N3Put' => 'N3Rut',
+        'N3Pum' => nil,
+        'N3Pim' => nil,
+        'N3Ppo' => 'N3Rpo',
+        'N3Ppr' => 'N3Rpr',
+        'N3Pps' => 'N3Rps',
+        'N3Pvo' => 'N3Rvo',
+        'N3Prp' => 'N3Rrp'
       }.freeze
 
       def calcule(evenements, nom_module, avec_rattrapage: false)

--- a/spec/models/restitution/place_du_marche_spec.rb
+++ b/spec/models/restitution/place_du_marche_spec.rb
@@ -17,13 +17,13 @@ describe Restitution::PlaceDuMarche do
               donnees: { succes: true, question: 'N1Prn1', scoreMax: 1, score: 1 },
               partie: partie),
         build(:evenement_reponse,
-              donnees: { succes: true, question: 'N2Q1', score: 0.5, scoreMax: 0.5 },
+              donnees: { succes: true, question: 'N2Pod1', score: 0.5, scoreMax: 0.5 },
               partie: partie),
         build(:evenement_reponse,
-              donnees: { succes: false, question: 'N2Q2', score: 0, scoreMax: 0.5 },
+              donnees: { succes: false, question: 'N2Pod2', score: 0, scoreMax: 0.5 },
               partie: partie),
         build(:evenement_reponse,
-              donnees: { succes: false, scoreMax: 1, question: 'N3Q1' },
+              donnees: { succes: false, scoreMax: 1, question: 'N3Ppo' },
               partie: partie)
       ]
     )
@@ -65,7 +65,7 @@ describe Restitution::PlaceDuMarche do
                                     partie: partie),
                               build(:evenement_reponse,
                                     donnees: { succes: true,
-                                               question: 'N2',
+                                               question: 'N2Pod1',
                                                score: 0.5 },
                                     partie: partie)
                             ])
@@ -100,7 +100,7 @@ describe Restitution::PlaceDuMarche do
                                                                    score: 2 },
                                                         partie: partie),
                               build(:evenement_reponse, donnees: { succes: true,
-                                                                   question: 'N2',
+                                                                   question: 'N2Pod1',
                                                                    score: 0.5 },
                                                         partie: partie)
                             ])


### PR DESCRIPTION
Cette PR ajoute la configuration pour permettre le recalcule des scores des niveau 2 et 3 si du rattrapage a été passé.
Initialement, on avait intégré le niveau 2 et 3 avec une seul question de test "N2" et "N3".