### PR TITLE
♿️ Traductions manquantes réponses Bienvenue non renseigné

### DIFF
--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -16,6 +16,8 @@ fr:
       autopositionnement: &autopositionnement
         questionnaire-auto-positionnement: 'Questionnaire d’auto-positionnement'
         non_renseigne: 'Non renseigné'
+        appareils: Usage du numérique
+        sante: Santé
       questions_reponses_autopositionnement:
         <<: *autopositionnement
       questionnaire_autopositionnement:
@@ -23,9 +25,6 @@ fr:
       donnees_sociodemographiques:
         situation: Situation
         scolarite: Scolarité
-      autopositionnement:
-        appareils: Usage du numérique
-        sante: Santé
       controle:
         <<: *commun
         nombre_trop_tard: 'Nombre de trop tard'


### PR DESCRIPTION
L'entrée `autopositionnement` était écrasé par la re-déclaration présente plus bas dans le fichier.

Affiche bien les accents, mais surtout évite aux lecteur d'écran d'énoncer tout haut que la traduction est manquante
<img width="957" alt="Capture d’écran 2025-02-06 à 10 48 49" src="https://github.com/user-attachments/assets/5a15091e-b86c-4ac5-9760-4ed70de1ec92" />

et ça marche toujours quand tout est renseigné
<img width="933" alt="Capture d’écran 2025-02-06 à 10 49 54" src="https://github.com/user-attachments/assets/9f4db5e0-0251-4830-8e4e-83aeb901632c" />
