### PR TITLE
🐛 corrige le crash au téléchargement d'un questionnaire

### DIFF
--- a/app/admin/questionnaires.rb
+++ b/app/admin/questionnaires.rb
@@ -3,8 +3,6 @@
 require 'zip'
 
 ActiveAdmin.register Questionnaire do
-  include Fichier
-
   menu parent: 'Parcours', if: proc { can? :manage, Compte }
 
   permit_params :libelle, :nom_technique,
@@ -61,9 +59,7 @@ ActiveAdmin.register Questionnaire do
       compressed_filestream = generate_zip_file(questionnaire.questions_par_type)
 
       send_data compressed_filestream.read,
-                filename: nom_fichier_horodate(
-                  "questionnaire_#{questionnaire.id}_export", 'zip'
-                ),
+                filename: questionnaire.nom_fichier_export,
                 type: 'application/zip'
     end
 

--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Questionnaire < ApplicationRecord
+  include Fichier
+
   LIVRAISON_SANS_REDACTION = 'livraison_sans_redaction'
   LIVRAISON_AVEC_REDACTION = 'livraison_expression_ecrite'
   SOCIODEMOGRAPHIQUE_AUTOPOSITIONNEMENT = 'sociodemographique_autopositionnement'
@@ -37,5 +39,9 @@ class Questionnaire < ApplicationRecord
 
   def questions_par_type
     questions.group_by(&:type)
+  end
+
+  def nom_fichier_export
+    nom_fichier_horodate("export-questionnaire-#{nom_technique}", 'zip')
   end
 end

--- a/spec/models/questionnaire_spec.rb
+++ b/spec/models/questionnaire_spec.rb
@@ -46,4 +46,15 @@ RSpec.describe Questionnaire, type: :model do
       )
     end
   end
+
+  describe '#nom_fichier_export' do
+    let(:questionnaire) { create :questionnaire, nom_technique: 'nom_technique' }
+
+    it "retourn un fichier horodaté avec l'identifiant" do
+      Timecop.freeze(Time.zone.local(2025, 2, 28, 1, 2, 3)) do
+        expect(questionnaire.nom_fichier_export)
+          .to eq '20250228010203-export-questionnaire-nom_technique.zip'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Déplace la responsabilité du nom d'export des questionnaires dans le modèle, pour plus de testabilité.

Au passage, remplace l'utilisation de l'id par le nom technique