### PR TITLE
🐛 Corrige le message d'erreur de validation du mot de passe

### DIFF
--- a/app/models/password_validator.rb
+++ b/app/models/password_validator.rb
@@ -4,10 +4,16 @@ class PasswordValidator < ActiveModel::Validator
   def validate(compte)
     value = compte.password
     return if value.blank?
-    return unless compte.anlci?
-    return if PasswordValidator.est_avec_12_maj_min_num_et_symbol?(value)
-
-    compte.errors.add(:password, I18n.t(".creation_compte.regles_mot_de_passe_anlci"))
+    if compte.anlci?
+      unless PasswordValidator.est_avec_12_maj_min_num_et_symbol?(value)
+        compte.errors.add(:password, I18n.t(".creation_compte.regles_mot_de_passe_anlci"))
+      end
+    else
+      if value.length < 8
+        compte.errors.add(
+          :password, I18n.t(".creation_compte.regles_mot_de_passe", longueur_mot_de_passe: 8))
+      end
+    end
   end
 
   def self.est_avec_12_maj_min_num_et_symbol?(value)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -167,7 +167,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 8..128
+  config.password_length = 1..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/spec/models/password_validator_spec.rb
+++ b/spec/models/password_validator_spec.rb
@@ -4,55 +4,69 @@ require 'rails_helper'
 
 describe PasswordValidator do
   describe '#validate' do
-    it 'quand le mot de passe contient bien des majuscule, minuscule, chiffre et symbol' do
-      compte = Compte.new(password: 'aA345678912$', role: :superadmin)
-      described_class.new.validate(compte)
-      expect(compte.errors.include?(:password)).to be false
-    end
-
-    it 'quand le mot de passe ne contient pas de majuscule' do
-      compte = Compte.new(password: 'aa345678912$', role: :superadmin)
-      described_class.new.validate(compte)
-      expect(compte.errors.include?(:password)).to be true
-    end
-
-    it 'quand le mot de passe ne contient pas de minuscule' do
-      compte = Compte.new(password: 'AA345678912$', role: :superadmin)
-      described_class.new.validate(compte)
-      expect(compte.errors.include?(:password)).to be true
-    end
-
-    it 'quand le mot de passe ne contient pas de chiffre' do
-      compte = Compte.new(password: 'aAAAAAAAAAA$', role: :superadmin)
-      described_class.new.validate(compte)
-      expect(compte.errors.include?(:password)).to be true
-    end
-
-    it 'quand le mot de passe ne contient pas de symbol' do
-      compte = Compte.new(password: 'aA3456789120', role: :superadmin)
-      described_class.new.validate(compte)
-      expect(compte.errors.include?(:password)).to be true
-    end
-
-    it 'quand le mot de passe ne contient pas assez de caracters' do
-      compte = Compte.new(password: 'aA34567891$', role: :superadmin)
-      described_class.new.validate(compte)
-      expect(compte.errors.include?(:password)).to be true
-    end
-
-    it 'ne fait aucune vérificaton pour les comptes non anlci' do
-      %i[conseiller admin compte_generique].each do |role|
-        compte = Compte.new(password: '123456', role: role)
+    context "compte anlci" do
+      it 'quand le mot de passe contient bien des majuscule, minuscule, chiffre et symbol' do
+        compte = Compte.new(password: 'aA345678912$', role: :superadmin)
         described_class.new.validate(compte)
         expect(compte.errors.include?(:password)).to be false
       end
-    end
 
-    it 'vérifie les comptes anlci' do
-      Compte::ANLCI_ROLES.each do |role|
-        compte = Compte.new(password: '123456', role: role)
+      it 'quand le mot de passe ne contient pas de majuscule' do
+        compte = Compte.new(password: 'aa345678912$', role: :superadmin)
         described_class.new.validate(compte)
         expect(compte.errors.include?(:password)).to be true
+      end
+
+      it 'quand le mot de passe ne contient pas de minuscule' do
+        compte = Compte.new(password: 'AA345678912$', role: :superadmin)
+        described_class.new.validate(compte)
+        expect(compte.errors.include?(:password)).to be true
+      end
+
+      it 'quand le mot de passe ne contient pas de chiffre' do
+        compte = Compte.new(password: 'aAAAAAAAAAA$', role: :superadmin)
+        described_class.new.validate(compte)
+        expect(compte.errors.include?(:password)).to be true
+      end
+
+      it 'quand le mot de passe ne contient pas de symbol' do
+        compte = Compte.new(password: 'aA3456789120', role: :superadmin)
+        described_class.new.validate(compte)
+        expect(compte.errors.include?(:password)).to be true
+      end
+
+      it 'quand le mot de passe ne contient pas assez de caracters' do
+        compte = Compte.new(password: 'aA34567891$', role: :superadmin)
+        described_class.new.validate(compte)
+        expect(compte.errors.include?(:password)).to be true
+      end
+
+      it 'vérifie les comptes anlci' do
+        Compte::ANLCI_ROLES.each do |role|
+          compte = Compte.new(password: '123456', role: role)
+          described_class.new.validate(compte)
+          expect(compte.errors.include?(:password)).to be true
+        end
+      end
+    end
+
+    context "compte standard, non anlci" do
+      it "Erreur si la taille est inférieur a 8 caracteres" do
+        %i[conseiller admin compte_generique].each do |role|
+          compte = Compte.new(password: '1234567', role: role)
+          described_class.new.validate(compte)
+          expect(compte.errors.include?(:password)).to be true
+          expect(compte.errors[:password])
+            .to eq [ "Votre mot de passe doit comporter au moins 8 caractères." ]
+        end
+      end
+
+      it "pas d'erreur si c'est 8 ou plus" do
+        %i[conseiller admin compte_generique].each do |role|
+          compte = Compte.new(password: '12345678', role: role)
+          described_class.new.validate(compte)
+          expect(compte.errors.include?(:password)).to be false
+        end
       end
     end
 


### PR DESCRIPTION
On affichait les deux règles moins de 8 et moins de 12 en même temps
![image](https://github.com/user-attachments/assets/afe116d0-e607-4217-97e8-68bcce1a8991)

## Maintenant : 
### pour les admins, conseillers et comptes génériques.
<img width="889" alt="Capture d’écran 2025-04-24 à 18 17 58" src="https://github.com/user-attachments/assets/9b29f656-9df8-4e44-8561-635ef2e1bbe4" />

### pour les superadmin et cmr
<img width="916" alt="Capture d’écran 2025-04-24 à 18 17 33" src="https://github.com/user-attachments/assets/16f6955c-0590-4456-b578-f3a06bc1d5d2" />
