### PR TITLE
🐛 Corrige le bug des illustrations (variant) qui disparaissent sans raison

### DIFF
--- a/app/jobs/redimensionne_illustrations_job.rb
+++ b/app/jobs/redimensionne_illustrations_job.rb
@@ -7,7 +7,6 @@ class RedimensionneIllustrationsJob < ApplicationJob
     Question.find_each do |question|
       next unless question.illustration.attached?
 
-      question.illustration.variant(:defaut).destroy
       question.illustration.variant(:defaut).processed
     end
   end


### PR DESCRIPTION
Avant on avait un enchainement de :
```
question.illustration.variant(:defaut).destroy
question.illustration.variant(:defaut).processed
```

Le `.destroy` envoie une demande de suppression du fichier auprès du service (S3). S3 retourne Ok (mais n'a pas encore réellement supprimer le fichier) 

Le `processed` vérifie sur le service (S3) que le fichier n'existe pas, si il n'existe pas, il crée le variant et l'upload sur le service. Or ici le fichier précedemment destroy existe encore potentiellement car S3 ne l'a supprimé pour l'instant. S3 déclenche ainsi la suppression après le `processed`, ce qui fait que notre app considère que le variant existe et que sur le S3, il n'y a plus de fichier