### PR TITLE
🐛 Ne provoque plus d'erreur 500 quand on tente d'importer un questionnaire qui est soft-delete

### DIFF
--- a/app/models/import_export/questionnaire/import.rb
+++ b/app/models/import_export/questionnaire/import.rb
@@ -29,12 +29,13 @@ module ImportExport
       end
 
       def cree_ou_actualise_questionnaire(ligne)
-        questionnaire = ::Questionnaire.find_or_create_by(nom_technique: ligne[1])
+        questionnaire = ::Questionnaire.find_or_initialize_by(nom_technique: ligne[1])
         questions = Question.where(nom_technique: ligne[2].split(','))
-        questionnaire.update!(
+        questionnaire.assign_attributes(
           libelle: ligne[0],
           questions: questions
         )
+        questionnaire.save!
         questionnaire
       end
     end

--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -15,7 +15,9 @@ class Questionnaire < ApplicationRecord
   has_many :questions, through: :questionnaires_questions
 
   validates :libelle, presence: true
-  validates :nom_technique, presence: true, uniqueness: true
+  validates :nom_technique, presence: true, uniqueness: { scope: :deleted_at, conditions: lambda {
+    with_deleted
+  } }
 
   accepts_nested_attributes_for :questionnaires_questions, allow_destroy: true
 

--- a/spec/models/questionnaire_spec.rb
+++ b/spec/models/questionnaire_spec.rb
@@ -7,7 +7,17 @@ RSpec.describe Questionnaire, type: :model do
 
   it { is_expected.to validate_presence_of :libelle }
   it { is_expected.to validate_presence_of :nom_technique }
-  it { is_expected.to validate_uniqueness_of :nom_technique }
+
+  context 'avec un enregistrement soft-supprimé' do
+    before do
+      create(:questionnaire, nom_technique: 'unique_nom_technique', deleted_at: Time.current)
+    end
+
+    it "ne permet pas la création d'un nouvel enregistrement avec le même nom_technique" do
+      new_questionnaire = build(:questionnaire, nom_technique: 'unique_nom_technique')
+      expect(new_questionnaire).to be_invalid
+    end
+  end
 
   describe '#livraison_sans_redaction?' do
     context 'quand le questionnaire est livraison sans rédaction' do


### PR DESCRIPTION
Le problème provient du faire qu'il existe déjà un questionnaire avec le nom_technique test mais ce questionnaire est soft delete.

J'ai fait évoluer la validation pour que cette dernière arrête l'enregistrement avant de le tenter en BDD

https://app.rollbar.com/a/eva-betagouv/fix/item/eva-serveur/4