### PR TITLE
🐛 Affiche une erreur à l'utilisateur quand la génération du pdf échoue

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -137,16 +137,17 @@ ActiveAdmin.register Evaluation do
     end
 
     def render_pdf
-      html_content = render_to_string(
-        template: 'admin/evaluations/show',
-        layout: 'application',
-        locals: { resource: resource }
-      )
+      html_content = render_to_string(template: 'admin/evaluations/show', layout: 'application',
+                                      locals: { resource: resource })
 
-      pdf_path = Html2Pdf.new.genere_pdf_depuis_html(html_content)
-
-      send_file(pdf_path, filename: "#{resource.nom}.pdf", type: 'application/pdf',
-                          disposition: disposition)
+      pdf_path = Html2Pdf.genere_pdf_depuis_html(html_content)
+      if pdf_path == false
+        flash[:error] = t('.erreur_generation_pdf')
+        redirect_to admin_evaluation_path(resource)
+      else
+        send_file(pdf_path, filename: "#{resource.nom}.pdf", type: 'application/pdf',
+                            disposition: disposition)
+      end
     end
 
     def disposition

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -203,6 +203,7 @@ fr:
         titre:
           restitution_globale: Restitution globale
         evaluation_anonyme: "Cette évaluation est anonyme : le nom du bénéficiaire est fictif et ses informations personnelles ont été supprimées."
+        erreur_generation_pdf: La génération du PDF a échoué. Veuillez réessayer dans un moment.
       nom_evaluation:
         suivi_par: Suivi(e) par
         pas_de_responsable: Pas de responsable de suivi

--- a/lib/html_2_pdf.rb
+++ b/lib/html_2_pdf.rb
@@ -6,68 +6,70 @@ class Html2Pdf
   A4_VIEWPORT = Puppeteer::Viewport.new(width: 1008, height: 1488)
   A4_WINDOW_SIZE = '--window-size=1920,1080'
 
-  def genere_pdf_depuis_html(html_content)
-    Puppeteer.launch(**puppeteer_options) do |browser|
-      page = prepare_page(browser, html_content)
+  class << self
+    def genere_pdf_depuis_html(html_content)
+      Puppeteer.launch(**puppeteer_options) do |browser|
+        page = prepare_page(browser, html_content)
 
-      page.pdf(**pdf_options)
-      filename
+        page.pdf(**pdf_options)
+        filename
+      end
+    rescue Puppeteer::Connection::ProtocolError, Puppeteer::TimeoutError => e
+      Rails.logger.error("Puppeteer : #{e.message}")
+      false
     end
-  rescue Puppeteer::Connection::ProtocolError, Puppeteer::TimeoutError => e
-    Rails.logger.error(e.message)
-    false
-  end
 
-  private
+    private
 
-  def prepare_page(browser, html_content)
-    page = browser.new_page
-    page.viewport = A4_VIEWPORT
-    page.set_content(html_content, wait_until: 'networkidle2')
-    pause_pdf
-    page
-  end
-
-  def debug_mode?
-    ENV['DEBUG_PDF'].present? && Rails.env.development?
-  end
-
-  # Le mode debug permet d'ouvrir une page chrome pour visualiser le rendu
-  # et inspecter l'html avant la transformation en PDF
-  def pause_pdf
-    return unless debug_mode?
-
-    Rails.logger.debug 'Appuyer sur la touche "Entrer" pour continuer le processus'
-    gets # Attend que l'utilisateur appuie sur "Enter" (dans le terminal du serveur)
-  end
-
-  def puppeteer_options
-    options = {
-      headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox', A4_WINDOW_SIZE]
-    }
-    if debug_mode?
-      options[:headless] = false
-      options[:args] += ['--auto-open-devtools-for-tabs']
+    def prepare_page(browser, html_content)
+      page = browser.new_page
+      page.viewport = A4_VIEWPORT
+      page.set_content(html_content, wait_until: 'networkidle2')
+      pause_pdf
+      page
     end
-    options[:executable_path] = ENV['GOOGLE_CHROME_SHIM'] if ENV['GOOGLE_CHROME_SHIM']
-    options
-  end
 
-  def pdf_options(format: 'A4', landscape: false)
-    @pdf_options ||= {
-      path: filename,
-      print_background: true,
-      format: format,
-      landscape: landscape,
-      margin: { top: '0px', right: '0px', bottom: '0px', left: '0px' }
-    }
-  end
+    def debug_mode?
+      ENV['DEBUG_PDF'].present? && Rails.env.development?
+    end
 
-  def filename
-    @filename ||= begin
-      dir_path = Rails.root.join('tmp/pdf')
-      FileUtils.mkdir_p(dir_path)
-      dir_path.join("document-#{SecureRandom.uuid}.pdf")
+    # Le mode debug permet d'ouvrir une page chrome pour visualiser le rendu
+    # et inspecter l'html avant la transformation en PDF
+    def pause_pdf
+      return unless debug_mode?
+
+      Rails.logger.debug 'Appuyer sur la touche "Entrer" pour continuer le processus'
+      gets # Attend que l'utilisateur appuie sur "Enter" (dans le terminal du serveur)
+    end
+
+    def puppeteer_options
+      options = {
+        headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox', A4_WINDOW_SIZE]
+      }
+      if debug_mode?
+        options[:headless] = false
+        options[:args] += ['--auto-open-devtools-for-tabs']
+      end
+      options[:executable_path] = ENV['GOOGLE_CHROME_SHIM'] if ENV['GOOGLE_CHROME_SHIM']
+      options
+    end
+
+    def pdf_options(format: 'A4', landscape: false)
+      @pdf_options ||= {
+        path: filename,
+        print_background: true,
+        format: format,
+        landscape: landscape,
+        margin: { top: '0px', right: '0px', bottom: '0px', left: '0px' }
+      }
+    end
+
+    def filename
+      @filename ||= begin
+        dir_path = Rails.root.join('tmp/pdf')
+        FileUtils.mkdir_p(dir_path)
+        dir_path.join("document-#{SecureRandom.uuid}.pdf")
+      end
     end
   end
 end

--- a/spec/features/admin/evaluation_spec.rb
+++ b/spec/features/admin/evaluation_spec.rb
@@ -262,20 +262,29 @@ describe 'Admin - Evaluation', type: :feature do
           end
         end
 
-        it "affiche l'évaluation en pdf" do
-          allow(restitution_globale).to receive(:interpretations_niveau2).and_return([])
-          visit admin_evaluation_path(mon_evaluation, format: :pdf)
-          # rubocop:disable Lint/Debugger
-          path = page.save_page
-          pdf_path = path.sub('.html', '.pdf')
-          File.rename(path, pdf_path) # Renomme l'extension du fichier pour pouvoir l'ouvrir
-          # system("open #{pdf_path}")
-          # rubocop:enable Lint/Debugger
+        describe 'génération PDF' do
+          it "affiche l'évaluation en pdf" do
+            allow(restitution_globale).to receive(:interpretations_niveau2).and_return([])
+            visit admin_evaluation_path(mon_evaluation, format: :pdf)
+            # rubocop:disable Lint/Debugger
+            path = page.save_page
+            pdf_path = path.sub('.html', '.pdf')
+            File.rename(path, pdf_path) # Renomme l'extension du fichier pour pouvoir l'ouvrir
+            # system("open #{pdf_path}")
+            # rubocop:enable Lint/Debugger
 
-          reader = PDF::Reader.new(pdf_path)
+            reader = PDF::Reader.new(pdf_path)
 
-          expect(reader.page(1).text).to include('Roger')
-          expect(reader.page(1).text).to include('structure')
+            expect(reader.page(1).text).to include('Roger')
+            expect(reader.page(1).text).to include('structure')
+          end
+
+          it 'erreur timeout à la génération du pdf' do
+            allow(restitution_globale).to receive(:interpretations_niveau2).and_return([])
+            expect(Html2Pdf).to receive(:genere_pdf_depuis_html).and_return(false)
+            visit admin_evaluation_path(mon_evaluation, format: :pdf)
+            expect(page).to have_content 'La génération du PDF a échoué. Veuillez réessayer dans un moment'
+          end
         end
       end
     end


### PR DESCRIPTION
Ce commit corrige l'erreur rollbar :
TypeError: no implicit conversion of false into String https://app.rollbar.com/a/eva-betagouv/fix/item/eva/1204

<img width="1255" alt="Capture d’écran 2025-03-20 à 17 15 03" src="https://github.com/user-attachments/assets/deacd2f2-2f79-4fb0-9cb9-3acedd1c5cb1" />
