### PR TITLE
🐛 Corrige la migration RenommeMetacompetencesPourQuestions

### DIFF
--- a/app/models/metacompetence.rb
+++ b/app/models/metacompetence.rb
@@ -6,7 +6,7 @@ class Metacompetence
       '2.1.1' => %w[operations_addition operations_soustraction operations_multiplication
                     operations_division],
       '2.1.2' => %w[denombrement],
-      '2.1.3' => %w[ordonner_nombres_decimaux operations_nombres_entiers],
+      '2.1.3' => %w[ordonner_nombres_entiers ordonner_nombres_decimaux],
       '2.1.4' => %w[estimation],
       '2.1.5' => %w[],
       '2.1.6' => %w[],

--- a/db/migrate/20250305180954_renomme_metacompetences_pour_questions.rb
+++ b/db/migrate/20250305180954_renomme_metacompetences_pour_questions.rb
@@ -1,8 +1,10 @@
 class RenommeMetacompetencesPourQuestions < ActiveRecord::Migration[7.2]
   def up
+    Question.reset_column_information
+
     Question.where(metacompetence: "reconaitre_les_nombres").update_all(metacompetence: "reconnaitre_les_nombres")
     Question.where(metacompetence: "plannings").update_all(metacompetence: "plannings_lecture")
-    Question.where(metacompetence: "ordonner_nombres_entiers").update_all(metacompetence: "")
+    Question.where(metacompetence: "operations_nombres_entiers").update_all(metacompetence: "")
     Question.where(metacompetence: "unites_temps").update_all(metacompetence: "unites_de_temps")
     Question.where(metacompetence: "perimetres_surfaces").update_all(metacompetence: "perimetres")
 

--- a/spec/models/metacompetence_spec.rb
+++ b/spec/models/metacompetence_spec.rb
@@ -12,8 +12,8 @@ describe Metacompetence, type: :model do
        operations_multiplication
        operations_division
        denombrement
+       ordonner_nombres_entiers
        ordonner_nombres_decimaux
-       operations_nombres_entiers
        estimation
        proportionnalite
        resolution_de_probleme


### PR DESCRIPTION
La colonne metacompetence conservé en mémoire le fait qu'elle soit encore un integer et pas une string. Ce qui provoquait une mise à jour des colonnes métacompétences avec une valeur vide

La ligne `Question.reset_column_information` vient vider le cache des colonnes pour le model Question