### PR TITLE
🐛 Importe le badge profil pour les PDF

### DIFF
--- a/app/assets/stylesheets/pdf/_base.scss
+++ b/app/assets/stylesheets/pdf/_base.scss
@@ -1,5 +1,6 @@
 @import "fonts";
 @import "admin/typography";
+@import 'admin/composants/badge_profil';
 
 // Les deux dimensions suivantes ont été calculées proportionnellement à la taille A4
 // en gardant un DPI constant entre la hauteur et la largeur.


### PR DESCRIPTION
Sinon les badges profil ne sont pas rendu dans le PDF quand on télécharge l'export d'une évaluation