### PR TITLE
🐛 L'admin ne doit pas avoir d'erreur 500 quand il supprime et modifie…

### DIFF
--- a/app/models/transcription.rb
+++ b/app/models/transcription.rb
@@ -20,8 +20,15 @@ class Transcription < ApplicationRecord
     cdn_for(audio)
   end
 
-  def supprime_audio(type, suppression_valeur)
-    audio.purge_later if send("#{type}?") && audio.attached? && suppression_valeur == '1'
+  def supprime_audio?(champ, suppression_valeur)
+    send("#{champ}?") &&
+      audio.attached? &&
+      suppression_valeur == '1' &&
+      !nouveau_audio?
+  end
+
+  def nouveau_audio?
+    attachment_changes && attachment_changes['audio'].present?
   end
 
   def complete?

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -12,6 +12,27 @@ describe Question, type: :model do
   it { is_expected.to have_one(:transcription_modalite_reponse).dependent(:destroy) }
   it { is_expected.to have_one(:transcription_consigne).dependent(:destroy) }
 
+  describe '#supprime_attachments' do
+    let(:question) { create :question_clic_dans_image, :avec_images }
+
+    it "supprime l'illustration" do
+      question.update(supprimer_illustration: '1')
+
+      expect(question.illustration.attached?).to be false
+    end
+
+    context 'quand une illustration est supprimé et changé en même temps' do
+      it "ne supprime pas l'illustration" do
+        nouvelle_illustration = Rack::Test::UploadedFile.new(
+          Rails.root.join('spec/support/programme_tele.png')
+        )
+        question.update(illustration: nouvelle_illustration, supprimer_illustration: '1')
+
+        expect(question.illustration.attached?).to be true
+      end
+    end
+  end
+
   describe '#restitue_reponse' do
     context "quand la question saisie n'a pas de choix" do
       let(:question) { create :question_saisie }


### PR DESCRIPTION
… l'image d'une question

Quand on sélectionnait l'option pour supprimer une illustration et ajouter une nouvelle illustration, cela provoquait une erreur 500

Avec ce correctif, on conserve la nouvelle illustration

https://captive-team.atlassian.net/browse/EVA-364