### PR TITLE
🗑️ Supprime la fonction svg_attachment_base64

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,13 +41,6 @@ module ApplicationHelper
     "#{ENV.fetch('PROTOCOLE_SERVEUR')}://#{ENV.fetch('HOTE_STOCKAGE')}/#{fichier.key}?#{param}"
   end
 
-  def svg_attachment_base64(attachment)
-    return unless attachment.attached?
-
-    file_content = attachment.download
-    svg_encode_en_base64(file_content)
-  end
-
   def inline_svg_content(attachment, options = {})
     return unless attachment.attached?
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -27,8 +27,4 @@ class ApplicationRecord < ActiveRecord::Base
 
     ApplicationController.helpers.cdn_for(attachment)
   end
-
-  def svg_attachment_base64(attachment)
-    ApplicationController.helpers.svg_attachment_base64(attachment)
-  end
 end


### PR DESCRIPTION
Elle n'est plus utilisée