### PR TITLE
Corrige l'affichage du lien DSFR de campagne

### DIFF
--- a/app/assets/stylesheets/admin/pages/_campagne.scss
+++ b/app/assets/stylesheets/admin/pages/_campagne.scss
@@ -65,7 +65,7 @@
             }
             td {
               padding-right: 6rem;
-              a {
+              span {
                 padding-right: 2rem;
               }
             }

--- a/app/views/admin/campagnes/_votre_code_campagne.html.arb
+++ b/app/views/admin/campagnes/_votre_code_campagne.html.arb
@@ -22,7 +22,7 @@ div id: 'votre_code_campagne', class: 'row' do
                                      'data-clipboard-text': code
           end
           row(:url) do
-            text_node lien_campagne(campagne)
+            span text_node lien_campagne(campagne)
             url = url_campagne(campagne.code)
             button "Copier l'URL", class: 'bouton-secondaire petit-bouton button copier-coller',
                                    'data-clipboard-text': url


### PR DESCRIPTION
Avant :
<img width="640" alt="Capture d’écran 2025-01-23 à 16 24 17" src="https://github.com/user-attachments/assets/c1ac8f7b-cd9c-414d-91fa-d26a10229297" />

<img width="641" alt="Capture d’écran 2025-01-23 à 16 28 15" src="https://github.com/user-attachments/assets/a66c2b92-4fd4-4cd7-bfce-d13556fa5a27" />
