### PR TITLE
Actualise les dépendances

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,7 +199,6 @@ GEM
       devise (>= 4.9.0)
       rails-i18n
     diff-lcs (1.6.0)
-    domain_name (0.6.20240107)
     down (5.4.2)
       addressable (~> 2.8)
     drb (2.2.1)
@@ -219,6 +218,12 @@ GEM
     factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     ffaker (2.24.0)
     ffi (1.17.1)
     foreman (0.88.1)
@@ -264,9 +269,6 @@ GEM
       railties (>= 5.0)
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
-    http-accept (1.7.0)
-    http-cookie (1.0.8)
-      domain_name (~> 0.5)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     i18n-js (3.9.2)
@@ -295,7 +297,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.10.1)
+    json (2.10.2)
     jwt (2.10.1)
       base64
     kaminari (1.2.2)
@@ -334,10 +336,10 @@ GEM
       net-imap
       net-pop
       net-smtp
-    mailjet (1.7.11)
+    mailjet (1.8.0)
       activesupport (>= 5.0.0)
+      faraday (~> 2.1)
       rack (>= 1.4.0)
-      rest-client (>= 2.1.0)
       yajl-ruby
     marcel (1.0.4)
     matrix (0.4.2)
@@ -351,9 +353,11 @@ GEM
       logger
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
-    minitest (5.25.4)
+    minitest (5.25.5)
     msgpack (1.8.0)
     nenv (0.3.0)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.6)
       date
       net-protocol
@@ -363,7 +367,6 @@ GEM
       timeout
     net-smtp (0.5.1)
       net-protocol
-    netrc (0.11.0)
     nio4r (2.7.4)
     nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
@@ -481,11 +484,6 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rexml (3.4.1)
     rollbar (3.6.1)
     rspec (3.13.0)
@@ -511,7 +509,7 @@ GEM
     rspec-support (3.13.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.73.2)
+    rubocop (1.74.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -581,7 +579,7 @@ GEM
       sidekiq (>= 6, < 8)
       tilt (>= 1.4.0, < 3)
     simpleidn (0.2.3)
-    sorbet-runtime (0.5.11919)
+    sorbet-runtime (0.5.11930)
     spreadsheet (1.3.3)
       bigdecimal
       ruby-ole
@@ -612,6 +610,7 @@ GEM
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     uniform_notifier (1.16.0)
+    uri (1.0.3)
     useragent (0.16.11)
     view_component (3.21.0)
       activesupport (>= 5.2.0, < 8.1)


### PR DESCRIPTION
Il y a une mise à jour mailjet. Ça méritera un test d'envoi de mail sur la préprod.