### PR TITLE
🔧 Configure le root pour Rollbar

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -9,6 +9,9 @@ Rollbar.configure do |config|
     config.enabled = false
   end
 
+  # Specify custom root path
+  config.root = '/app'
+
   # By default, Rollbar will try to call the `current_user` controller method
   # to fetch the logged-in user object, and then call that object's `id`
   # method to fetch this property. To customize:


### PR DESCRIPTION
Comme le dockerfile place l'ensemble du projet dans un dossier app, sur Rollbar, les chemins des fichiers sont `/app/app/components/evaluation/numeratie_component.rb:10`

Ce qui empêche Rollbar de relier à notre codebase

![Capture d’écran 2025-03-12 à 16 26 30](https://github.com/user-attachments/assets/facbc793-d795-422a-8884-f3f5f70dc581)
