### PR TITLE
🐛 Export réponses numératie, le questionnaire ne doit pas être porté par la situation

### DIFF
--- a/app/models/restitution/positionnement/export.rb
+++ b/app/models/restitution/positionnement/export.rb
@@ -2,7 +2,7 @@
 
 module Restitution
   module Positionnement
-    class Export < ::ImportExport::ExportXls # rubocop:disable Metrics/ClassLength
+    class Export < ::ImportExport::ExportXls
       def initialize(partie:)
         super()
         @partie = partie
@@ -11,8 +11,7 @@ module Restitution
 
       def to_xls
         defini_onglets_du_fichier
-        remplie_la_feuille_de_donnee
-        remplie_la_feuille_de_synthese if @partie.situation.numeratie?
+        remplie_les_onglets
         retourne_le_contenu_du_xls
       end
 
@@ -35,38 +34,13 @@ module Restitution
         @onglet_donnees = @export.cree_worksheet_donnees(entetes_donnees)
       end
 
-      def remplie_la_feuille_de_donnee
-        ligne = 1
+      def remplie_les_onglets
         if @partie.situation.litteratie?
-          ligne = remplis_reponses_litteratie(ligne)
+          ExportLitteratie.new(@partie, @onglet_donnees).remplis_reponses(1)
         elsif @partie.situation.numeratie?
-          ligne = remplis_reponses_numeratie(ligne)
+          ExportNumeratie.new(@partie, @onglet_donnees).remplis_reponses(1)
+          remplie_la_feuille_de_synthese
         end
-        ligne
-      end
-
-      def remplis_reponses_litteratie(ligne)
-        export = ExportLitteratie.new(@partie, @onglet_donnees)
-        export.remplis_reponses(ligne)
-      end
-
-      def remplis_reponses_numeratie(ligne)
-        export = ExportNumeratie.new(@partie, @onglet_donnees)
-        export.regroupe_par_codes_clea.each do |code, sous_codes|
-          ligne = remplis_par_sous_domaine(ligne, code, sous_codes, export)
-        end
-        ligne
-      end
-
-      def remplis_par_sous_domaine(ligne, _code, sous_codes, export)
-        sous_codes.each do |sous_code, evenements_questions|
-          ligne = remplis_par_sous_sous_domaine(ligne, sous_code, evenements_questions, export)
-        end
-        ligne
-      end
-
-      def remplis_par_sous_sous_domaine(ligne, _sous_code, evenements_questions, export)
-        export.remplis_reponses(ligne, evenements_questions)
       end
 
       def remplie_la_feuille_de_synthese

--- a/app/models/restitution/positionnement/export_numeratie.rb
+++ b/app/models/restitution/positionnement/export_numeratie.rb
@@ -16,7 +16,7 @@ module Restitution
 
       def evenements_questions(partie)
         evenements_reponses = Evenement.where(session_id: partie.session_id).reponses
-        questions_situation = partie.situation.questionnaire&.questions || []
+        questions_situation = partie.campagne.questionnaire_pour(partie.situation).questions
         questions_situation_repondables = questions_situation.to_a.reject do |question|
           question.type == QuestionSousConsigne::QUESTION_TYPE
         end

--- a/spec/models/restitution/positionnement/export_spec.rb
+++ b/spec/models/restitution/positionnement/export_spec.rb
@@ -11,15 +11,20 @@ describe Restitution::Positionnement::Export do
 
   let(:spreadsheet) { response_service.export.workbook }
   let(:worksheet) { spreadsheet.worksheet(0) }
-  let!(:question1) { create(:question_qcm, nom_technique: 'LOdi1') }
-  let!(:question2) { create(:question_qcm, nom_technique: 'LOdi2') }
+  let!(:question1) { create :question_qcm, nom_technique: 'LOdi1' }
+  let!(:question2) { create :question_qcm, nom_technique: 'LOdi2' }
   let(:questions) { [question1, question2] }
-  let(:questionnaire) { create(:questionnaire, questions: questions) }
-  let(:situation) { create(:situation, questionnaire: questionnaire) }
-  let!(:partie) { create :partie, situation: situation }
+  let(:questionnaire) { create :questionnaire, questions: questions }
+  let(:campagne) { create :campagne }
+  let(:evaluation) { create :evaluation, campagne: campagne }
+  let!(:partie) { create :partie, situation: situation, evaluation: evaluation }
+
+  before do
+    campagne.situations_configurations.create situation: situation, questionnaire: questionnaire
+  end
 
   describe 'pour un export littératie' do
-    let(:situation) { create(:situation_cafe_de_la_place, questionnaire: questionnaire) }
+    let(:situation) { create(:situation_cafe_de_la_place) }
     let(:intitule_question2) do
       'Donc, c’est une émission sur les livres. Quel est le nom du livre dont on parle ?'
     end
@@ -87,8 +92,7 @@ describe Restitution::Positionnement::Export do
   describe 'pour un export numératie' do
     let!(:question) { create :question }
     let(:questions) { [question] }
-    let!(:situation) { create(:situation_place_du_marche, questionnaire: questionnaire) }
-    let!(:partie) { create :partie, situation: situation }
+    let!(:situation) { create(:situation_place_du_marche) }
     let!(:choix) { create(:choix, :mauvais, question_id: question.id, intitule: 'drapeau') }
     let!(:choix2) { create(:choix, :bon, question_id: question.id, intitule: 'couverture') }
     let!(:choix3) { create(:choix, :mauvais, question_id: question.id, intitule: 'autre') }
@@ -215,6 +219,8 @@ describe Restitution::Positionnement::Export do
   end
 
   describe '#nom_du_fichier' do
+    let(:situation) { create :situation }
+
     it "genere le nom du fichier en fonction de l'évaluation" do
       code_de_campagne = partie.evaluation.campagne.code.parameterize
       nom_de_levaluation = partie.evaluation.nom.parameterize.first(15)


### PR DESCRIPTION
Pour garder de la flexibilité, on préfère enregistrer le questionnaire dans la situations_configurations de la campagne.

La solution proposée ici supporte quand même que le questionnaire soir sur la situation, mais ce n'est pas testé directement.

On demande le questionnaire à la campagne.

J'en ai profité pour refactorer un peu et j'ai réussi à retirer quelques exceptions rubocop. Je n'ai quand même pas été jusqu'à traiter le problème de longueur de la class `Positionnement.ExportNumeratie` et je l'ai même un peu aggravé.