### PR TITLE
♿️ Tableau de bord, actus et campagnes : en 640px

### DIFF
--- a/app/assets/stylesheets/admin/composants/_carte_prise_en_main.scss
+++ b/app/assets/stylesheets/admin/composants/_carte_prise_en_main.scss
@@ -2,7 +2,10 @@ $grid-gutter-width: 1.25rem;
 
 .carte-prise-en-main {
   display: grid;
-  grid-template-columns: 4fr 2fr;
+  grid-template-columns: 66% 33%;
+  @media (max-width: 640px) {
+    grid-template-columns: 60% 40%;
+  }
   grid-gap: $grid-gutter-width;
   @include carte-avec-ombre();
   overflow: hidden;

--- a/app/assets/stylesheets/admin/layout/_main_structure.scss
+++ b/app/assets/stylesheets/admin/layout/_main_structure.scss
@@ -1,7 +1,11 @@
 #active_admin_content {
   padding: .5rem 0;
-  #main_content_wrapper #main_content {
-    margin-top: 2.5rem;
+  #main_content_wrapper {
+    max-width: 100vw;
+
+    #main_content {
+      margin-top: 2.5rem;
+    }
   }
 }
 

--- a/app/assets/stylesheets/admin/layout/_sidebar.scss
+++ b/app/assets/stylesheets/admin/layout/_sidebar.scss
@@ -31,7 +31,7 @@
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 854px) {
   #active_admin_content.with_sidebar {
     align-items: start;
     flex-direction: column;

--- a/app/assets/stylesheets/admin/mixins/_buttons.scss
+++ b/app/assets/stylesheets/admin/mixins/_buttons.scss
@@ -15,6 +15,7 @@
   box-shadow: none;
   transition: all 150ms ease-out;
   width: fit-content;
+  height: fit-content;
 
   border: 1px solid;
 

--- a/app/assets/stylesheets/admin/mixins/_typography.scss
+++ b/app/assets/stylesheets/admin/mixins/_typography.scss
@@ -25,7 +25,7 @@
 
 @mixin texte-xs() {
   font-size: 0.75rem;
-  line-height: 0.875rem;
+  line-height: 1rem;
 }
 
 @mixin h1() {

--- a/app/assets/stylesheets/admin/pages/_actualite.scss
+++ b/app/assets/stylesheets/admin/pages/_actualite.scss
@@ -1,12 +1,21 @@
 .admin_actualites {
   &.show {
-    #active_admin_content {
+    #active_admin_content.with_sidebar {
       #main_content_wrapper #main_content {
         margin-right: 465px;
       }
       #sidebar {
         width: 445px;
         margin-left: -445px;
+      }
+      @media (max-width: 854px) {
+        #main_content_wrapper #main_content {
+          margin-right: 0;
+        }
+        #sidebar {
+          width: 100%;
+          margin-left: 0;
+        }
       }
     }
 

--- a/app/assets/stylesheets/admin/pages/_campagne.scss
+++ b/app/assets/stylesheets/admin/pages/_campagne.scss
@@ -15,11 +15,6 @@
   }
 
   &.show {
-    // Retire le margin-right de activeadmin afin que le contenu de la page soit sur toute la largeur (filtre compris)
-    #active_admin_content #main_content_wrapper #main_content {
-      margin-right: 0;
-    }
-
     h2 {
       margin-top: 1.5rem;
     }

--- a/app/views/admin/campagnes/_show.html.arb
+++ b/app/views/admin/campagnes/_show.html.arb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 div class: "row" do
-  div class: "offset-1 col-4" do
+  div class: "offset-1 col-6" do
     div class: "panel font-italic" do
       t(".intro")
     end

--- a/config/locales/views/campagnes.yml
+++ b/config/locales/views/campagnes.yml
@@ -28,7 +28,7 @@ fr:
           vous pouvez partager le code ou l’URL suivante.
       banniere_test_campagne:
         testez_votre_campagne: |
-          #### Testez votre campagne !
+          #### Testez votre campagne !
 
           Tout est prêt pour évaluer les compétences que vous avez sélectionnées.
 


### PR DESCRIPTION
## Le tableau de bord
<img width="641" alt="Capture d’écran 2025-05-15 à 19 29 35" src="https://github.com/user-attachments/assets/cc0f2449-2d04-4779-82f9-2e64df627646" />
<img width="641" alt="Capture d’écran 2025-05-15 à 19 29 44" src="https://github.com/user-attachments/assets/ed3abd40-489c-4b48-919e-fc94097261f7" />
<img width="641" alt="Capture d’écran 2025-05-15 à 19 29 55" src="https://github.com/user-attachments/assets/e4809886-be7a-4fab-8d02-156f08c14afa" />

## Actualité
<img width="640" alt="Capture d’écran 2025-05-15 à 19 30 07" src="https://github.com/user-attachments/assets/c51abf68-6eb4-48c9-8eea-a9abf2c4cf04" />

## Campagne
<img width="642" alt="Capture d’écran 2025-05-15 à 19 30 28" src="https://github.com/user-attachments/assets/c2fcd267-065f-4b02-a728-d98c0c23fe7a" />
