### PR TITLE
Eva-261 - Renommer le type de saisie prix centimes et retirer le suffix € automatique

### DIFF
--- a/app/models/question_saisie.rb
+++ b/app/models/question_saisie.rb
@@ -5,12 +5,12 @@ class QuestionSaisie < Question
   QUESTION_TYPE = 'QuestionSaisie'
 
   enum :metacompetence, Metacompetence::METACOMPETENCES
-  enum :type_saisie, { redaction: 0, numerique: 1, texte: 2, prix_avec_centimes: 3 }
+  enum :type_saisie, { redaction: 0, numerique: 1, texte: 2, nombre_avec_virgule: 3 }
 
   has_many :reponses, class_name: 'Choix', foreign_key: :question_id, dependent: :destroy
   accepts_nested_attributes_for :reponses, allow_destroy: true
 
-  before_save :parametre_prix_avec_centimes, if: -> { type_saisie == 'prix_avec_centimes' }
+  before_save :parametre_nombre_avec_virgule, if: -> { type_saisie == 'nombre_avec_virgule' }
 
   def as_json(_options = nil)
     json = base_json
@@ -21,7 +21,7 @@ class QuestionSaisie < Question
     reponses.where(type_choix: :bon)&.pluck(:intitule)&.join(' | ')
   end
 
-  def parametre_prix_avec_centimes
+  def parametre_nombre_avec_virgule
     self.reponse_placeholder = '0,00' if reponse_placeholder.blank?
     self.suffix_reponse = '€' if suffix_reponse.blank?
   end
@@ -44,7 +44,7 @@ class QuestionSaisie < Question
       'description' => description,
       'texte_a_trous' => texte_a_trous,
       'aide' => aide,
-      'max_length' => type_saisie == 'prix_avec_centimes' ? 6 : nil
+      'max_length' => type_saisie == 'nombre_avec_virgule' ? 6 : nil
     }
   end
 

--- a/app/views/admin/questions_saisies/_form.html.arb
+++ b/app/views/admin/questions_saisies/_form.html.arb
@@ -9,9 +9,9 @@ active_admin_form_for [:admin, resource] do |f|
     f.input :description
     render partial: 'admin/questions/input_illustration', locals: { f: f }
 
+    f.input :type_saisie
     f.input :suffix_reponse
     f.input :reponse_placeholder
-    f.input :type_saisie
     f.input :texte_a_trous, input_html: { rows: 10 }
     f.input :aide, as: :text, input_html: { class: 'simple-mde-editor' }
   end

--- a/config/locales/models/question.yml
+++ b/config/locales/models/question.yml
@@ -32,9 +32,11 @@ fr:
         illustration: Image de fond de la question
         type_qcm: Type QCM
       question_saisie:
-        suffix_reponse: Suffix réponse
-        reponse_placeholder: Réponse placeholder
+        type_saisie: Type de saisie
+        suffix_reponse: Suffix de la réponse
+        reponse_placeholder: Placeholder
         bonne_reponse: Bonne réponse
+        texte_a_trous: Texte à trous
       question_glisser_deposer:
         reponses: Réponses
     errors:

--- a/db/migrate/20241216134408_renomme_prix_avec_centimes_en_nombre_avec_virgule_sur_questions_saisie.rb
+++ b/db/migrate/20241216134408_renomme_prix_avec_centimes_en_nombre_avec_virgule_sur_questions_saisie.rb
@@ -1,0 +1,9 @@
+class RenommePrixAvecCentimesEnNombreAvecVirguleSurQuestionsSaisie < ActiveRecord::Migration[7.2]
+  def up
+    QuestionSaisie.where(type_saisie: 'prix_avec_centimes').update_all(type_saisie: 'nombre_avec_virgule', suffix_reponse: '€')
+  end
+
+  def down
+    QuestionSaisie.where(type_saisie: 'nombre_avec_virgule').update_all(type_saisie: 'prix_avec_centimes')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_11_075936) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_16_134408) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/spec/models/question_saisie_spec.rb
+++ b/spec/models/question_saisie_spec.rb
@@ -71,12 +71,12 @@ describe QuestionSaisie, type: :model do
     end
   end
 
-  describe '#parametre_prix_avec_centimes' do
+  describe '#parametre_nombre_avec_virgule' do
     context 'sans reponse_placeholder et suffix_reponse spécifiés' do
-      let(:question_saisie) { create(:question_saisie, type_saisie: 'prix_avec_centimes') }
+      let(:question_saisie) { create(:question_saisie, type_saisie: 'nombre_avec_virgule') }
 
       it 'paramétre les champs par défaut' do
-        question_saisie.parametre_prix_avec_centimes
+        question_saisie.parametre_nombre_avec_virgule
         expect(question_saisie.reponse_placeholder).to eql('0,00')
         expect(question_saisie.suffix_reponse).to eql('€')
       end
@@ -84,7 +84,7 @@ describe QuestionSaisie, type: :model do
 
     context 'avec reponse_placeholder et suffix_reponse spécifiés' do
       let(:question_saisie) do
-        create(:question_saisie, type_saisie: 'prix_avec_centimes', reponse_placeholder: '1.000',
+        create(:question_saisie, type_saisie: 'nombre_avec_virgule', reponse_placeholder: '1.000',
                                  suffix_reponse: '$')
       end
 
@@ -94,7 +94,7 @@ describe QuestionSaisie, type: :model do
       end
     end
 
-    context 'quand le type de saisie n est pas prix_avec_centimes' do
+    context 'quand le type de saisie n est pas nombre_avec_virgule' do
       let(:question_saisie) { create(:question_saisie, type_saisie: 'texte') }
 
       it 'ne met pas à jour les champs' do


### PR DESCRIPTION
![Capture d’écran 2024-12-16 à 15 01 38](https://github.com/user-attachments/assets/8bdf1ed7-f574-459c-9501-98e9ac7584cb)
