### PR TITLE
♿️ Accessibilite restitution quelques poins supplémentaires d'amélioration

### DIFF
--- a/app/views/admin/evaluations/_autopositionnement.arb
+++ b/app/views/admin/evaluations/_autopositionnement.arb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-h2 t(".#{categorie}"), class: 'categorie'
+h3 t(".#{categorie}"), class: 'categorie'
 questions_reponses.each do |question, reponse|
   if question.categorie == categorie
     div question.transcription_intitule&.ecrit

--- a/app/views/admin/evaluations/_competence_niveau1.arb
+++ b/app/views/admin/evaluations/_competence_niveau1.arb
@@ -4,7 +4,7 @@ competence = competence.to_s
 scope = "admin.restitutions.#{referentiel}.#{competence}"
 
 div class: 'col-auto badge' do
-  div image_tag "#{competence}_#{referentiel}.svg", alt: ''
+  div image_tag "#{competence}_#{referentiel}.svg", alt: t(:titre, scope: scope)
   if niveau.present?
     div image_tag "badges/#{referentiel}/#{niveau}.svg",
                   alt: t(niveau, scope: 'admin.restitutions.references')

--- a/app/views/admin/evaluations/_donnees_sociodemographiques.arb
+++ b/app/views/admin/evaluations/_donnees_sociodemographiques.arb
@@ -2,7 +2,7 @@
 
 donnee_sociodemographique = resource.donnee_sociodemographique
 
-h2 t(".#{categorie}"), class: 'categorie'
+h3 t(".#{categorie}"), class: 'categorie'
 
 bienvenue.questionnaires_questions_pour(categorie).each do |config|
   div config.question.transcription_intitule&.ecrit

--- a/app/views/admin/evaluations/_questionnaire_autopositionnement.arb
+++ b/app/views/admin/evaluations/_questionnaire_autopositionnement.arb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 div class: 'autopositionnement questionnaire' do
-  h2 t('.questionnaire-auto-positionnement'), class: 'categorie'
+  h3 t('.questionnaire-auto-positionnement'), class: 'categorie'
   auto_positionnement.questions_et_reponses(:jauge).each do |question, reponse|
     div class: 'row' do
       div class: 'col intitule-question' do

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -369,17 +369,17 @@ fr:
         pre_A1: Niveau pre A1
         A1: Niveau A1
         A2: Niveau A2
-        B1: Niveau B1 plus
+        B1: Niveau B1 pluss
         pre_X1: Niveau pre X1
         X1: Niveau X1
         X2: Niveau X2
-        Y1: Niveau Y1 plus
+        Y1: Niveau Y1 pluss
         profil1: Profil 1
         profil2: Profil 2
         profil3: Profil 3
         profil4: Profil 4
-        profil4_plus: Profil 4 plus
-        profil4_plus_plus: Profil 4 plus plus
+        profil4_plus: Profil 4 pluss
+        profil4_plus_plus: Profil 4 pluss pluss
         explications-cefr: |
           Les restitutions eva sont basées sur les référentiels européens d’évaluation du français et des mathématiques, ainsi que sur le référentiel Cléa.
         explications-anlci: |


### PR DESCRIPTION
- Hiérarchie des titres de la restitution de Bienvenue ;
- Forcer le lecteur d'écran à prononcer le s des plus dans « 4+ » et « 4++ » ;
- Ajoute des descriptions alternatives aux badges d'illustration des sous-compétences du diagnostic, pour une question d'enchainement de lecture.