### PR TITLE
Revert "🔧 Remonte les N+1 query directement sur Rollbar à l'aide de Bullet"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem "ancestry", "~> 4.3"
 gem "auto_strip_attributes", "~> 2.6"
 gem "bootsnap", ">= 1.1.0", require: false
 gem "bootstrap", "~> 4.3", ">= 4.3.1"
-gem "bullet"
 gem "cancancan"
 gem "chartkick"
 gem "coffee-rails"
@@ -75,6 +74,7 @@ source "https://rails-assets.org" do
 end
 
 group :development, :test do
+  gem "bullet"
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "listen", "~> 3.2"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,11 +1,4 @@
 Rails.application.configure do
-  config.after_initialize do
-    Bullet.enable = true
-    Bullet.rollbar = true
-    Bullet.rails_logger = true
-    Bullet.alert = false
-    Bullet.add_footer = false
-  end
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.


### PR DESCRIPTION
This reverts commit 9a75f9e01df96ec49234838b062d3543d0849a6f.

Les alertes bullets sont trop nombreuses et produisent trop de bruit sur rollbar