### PR TITLE
🐛 N'affiche pas les liens d'évitement sur les pages non connectées

### DIFF
--- a/app/assets/javascripts/liens_evitement.js
+++ b/app/assets/javascripts/liens_evitement.js
@@ -1,4 +1,7 @@
 window.addEventListener('load', () => {
+  let body_connecte = document.querySelector("body.logged_in")
+  if(!body_connecte) return;
+
   const skiplinks = document.createElement('div');
   skiplinks.className = 'fr-skiplinks';
   skiplinks.id = 'skiplink';
@@ -11,5 +14,5 @@ window.addEventListener('load', () => {
       </ul>
     </nav>
   `;
-  document.body.insertBefore(skiplinks, document.body.firstChild);
+  body_connecte.insertBefore(skiplinks, body_connecte.firstChild);
 });


### PR DESCRIPTION
Il n'y a pas de menu à éviter sur ces pages