### PR TITLE
♿️ Page aide : redimentionenemt de la carte 'support' proportionel plutot que fixe

### DIFF
--- a/app/assets/stylesheets/admin/pages/aide/_contact.scss
+++ b/app/assets/stylesheets/admin/pages/aide/_contact.scss
@@ -17,7 +17,7 @@
     }
     &__support {
       @include carte-avec-ombre();
-      width: 23.75rem;
+      width: 42%;
       padding: 1rem 1.5rem;
       position: absolute;
       top: -1.5rem;


### PR DESCRIPTION
Avant :
<img width="1000" alt="Capture d’écran 2025-02-03 à 18 13 23" src="https://github.com/user-attachments/assets/64ce6211-5c13-4aea-8ccc-08f0960163f4" />

Après : 
<img width="999" alt="Capture d’écran 2025-02-03 à 18 13 09" src="https://github.com/user-attachments/assets/e7c2e4dd-c2d9-4938-b507-b7d503e1a51d" />
