### PR TITLE
Corrige la restitution suite à l'introduction du DSFR

### DIFF
--- a/app/assets/stylesheets/admin/composants/_card.scss
+++ b/app/assets/stylesheets/admin/composants/_card.scss
@@ -47,6 +47,7 @@
       }
       p {
         margin-bottom: 0.5rem;
+        line-height: 1rem;
       }
       &__button {
         display: flex;

--- a/app/assets/stylesheets/admin/composants/_menu_transverse.scss
+++ b/app/assets/stylesheets/admin/composants/_menu_transverse.scss
@@ -25,6 +25,7 @@
       margin-bottom: 1rem;
       font-size: 1.125rem;
       line-height: 1.313rem;
+      padding-bottom: 0;
     }
     a {
       color: $couleur-texte;

--- a/app/assets/stylesheets/admin/pages/restitution_globale/_base.scss
+++ b/app/assets/stylesheets/admin/pages/restitution_globale/_base.scss
@@ -1,6 +1,10 @@
 .evaluation__restitution-globale {
   font-size: 0.875rem;
   font-family: $font-texte;
+  p {
+    font-size: 0.875rem;
+    line-height: 1rem;
+  }
 
   .panel {
     padding: 3rem 0;

--- a/app/views/admin/evaluations/_menu_sidebar.html.arb
+++ b/app/views/admin/evaluations/_menu_sidebar.html.arb
@@ -18,6 +18,11 @@ div class: 'menu menu-transverse' do
       end
     end
     li do
+      a href: '#competence-numerique' do
+        text_node t('admin.evaluations.restitution_globale.prise_en_main.titre_menu_lateral')
+      end
+    end
+    li do
       a href: '#competences_transversales' do
         text_node t('admin.evaluations.competences_transversales.titre_menu_lateral')
       end

--- a/app/views/admin/evaluations/_restitution_globale.arb
+++ b/app/views/admin/evaluations/_restitution_globale.arb
@@ -62,9 +62,9 @@ div class: 'evaluation__restitution-globale' do
       render 'entete_page', restitution_globale: restitution_globale
 
       if pdf
-        h2 t('.prise_en_main_titre'), class: 'text-center mt-5 mb-4'
+        h2 t('.prise_en_main.titre'), class: 'text-center mt-5 mb-4'
       else
-        h2 t('.prise_en_main_titre')
+        h2 t('.prise_en_main.titre')
       end
 
       div class: 'panel' do

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -63,7 +63,9 @@ fr:
         autopositionnement:
           titre: Profil de la personne
           titre_menu_lateral: Profil de la personne
-        prise_en_main_titre: Compétences numériques
+        prise_en_main:
+          titre: Compétences numériques
+          titre_menu_lateral: Compétences numériques
         legende_titre: 'Les compétences transversales sont des compétences que l’on retrouve dans de nombreux métiers'
       competences_transversales:
         titre: Vos compétences transversales

--- a/spec/features/admin/evaluation_spec.rb
+++ b/spec/features/admin/evaluation_spec.rb
@@ -43,7 +43,7 @@ describe 'Admin - Evaluation', type: :feature do
         end
 
         it 'affiche une restitution' do
-          expect(page).to have_content 'Compétences numériques'
+          expect(page).to have_content 'Maîtrise des fondamentaux de l’informatique'
         end
       end
 
@@ -54,7 +54,7 @@ describe 'Admin - Evaluation', type: :feature do
 
         it "n'affiche pas de restitution si la situation n'est par terminée" do
           visit admin_evaluation_path(mon_evaluation_plan_de_la_ville)
-          expect(page).not_to have_content 'Compétences numériques'
+          expect(page).not_to have_content 'Maîtrise des fondamentaux de l’informatique'
         end
       end
     end
@@ -156,7 +156,7 @@ describe 'Admin - Evaluation', type: :feature do
 
       it 'restitution sans plan de la ville' do
         visit admin_evaluation_path(mon_evaluation)
-        expect(page).not_to have_content 'Compétences numériques'
+        expect(page).not_to have_content 'Maîtrise des fondamentaux de l’informatique'
       end
 
       describe 'en moquant restitution_globale :' do


### PR DESCRIPTION
## Restore le line-heigh d'eva sur les evaluations
Mettre à line-height à 1.5rem sur l'évaluation remet trop en question le design. Je suis revenu au line-height de 1rem

## Corrige le menu latéral
Corrige l'espacement entre les entrées et ajoute une entrée manquante pour la restitution des compétences numériques