### PR TITLE
Affiche 'Vide' quand il n'y a pas d'image et ne souligne pas les liens

### DIFF
--- a/app/assets/stylesheets/admin/_adaptation_dsfr.scss
+++ b/app/assets/stylesheets/admin/_adaptation_dsfr.scss
@@ -9,6 +9,11 @@ ol > li::marker {
 a, a:link, a:visited {
   text-decoration: none;
 }
+
+a.pas-souligne {
+  background-image: none;
+}
+
 .tarteaucitronSelfLink {
     background-image: none;
     &::after {

--- a/app/views/admin/questions/_show_illustration.html.erb
+++ b/app/views/admin/questions/_show_illustration.html.erb
@@ -2,4 +2,6 @@
   <%= link_to cdn_for(illustration), target: '_blank', rel: 'noopener' do %>
     <%= image_tag cdn_for(illustration), class: 'image-preview', alt: illustration.filename %>
   <% end %>
+<% else %>
+    <span class="empty">Vide</span>
 <% end %>

--- a/app/views/admin/questions/_show_illustration.html.erb
+++ b/app/views/admin/questions/_show_illustration.html.erb
@@ -1,5 +1,5 @@
 <% if illustration.attached? %>
-  <%= link_to cdn_for(illustration), target: '_blank', rel: 'noopener' do %>
+  <%= link_to cdn_for(illustration), target: '_blank', rel: 'noopener', class: 'pas-souligne' do %>
     <%= image_tag cdn_for(illustration), class: 'image-preview', alt: illustration.filename %>
   <% end %>
 <% else %>


### PR DESCRIPTION
Quand il n'y a pas d'image :
<img width="339" alt="Capture d’écran 2025-02-05 à 17 43 58" src="https://github.com/user-attachments/assets/fbce0c13-4aee-41ce-b96d-64ccc90e2b62" />
Quand il y en a une :
<img width="594" alt="Capture d’écran 2025-02-05 à 17 58 14" src="https://github.com/user-attachments/assets/80ea6c36-c201-4ea2-9707-9cf5b8796706" />
