### PR TITLE
Améliore performance sur les évaluations

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -146,6 +146,12 @@ ActiveAdmin.register Evaluation do
 
     private
 
+    def find_resource
+      scoped_collection.where(id: params[:id])
+                       .includes(campagne: { situations_configurations: :situation })
+                       .first!
+    end
+
     def statistiques
       @statistiques ||= StatistiquesEvaluation.new(resource)
     end

--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register Evaluation do
   permit_params :campagne_id, :nom, :beneficiaire_id, :statut, :responsable_suivi_id
   menu priority: 4, if: proc { current_compte.structure_id.present? && can?(:read, Evaluation) }
 
-  includes :responsable_suivi, campagne: [:parcours_type, { compte: [:structure] }]
+  includes :responsable_suivi, campagne: [:parcours_type]
 
   config.sort_order = 'created_at_desc'
 

--- a/app/models/evenement.rb
+++ b/app/models/evenement.rb
@@ -39,9 +39,9 @@ class Evenement < ApplicationRecord
   def self.questions_repondues_et_non_repondues(questionnaire, noms_techniques)
     noms_techniques_repondues = (noms_techniques + questions_repondues).flatten
     non_repondues = questionnaire.questions
-                                 .includes(:illustration_attachment, :transcription_consigne,
-                                           :transcription_intitule, :transcription_modalite_reponse)
                                  .non_repondues(noms_techniques_repondues)
+                                 .preload_all_pour_as_json
+
     non_repondues = non_repondues.map(&:as_json).each do |q|
       q['scoreMax'] = q.delete('score')
       q['question'] = q.delete('nom_technique')

--- a/app/models/evenement.rb
+++ b/app/models/evenement.rb
@@ -11,18 +11,6 @@ class Evenement < ApplicationRecord
   acts_as_paranoid
 
   scope :reponses, -> { where(nom: 'reponse') }
-  scope :questions_repondues_et_non_repondues, lambda { |questionnaire, noms_techniques|
-    noms_techniques_repondues = (noms_techniques + questions_repondues).flatten
-    non_repondues = questionnaire.questions
-                                 .includes(:illustration_attachment, :transcription_consigne,
-                                           :transcription_intitule, :transcription_modalite_reponse)
-                                 .non_repondues(noms_techniques_repondues)
-    non_repondues = non_repondues.map(&:as_json).each do |q|
-      q['scoreMax'] = q.delete('score')
-      q['question'] = q.delete('nom_technique')
-    end
-    reponses.map(&:donnees) + non_repondues
-  }
 
   def fin_situation?
     nom == 'finSituation'
@@ -46,5 +34,18 @@ class Evenement < ApplicationRecord
         Metacompetence.new(e['metacompetence']).code_clea_sous_sous_domaine
       end
     end
+  end
+
+  def self.questions_repondues_et_non_repondues(questionnaire, noms_techniques)
+    noms_techniques_repondues = (noms_techniques + questions_repondues).flatten
+    non_repondues = questionnaire.questions
+                                 .includes(:illustration_attachment, :transcription_consigne,
+                                           :transcription_intitule, :transcription_modalite_reponse)
+                                 .non_repondues(noms_techniques_repondues)
+    non_repondues = non_repondues.map(&:as_json).each do |q|
+      q['scoreMax'] = q.delete('score')
+      q['question'] = q.delete('nom_technique')
+    end
+    reponses.map(&:donnees) + non_repondues
   end
 end

--- a/app/models/fabrique_restitution.rb
+++ b/app/models/fabrique_restitution.rb
@@ -14,7 +14,7 @@ class FabriqueRestitution
 
     def restitution_globale(evaluation, parties_selectionnees_ids = nil)
       restitutions_retenues = instancie_restitutions(evaluation, parties_selectionnees_ids)
-      Restitution::Globale.new restitutions: restitutions_retenues, evaluation: evaluation
+      Restitution::Globale.new evaluation: evaluation, restitutions: restitutions_retenues
     end
 
     def instancie_restitutions(evaluation, parties_selectionnees_ids = nil)

--- a/app/models/question_clic_dans_image.rb
+++ b/app/models/question_clic_dans_image.rb
@@ -40,6 +40,10 @@ class QuestionClicDansImage < Question
     cdn_for(image_au_clic)
   end
 
+  def self.preload_assocations_pour_as_json
+    base_includes_pour_as_json + %i[zone_cliquable_attachment image_au_clic_attachment]
+  end
+
   private
 
   def base_json

--- a/app/models/question_glisser_deposer.rb
+++ b/app/models/question_glisser_deposer.rb
@@ -30,6 +30,10 @@ class QuestionGlisserDeposer < Question
     cdn_for(zone_depot)
   end
 
+  def self.preload_assocations_pour_as_json
+    base_includes_pour_as_json + [:zone_depot_attachment, { reponses: :illustration_attachment }]
+  end
+
   private
 
   def base_json

--- a/app/models/question_qcm.rb
+++ b/app/models/question_qcm.rb
@@ -31,6 +31,10 @@ class QuestionQcm < Question
     choix.where(type_choix: :bon)&.pluck(:intitule)&.join(' | ')
   end
 
+  def self.preload_assocations_pour_as_json
+    base_includes_pour_as_json + [{ choix: :audio_attachment }]
+  end
+
   private
 
   def base_json

--- a/app/models/question_saisie.rb
+++ b/app/models/question_saisie.rb
@@ -26,6 +26,10 @@ class QuestionSaisie < Question
     self.suffix_reponse = '€' if suffix_reponse.blank?
   end
 
+  def self.preload_assocations_pour_as_json
+    base_includes_pour_as_json + [:reponses]
+  end
+
   private
 
   def base_json


### PR DESCRIPTION
+ [⚡️ Preload les associations pour les méthodes as_json sur les questions](https://github.com/betagouv/eva-serveur/commit/8a497169bd3887c7839722d969b86e9b1d10ae6b) 

Du fait de la STI sur les questions, il faut précharger les associations en fonction du type de la question.

La méthode `.preload_all_pour_as_json` se charge de faire cela pour une collection de Question de manière automatique.