### PR TITLE
💄 Masque l'encart action de la sidebar quand il est vide

### DIFF
--- a/lib/active_admin/actions_items_sidebar/resource_extension.rb
+++ b/lib/active_admin/actions_items_sidebar/resource_extension.rb
@@ -3,18 +3,32 @@
 module ActiveAdmin
   module ActionsItemsSidebar
     module ResourceExtension
+      ACTION_MAP = {
+        'new' => :create,
+        'edit' => :update,
+        'destroy' => :destroy
+      }.freeze
+
       def initialize(*)
         super
         add_action_items_sidebar
       end
 
       def actions_items_sidebar_section
-        displayable = -> { active_admin_config.action_items_for(params[:action], self).any? }
-        ActiveAdmin::SidebarSection.new :action_items, if: displayable,
+        ActiveAdmin::SidebarSection.new :action_items, if: au_moins_une_action_autorisee,
                                                        class: 'action-items-sidebar' do
           insert_tag view_factory.action_items,
                      active_admin_config.action_items_for(params[:action], self)
         end
+      end
+
+      def au_moins_une_action_autorisee
+        lambda {
+          active_admin_config.action_items_for(params[:action], self).any? do |item|
+            action = ACTION_MAP.fetch(item.name.to_s, :read)
+            authorized?(action, active_admin_config.resource_class)
+          end
+        }
       end
 
       def add_action_items_sidebar

--- a/spec/features/structures_spec.rb
+++ b/spec/features/structures_spec.rb
@@ -33,23 +33,47 @@ describe 'Structures', type: :feature do
   end
 
   describe '#show' do
-    let!(:compte) { create :compte_admin }
-
     before { connecte(compte) }
 
-    context "lorsqu'il n'y a pas de campagnes associées à la structure" do
-      it "affiche un message qui explique qu'il n'y a pas de campagne pour le moment" do
-        visit admin_structure_locale_path(compte.structure_id)
-        expect(page).to have_content 'Pas de campagne à afficher pour le moment.'
+    describe 'menu latéral de gestion' do
+      let!(:compte_admin) { create :compte_admin }
+
+      context 'quand je suis connecté avec un compte admin' do
+        let!(:compte) { compte_admin }
+
+        it 'affiche le block Gestion car il y a une action de modification possible' do
+          visit admin_structure_locale_path(compte.structure_id)
+          expect(page).to have_content 'Gestion'
+        end
+      end
+
+      context 'quand je suis connecté avec un compte conseiller' do
+        let!(:compte) { create :compte_conseiller, structure: compte_admin.structure }
+
+        it "n'affiche pas le block Gestion car il n'y a pas d'action possible" do
+          visit admin_structure_locale_path(compte.structure_id)
+          expect(page).not_to have_content 'Gestion'
+        end
       end
     end
 
-    context "lorsqu'il y a des campagnes associées à la structure" do
-      let!(:campagne) { create :campagne, compte: compte }
+    describe 'section campagne' do
+      let!(:compte) { create :compte_admin }
 
-      it 'affiche les campagnes' do
-        visit admin_structure_locale_path(compte.structure_id)
-        expect(page).to have_content campagne.libelle
+      context "lorsqu'il n'y a pas de campagnes associées à la structure" do
+        it "affiche un message qui explique qu'il n'y a pas de campagne pour le moment" do
+          visit admin_structure_locale_path(compte.structure_id)
+          expect(page).to have_content 'Pas de campagne à afficher pour le moment.'
+        end
+      end
+
+      context "lorsqu'il y a des campagnes associées à la structure" do
+        let!(:campagne) { create :campagne, compte: compte }
+
+        it 'affiche les campagnes' do
+          visit admin_structure_locale_path(compte.structure_id)
+          expect(page).to have_content campagne.libelle
+        end
       end
     end
   end


### PR DESCRIPTION
avant : 
<img width="1286" alt="Capture d’écran 2025-02-03 à 17 39 17" src="https://github.com/user-attachments/assets/1d62c406-da87-407b-8535-98dbb072ca27" />

après :
<img width="1315" alt="Capture d’écran 2025-02-03 à 17 38 42" src="https://github.com/user-attachments/assets/e729e122-f1bb-44df-ab8b-7977e20ecc34" />
