### PR TITLE
EVA-280 - ⚡️  Réduit le temps de chargement de la situation place du marché

### DIFF
--- a/app/models/question_clic_dans_image.rb
+++ b/app/models/question_clic_dans_image.rb
@@ -21,7 +21,7 @@ class QuestionClicDansImage < Question
 
   def as_json(_options = nil)
     json = base_json
-    json['image_au_clic'] = svg_attachment_base64(image_au_clic) if image_au_clic.attached?
+    json['image_au_clic'] = cdn_for(image_au_clic) if image_au_clic.attached?
     json.merge!(json_audio_fields, additional_json_fields)
   end
 
@@ -52,7 +52,7 @@ class QuestionClicDansImage < Question
       json['type'] = 'clic-dans-image'
       json['illustration'] = cdn_for(illustration) if illustration.attached?
       json['description'] = description
-      json['zone_cliquable'] = svg_attachment_base64(zone_cliquable) if zone_cliquable.attached?
+      json['zone_cliquable'] = cdn_for(zone_cliquable) if zone_cliquable.attached?
     end
   end
 

--- a/app/models/question_clic_dans_image.rb
+++ b/app/models/question_clic_dans_image.rb
@@ -21,7 +21,7 @@ class QuestionClicDansImage < Question
 
   def as_json(_options = nil)
     json = base_json
-    json['image_au_clic'] = cdn_for(image_au_clic) if image_au_clic.attached?
+    json['image_au_clic_url'] = cdn_for(image_au_clic) if image_au_clic.attached?
     json.merge!(json_audio_fields, additional_json_fields)
   end
 
@@ -52,7 +52,7 @@ class QuestionClicDansImage < Question
       json['type'] = 'clic-dans-image'
       json['illustration'] = cdn_for(illustration) if illustration.attached?
       json['description'] = description
-      json['zone_cliquable'] = cdn_for(zone_cliquable) if zone_cliquable.attached?
+      json['zone_cliquable_url'] = cdn_for(zone_cliquable) if zone_cliquable.attached?
     end
   end
 

--- a/app/models/question_glisser_deposer.rb
+++ b/app/models/question_glisser_deposer.rb
@@ -22,7 +22,7 @@ class QuestionGlisserDeposer < Question
 
   def as_json(_options = nil)
     json = base_json
-    json['zone_depot_url'] = svg_attachment_base64(zone_depot) if zone_depot.attached?
+    json['zone_depot_url'] = cdn_for(zone_depot) if zone_depot.attached?
     json.merge!(json_audio_fields, reponses_fields)
   end
 

--- a/spec/models/question_clic_dans_image_spec.rb
+++ b/spec/models/question_clic_dans_image_spec.rb
@@ -36,7 +36,7 @@ describe QuestionClicDansImage, type: :model do
       json = question_clic_dans_image.as_json
       expect(json.keys)
         .to match_array(%w[description id intitule audio_url nom_technique type illustration
-                           modalite_reponse zone_cliquable image_au_clic consigne_audio
+                           modalite_reponse zone_cliquable_url image_au_clic_url consigne_audio
                            score metacompetence demarrage_audio_modalite_reponse])
       expect(json['type']).to eql('clic-dans-image')
       expect(json['intitule']).to eql('Mon Intitulé')

--- a/spec/models/question_clic_dans_image_spec.rb
+++ b/spec/models/question_clic_dans_image_spec.rb
@@ -47,8 +47,8 @@ describe QuestionClicDansImage, type: :model do
                                          intitule.audio
                                        ))
       expect(json['modalite_reponse']).to eql(modalite.ecrit)
-      expect(json['zone_cliquable']).to start_with('http://')
-      expect(json['image_au_clic']).to start_with('http://')
+      expect(json['zone_cliquable_url']).to start_with('http://')
+      expect(json['image_au_clic_url']).to start_with('http://')
     end
   end
 

--- a/spec/models/question_clic_dans_image_spec.rb
+++ b/spec/models/question_clic_dans_image_spec.rb
@@ -47,8 +47,8 @@ describe QuestionClicDansImage, type: :model do
                                          intitule.audio
                                        ))
       expect(json['modalite_reponse']).to eql(modalite.ecrit)
-      expect(json['zone_cliquable']).to start_with('data:image/svg+xml;base64,')
-      expect(json['image_au_clic']).to start_with('data:image/svg+xml;base64,')
+      expect(json['zone_cliquable']).to start_with('http://')
+      expect(json['image_au_clic']).to start_with('http://')
     end
   end
 

--- a/spec/models/question_glisser_deposer_spec.rb
+++ b/spec/models/question_glisser_deposer_spec.rb
@@ -40,7 +40,7 @@ describe QuestionGlisserDeposer, type: :model do
       expect(json['illustration']).to eql(Rails.application.routes.url_helpers.url_for(
                                             question.illustration
                                           ))
-      expect(json['zone_depot_url']).to start_with('data:image/svg+xml;base64,')
+      expect(json['zone_depot_url']).to start_with('http://')
     end
 
     describe 'les reponsesNonClassees' do


### PR DESCRIPTION
En retournant directement les URL des SVG

Car sinon le serveur télécharger un à un les fichiers SVG, ce qui donner un temps de chargement de >10s pour l'api de détail d'une campagne

https://captive-team.atlassian.net/browse/EVA-280