### PR TITLE
💄 Corrige le soulignement des liens de la restitution PDF

### DIFF
--- a/app/assets/stylesheets/print.pdf.scss
+++ b/app/assets/stylesheets/print.pdf.scss
@@ -63,7 +63,7 @@ $padding-pdf: 5rem;
   }
 
   a {
-    text-decoration: underline;
+    text-decoration: none;
   }
 
   .autopositionnement {


### PR DESCRIPTION
Avant : 
<img width="1009" alt="Capture d’écran 2025-03-18 à 23 12 11" src="https://github.com/user-attachments/assets/b8d8545d-b077-4b5b-9707-296aca1abdf8" />

Après : 
<img width="1042" alt="Capture d’écran 2025-03-18 à 23 12 45" src="https://github.com/user-attachments/assets/8302c0e1-5e72-4c65-a6c9-e6d58f2efd0a" />
