### PR TITLE
🐛 Le jeu ne se lance pas

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,14 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
+# Les methods options et head sont ajoutées pour permettre à l'API de répondre aux requêtes préflight CORS
+
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins '*'
 
     resource '*',
       headers: :any,
-      methods: [:get, :post, :patch]
+      methods: [:get, :post, :patch, :options, :head]
   end
 end


### PR DESCRIPTION
Il y avait des fichiers mp3 qui n'était pas correctement chargé par le navigateur alors que l'appel retourné une 200

L'erreur vient du fait que le serveur n'acceptés pas les méthodes OPTIONS

Documentation : https://medium.com/@chris.lty07/configuring-for-cors-with-ruby-on-rails-part-ii-fb5399a80d64

Origine du problème :
Le 19/08/2024, nous avons retiré :options et :head des cors https://github.com/betagouv/eva-serveur/pull/1628