### PR TITLE
🗑️ Ffmpeg-buildpack est deprecated

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,5 +1,4 @@
 https://github.com/Scalingo/nodejs-buildpack.git
 https://github.com/Scalingo/apt-buildpack.git
 https://github.com/Captive-Studio/scalingo-buildpack-google-chrome.git
-https://github.com/Scalingo/ffmpeg-buildpack.git
 https://github.com/Scalingo/ruby-buildpack.git

--- a/Aptfile
+++ b/Aptfile
@@ -1,2 +1,3 @@
 # Pour la manipulation d'image
 libvips-dev
+ffmpeg


### PR DESCRIPTION
On utilise la manière officiel de télécharger Ffmpeg : https://doc.scalingo.com/platform/app/ffmpeg