### PR TITLE
💄 Restore le style des listes dsfr

### DIFF
--- a/app/assets/stylesheets/admin/_adaptation_dsfr.scss
+++ b/app/assets/stylesheets/admin/_adaptation_dsfr.scss
@@ -4,7 +4,9 @@
   }
 }
 ul {
-  list-style-type: none;
+  list-style-type: var(--ul-type);
+  padding-left: var(--ul-start);
+  margin: var(--text-spacing);
 }
 ol > li::marker {
   content: none;


### PR DESCRIPTION
## avant : 
### Restitution :
<img width="943" alt="Capture d’écran 2025-04-16 à 12 03 13" src="https://github.com/user-attachments/assets/a4f4bc01-d048-4c71-b6c3-0efe6a3fe03e" />
<img width="941" alt="Capture d’écran 2025-04-16 à 12 03 20" src="https://github.com/user-attachments/assets/c5ad69fc-23bc-4802-b1a0-c9fc95ed9441" />

### Création de campagne :
<img width="634" alt="Capture d’écran 2025-04-16 à 12 03 01" src="https://github.com/user-attachments/assets/df23983c-3acc-499d-a2a7-c285dab2dd12" />


## après : 
### Restitution :
<img width="932" alt="Capture d’écran 2025-04-16 à 12 00 34" src="https://github.com/user-attachments/assets/4ee2b1b1-6969-43de-a313-8b88cceca6a7" />
<img width="958" alt="Capture d’écran 2025-04-16 à 12 00 43" src="https://github.com/user-attachments/assets/e3f55449-797c-41e4-86ae-6426d57c9149" />

### Création de campagne :
<img width="654" alt="Capture d’écran 2025-04-16 à 11 59 49" src="https://github.com/user-attachments/assets/4ef3cce4-bfa5-4816-aca9-a4d0c36bd220" />

