### PR TITLE
🐛 Exporte les noms techniques des reponses qui ont un intitulé de réponse vide

### DIFF
--- a/app/models/evenement_question.rb
+++ b/app/models/evenement_question.rb
@@ -22,7 +22,7 @@ class EvenementQuestion
   end
 
   def reponse
-    @evenement.donnees['reponseIntitule'] ||
+    @evenement.donnees['reponseIntitule'].presence ||
       @question.intitule_reponse(@evenement.donnees['reponse'])
   end
 

--- a/spec/models/evenement_question_spec.rb
+++ b/spec/models/evenement_question_spec.rb
@@ -98,6 +98,40 @@ describe EvenementQuestion, type: :model do
     end
   end
 
+  describe '#reponse' do
+    let(:choix1) { create :choix, :bon, nom_technique: 'choix_1', intitule: '' }
+
+    let(:question_qcm) { create(:question_qcm, choix: [choix1]) }
+    let(:evenement_question_n1) do
+      described_class.new(question: question_qcm, evenement: evenement_n1)
+    end
+
+    context 'avec un envenement qui a un intitulé de réponse' do
+      let(:evenement_n1) do
+        build(:evenement, donnees: { score: 1, reponseIntitule: 'la réponse du bénéficaire' })
+      end
+
+      it { expect(evenement_question_n1.reponse).to eq('la réponse du bénéficaire') }
+    end
+
+    context 'avec un envenement sans intitulé de réponse' do
+      let(:evenement_n1) do
+        build(:evenement, donnees: { score: 1, question: question_qcm, reponse: choix1.id })
+      end
+
+      it { expect(evenement_question_n1.reponse).to eq('choix_1') }
+    end
+
+    context 'avec un envenement avec un intitulé de réponse vide' do
+      let(:evenement_n1) do
+        build(:evenement, donnees: { score: 1, question: question_qcm,
+                                     reponse: choix1.id, reponseIntitule: '' })
+      end
+
+      it { expect(evenement_question_n1.reponse).to eq('choix_1') }
+    end
+  end
+
   describe '.pour_code_clea' do
     let(:code) { '2.1' }
     let(:sous_code) { '2.1.1' }


### PR DESCRIPTION
Suite de l'export des noms techniques de réponses : 

Dans le cas d'un événement comme suit : 
<img width="1192" alt="Capture d’écran 2025-03-27 à 16 39 04" src="https://github.com/user-attachments/assets/2c1ba4d1-9787-488f-a8f5-fb2d9d876ac2" />

On remonte le nom technique de la réponse dans l'export détaillé