### PR TITLE
💄 Corrige le style des sources d'aide

### DIFF
--- a/app/assets/stylesheets/admin/pages/aide/_sources_aide.scss
+++ b/app/assets/stylesheets/admin/pages/aide/_sources_aide.scss
@@ -14,7 +14,8 @@
 
     .illustration {
       margin-right: 1.5rem;
-      height: 100%;
+      height: 150px;
+      width: 111px;
     }
 
     .titre {
@@ -24,6 +25,10 @@
 
     .description {
       font-style: italic;
+      p {
+        line-height: 1rem;
+        font-size: .875rem;
+      }
     }
 
     .action {


### PR DESCRIPTION
Avant : 
<img width="961" alt="Capture d’écran 2025-01-29 à 23 46 58" src="https://github.com/user-attachments/assets/64da27de-98e6-46e2-8638-3385d4214cff" />

Après : 
<img width="948" alt="Capture d’écran 2025-01-29 à 23 47 28" src="https://github.com/user-attachments/assets/6d6bdea9-884f-4229-ab19-0a3b0dd6cf3d" />
