### PR TITLE
🐛 Corrige erreur 500 restitution inventaire sans evenements

### DIFF
--- a/app/models/restitution/inventaire.rb
+++ b/app/models/restitution/inventaire.rb
@@ -67,11 +67,11 @@ module Restitution
     end
 
     def essais_verifies
-      essais.last.verifie? ? essais : essais[0...-1]
+      essais.last&.verifie? ? essais : essais[0...-1]
     end
 
     def essais
-      evenements_sans_la_fin = evenements.to_a.delete_if { |e| e.nom == EVENEMENT[:FIN_SITUATION] }
+      evenements_sans_la_fin = evenements.to_a.reject { |e| e.nom == EVENEMENT[:FIN_SITUATION] }
       evenements_par_essais = evenements_sans_la_fin.chunk_while do |evenement_avant, _|
         evenement_avant.nom != EVENEMENT[:SAISIE_INVENTAIRE]
       end

--- a/spec/models/restitution/inventaire_spec.rb
+++ b/spec/models/restitution/inventaire_spec.rb
@@ -154,6 +154,14 @@ describe Restitution::Inventaire do
   end
 
   describe '#essais_verifies' do
+    it "Quand seul l'évenement de fin a été enregistré" do
+      evenements = [
+        build(:evenement_fin_situation)
+      ]
+      restitution = described_class.new(campagne, evenements)
+      expect(restitution.essais_verifies).to eq([])
+    end
+
     it 'retourne les essais verifiés avec le nombre de click et le temps' do
       evenements = [
         build(:evenement_demarrage, date: 10.minutes.ago),


### PR DESCRIPTION
https://app.rollbar.com/a/eva-betagouv/fix/item/eva/1196

En prod, la partie `b06dee1b-dde9-4649-80ac-d7eaebc94162` n'a reçu que l'événement fin. La restitution de l'évaluation fait une erreur 500.