### PR TITLE
♿️ Donnes le style DSFR aux filtres de dates

### DIFF
--- a/app/admin/annonce_generales.rb
+++ b/app/admin/annonce_generales.rb
@@ -7,6 +7,10 @@ ActiveAdmin.register AnnonceGenerale do
 
   permit_params :texte, :afficher
 
+  filter :texte
+  filter :afficher, as: :boolean
+  filter :created_at
+
   index do
     column :texte do |ag|
       link_to ag.texte, admin_annonce_generale_path(ag)

--- a/app/admin/parcours_type.rb
+++ b/app/admin/parcours_type.rb
@@ -10,8 +10,8 @@ ActiveAdmin.register ParcoursType do
   filter :libelle
   filter :nom_technique
   filter :type_de_programme, as: :select
-  filter :created_at
   filter :description
+  filter :created_at
 
   form partial: 'form'
 

--- a/app/admin/parties.rb
+++ b/app/admin/parties.rb
@@ -25,7 +25,6 @@ ActiveAdmin.register Partie do
          order_by: 'nom_asc'
   filter :session_id
   filter :created_at
-  filter :updated_at
 
   index pagination_total: false do
     column :evaluation

--- a/app/admin/situations.rb
+++ b/app/admin/situations.rb
@@ -6,6 +6,10 @@ ActiveAdmin.register Situation do
   permit_params :libelle, :nom_technique, :questionnaire_id, :questionnaire_entrainement_id,
                 :description, :illustration
 
+  filter :libelle
+  filter :nom_technique
+  filter :description
+
   includes :questionnaire, :questionnaire_entrainement, illustration_attachment: :blob
 
   form do |f|

--- a/app/admin/source_aides.rb
+++ b/app/admin/source_aides.rb
@@ -5,7 +5,9 @@ ActiveAdmin.register SourceAide do
 
   permit_params :titre, :description, :url, :categorie, :type_document, :position
 
-  config.filters = false
+  filter :titre
+  filter :categorie, as: :select
+  filter :description
 
   index do
     column :titre do |sa|

--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -11,6 +11,7 @@
 //= require faq
 //= require aide
 //= require autocomplete_recherche
+//= require filtres_dates
 //= require bouton_menu
 //= require cgu
 //= require clipboard

--- a/app/assets/javascripts/filtres_dates.js
+++ b/app/assets/javascripts/filtres_dates.js
@@ -1,0 +1,22 @@
+function convertir_champ(input, label) {
+  input.type = 'date';
+  input.classList.remove('datepicker', 'hasDatepicker');
+  input.removeAttribute('autocomplete');
+
+  const labelElement = document.createElement('label');
+  labelElement.setAttribute('for', input.id);
+  labelElement.textContent = label;
+  input.parentNode.insertBefore(labelElement, input);
+}
+
+function utilise_date_picker_du_dsfr(filtre) {
+  filtre.querySelectorAll('label').forEach((label) => label.remove());
+  const champs = filtre.querySelectorAll('input');
+  convertir_champ(champs[0], I18n.t('admin.date_depuis'));
+  convertir_champ(champs[1], I18n.t('admin.date_jusqua'));
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  utilise_date_picker_du_dsfr(document.getElementById('q_created_at_input'));
+});
+

--- a/app/assets/stylesheets/admin/composants/_filtres.scss
+++ b/app/assets/stylesheets/admin/composants/_filtres.scss
@@ -11,19 +11,18 @@
           }
         }
         &.filter_date_range {
-          input[type='text'] {
-            width: 7.188rem;
+          input:first-of-type {
+            margin-bottom: 0.5rem;
           }
-        }
-      }
-      .input:not(.select_and_search) {
-        select {
-          width: 100%;
         }
       }
       .select2-selection {
         padding: .5rem 0.5rem;
       }
+    }
+
+    .buttons {
+      margin-top: 1rem;
     }
 
     .filter_form_field {

--- a/config/locales/date.yml
+++ b/config/locales/date.yml
@@ -1,4 +1,7 @@
 fr:
+  admin:
+    date_depuis: créé(e) depuis le
+    date_jusqua: jusqu'au
   date:
     formats: &formats
       sans_heure: "%d %b %Y"


### PR DESCRIPTION
Cette PR permet de rendre un peu plus accessible les filtres sur les dates, en permettant l'accès au clavier. Par contre, VoiceOver continue de ne pas réussir à accéder au composant.

Au passage, j'ai refait une passe sur la configuration de tous les filtres et corrigé quelques cas.

<img width="524" alt="Capture d’écran 2025-04-14 à 15 49 53" src="https://github.com/user-attachments/assets/4dbace69-f735-4d0d-b446-c3c9e70d72e6" />
<img width="364" alt="Capture d’écran 2025-04-14 à 15 50 00" src="https://github.com/user-attachments/assets/2f5905c9-021d-4616-9595-7231d3c60c2b" />
