### PR TITLE
Accessibilite restitution

### DIFF
--- a/app/assets/stylesheets/admin/pages/restitution_globale/_evaluation.scss
+++ b/app/assets/stylesheets/admin/pages/restitution_globale/_evaluation.scss
@@ -29,7 +29,11 @@
 
 @mixin card__banner-couleur($couleur-principale, $couleur-principale-legere) {
   border: 1px solid $couleur-principale;
-  h5 { color: $couleur-principale; }
+  h3 {
+    color: $couleur-principale;
+    font-size: 1rem;
+    line-height:1.25rem;
+  }
   .card__banner__icone { fill: $couleur-principale; }
   .mise-en-action__texte { color: $couleur-principale; }
 }

--- a/app/components/barre_segmentee_component.erb
+++ b/app/components/barre_segmentee_component.erb
@@ -1,6 +1,6 @@
 <div class="barre-segmentee">
   <% if @pourcentage_reussite.present? %>
-    <p class="barre-segmentee__score"><%= resultat %></p>
+    <p class="barre-segmentee__score"><%= I18n.t('.barre_segmentee.score', score: @pourcentage_reussite) %></p>
   <% end %>
   <p class="barre-segmentee__legende">
     <%= I18n.t('.barre_segmentee.legende',

--- a/app/components/barre_segmentee_component.erb
+++ b/app/components/barre_segmentee_component.erb
@@ -1,15 +1,16 @@
 <div class="barre-segmentee">
   <% if @pourcentage_reussite.present? %>
-    <div class="barre-segmentee__score"><%= resultat %></div>
+    <p class="barre-segmentee__score"><%= resultat %></p>
   <% end %>
-  <div class="barre-segmentee__legende">
-      Réussite : <%= @nombre_questions_reussies %> - 
-      Échec : <%= @nombre_questions_echecs %> - 
-      Non passés : <%= @nombre_questions_non_passees %> - 
-      Total : <%= nombre_questions_total %>
-  </div>
+  <p class="barre-segmentee__legende">
+    <%= I18n.t('.barre_segmentee.legende',
+               reussite: @nombre_questions_reussies,
+               echec: @nombre_questions_echecs,
+               non_passees: @nombre_questions_non_passees,
+               total: nombre_questions_total) %>
+  </p>
   <% if @pourcentage_reussite.present? %>
-    <div class="barre-segmentee__graphique">
+    <div class="barre-segmentee__graphique" aria-hidden="true">
       <% if @nombre_questions_reussies.positive? %>
         <div class="barre-segmentee__graphique-element barre-segmentee__graphique-element--succes" style="width: <%= pourcentage_questions(@nombre_questions_reussies) %>%"></div>
       <% end %>

--- a/app/components/barre_segmentee_component.rb
+++ b/app/components/barre_segmentee_component.rb
@@ -18,12 +18,4 @@ class BarreSegmenteeComponent < ViewComponent::Base
 
     (nombre_questions.to_f / nombre_questions_total) * 100
   end
-
-  def resultat
-    if @pourcentage_reussite.nil?
-      ''
-    else
-      "Score #{@pourcentage_reussite}% "
-    end
-  end
 end

--- a/app/components/sous_competence_component.erb
+++ b/app/components/sous_competence_component.erb
@@ -13,6 +13,12 @@
   </div>
 <% elsif numeratie? %>
   <div class="sous-competence fr-tile fr-tile--horizontal fr-tile--sous-domaine" id="tile-17">
+    <div class="fr-tile__header" aria-hidden="true">
+      <div class="fr-tile__pictogram">
+        <%= image_tag("icone_profil/numeratie_#{@sous_competence}.svg", alt: '') %>
+      </div>
+    </div>
+
     <div class="fr-tile__body">
       <div class="fr-tile__content">
         <div>
@@ -24,12 +30,6 @@
         <div class="sous-competence__barre-segmentee">
           <%= render(BarreSegmenteeComponent.new(nombre_questions_reussies: nombre_questions_reussies, nombre_questions_echecs: nombre_questions_echecs, nombre_questions_non_passees: nombre_questions_non_passees, pourcentage_reussite: pourcentage_reussite)) %>
         </div>
-      </div>
-    </div>
-
-    <div class="fr-tile__header" aria-hidden="true">
-      <div class="fr-tile__pictogram">
-        <%= image_tag("icone_profil/numeratie_#{@sous_competence}.svg", alt: '') %>
       </div>
     </div>
   </div>

--- a/app/components/sous_competence_component.erb
+++ b/app/components/sous_competence_component.erb
@@ -29,7 +29,7 @@
     
     <div class="fr-tile__header">
       <div class="fr-tile__pictogram">
-        <%= inline_svg_tag("icone_profil/numeratie_#{@sous_competence}.svg") %>
+        <%= image_tag("icone_profil/numeratie_#{@sous_competence}.svg", alt: '') %>
       </div>
     </div>
   </div>

--- a/app/components/sous_competence_component.erb
+++ b/app/components/sous_competence_component.erb
@@ -26,8 +26,8 @@
         </div>
       </div>
     </div>
-    
-    <div class="fr-tile__header">
+
+    <div class="fr-tile__header" aria-hidden="true">
       <div class="fr-tile__pictogram">
         <%= image_tag("icone_profil/numeratie_#{@sous_competence}.svg", alt: '') %>
       </div>

--- a/app/views/admin/evaluations/_suivi_accompagnement_illettrisme.erb
+++ b/app/views/admin/evaluations/_suivi_accompagnement_illettrisme.erb
@@ -6,7 +6,8 @@
       <%= inline_svg_tag 'banner_icone_question.svg', class: 'card__banner__icone' %>
     </div>
     <div>
-      <div><%= md t('illettrisme_potentiel.message', scope: scope) %></div>
+      <h3><%= t('illettrisme_potentiel.titre', scope: scope) %></h3>
+      <%= md t('illettrisme_potentiel.message', scope: scope) %>
       <%= render partial: 'components/reponse_mise_en_action', locals: { evaluation: resource, affiche_qualification: true } %>
     </div>
   </div>

--- a/app/views/admin/evaluations/_suivi_accompagnement_illettrisme.erb
+++ b/app/views/admin/evaluations/_suivi_accompagnement_illettrisme.erb
@@ -2,8 +2,8 @@
 
 <div class="card__banner card__banner--illettrisme <%= reponse %>">
   <div class= 'container d-flex py-3 px-4'>
-    <div class='d-flex align-items-center justify-content-center'>
-      <%= inline_svg_tag 'banner_icone_question.svg', class: 'card__banner__icone', alt: '' %>
+    <div class='d-flex align-items-center justify-content-center' aria-hidden="true">
+      <%= inline_svg_tag 'banner_icone_question.svg', class: 'card__banner__icone' %>
     </div>
     <div>
       <div><%= md t('illettrisme_potentiel.message', scope: scope) %></div>

--- a/config/locales/components/barre_segmentee.yml
+++ b/config/locales/components/barre_segmentee.yml
@@ -1,0 +1,3 @@
+fr:
+  barre_segmentee:
+    legende: "Réussite : %{reussite}, Échec : %{echec}, Non passés : %{non_passees}, Total : %{total}"

--- a/config/locales/components/barre_segmentee.yml
+++ b/config/locales/components/barre_segmentee.yml
@@ -1,3 +1,4 @@
 fr:
   barre_segmentee:
     legende: "Réussite : %{reussite}, Échec : %{echec}, Non passés : %{non_passees}, Total : %{total}"
+    score: "Score %{score}%"

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -185,9 +185,8 @@ fr:
           Certains modules **n’ont pas été complétés lors de cette passation**. La fiabilité des résultats peut donc être diminuée.
         illettrisme_potentiel:
           action: Signaler une difficulté
+          titre: Cette personne semble avoir besoin de consolider ses compétences de base.
           message: |
-            ##### Cette personne semble avoir besoin de consolider ses compétences de base.
-
             D'après nos enquêtes, seulement **25% des personnes en illettrisme potentiel réussissent à entrer en formation.**
 
             **Avez-vous été en mesure d’orienter cette personne vers une solution d’accompagnement adaptée<a href="#asterisque" class="lien-secondaire" title="aller à la description pistes de solutions"><sup>*</sup></a> ?**

--- a/spec/components/barre_segmentee_component_spec.rb
+++ b/spec/components/barre_segmentee_component_spec.rb
@@ -22,10 +22,10 @@ describe BarreSegmenteeComponent, type: :component do
     render_inline(component)
 
     expect(page).to have_css('.barre-segmentee')
-    expect(page).to have_content("Réussite : #{nombre_questions_reussies}")
-    expect(page).to have_content("Échec : #{nombre_questions_echecs}")
-    expect(page).to have_content("Non passés : #{nombre_questions_non_passees}")
-    expect(page).to have_content("Total : #{component.nombre_questions_total}")
+    expect(page).to have_content("Réussite : #{nombre_questions_reussies}")
+    expect(page).to have_content("Échec : #{nombre_questions_echecs}")
+    expect(page).to have_content("Non passés : #{nombre_questions_non_passees}")
+    expect(page).to have_content("Total : #{component.nombre_questions_total}")
     expect(page).to have_content("Score #{pourcentage_reussite}%")
   end
 


### PR DESCRIPTION
## Mise en action
- Hiérarchie des titres ;
- Cache l'illustration aux lecteurs d'écran ;

## Numératie
- Ajoute une description alternative vide aux images d'illustrations ;
- Accessibilité de la légende du composant *barre segmentée* ;

D'une manière générale, pour l'accessibilité, préférer utiliser `image_tag` plutôt que `inline_svg_tag` si on n'a pas besoins de faire varier l'aspect du svg avec des règles css. 