### PR TITLE
Ne propose pas le telechargement 'inline' en prod

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -146,7 +146,11 @@ ActiveAdmin.register Evaluation do
       pdf_path = Html2Pdf.new.genere_pdf_depuis_html(html_content)
 
       send_file(pdf_path, filename: "#{resource.nom}.pdf", type: 'application/pdf',
-                          disposition: 'inline')
+                          disposition: disposition)
+    end
+
+    def disposition
+      Rails.env.development? ? 'inline' : 'attachment'
     end
 
     def destroy


### PR DESCRIPTION
Il me semble que c'est trop compliqué de demander aux utilisateurs de récupérer leur PDFs en deux fois et que c'est mieux que le téléchargement du PDF ait lieu directement.