### PR TITLE
Actualisation mail support

### DIFF
--- a/app/assets/stylesheets/admin/composants/_carte_prise_en_main.scss
+++ b/app/assets/stylesheets/admin/composants/_carte_prise_en_main.scss
@@ -34,7 +34,7 @@ $grid-gutter-width: 1.25rem;
     }
     &__progression {
       background-color: $eva_bluegrey;
-      padding: 0 1.5rem;
+      padding: 1rem 1.5rem;
       display: flex;
       flex-direction: column;
       justify-content: center;

--- a/app/lib/eva.rb
+++ b/app/lib/eva.rb
@@ -3,7 +3,7 @@
 module Eva
   DOCUMENT_PRISE_EN_MAIN = "https://docs.google.com/presentation/d/e/2PACX-1vRbrOAP6ojsMldL0YZaLLWH_nrluOd9kkp_0XACQsn7lateomMATUC5uEn_CZMLni--pjpfSJ366ppf/pub?start=true&loop=false&delayms=3000"
   EMAIL_CONTACT = "eva@anlci.gouv.fr"
-  EMAIL_SUPPORT = "support@eva.beta.gouv.fr"
+  EMAIL_SUPPORT = "eva@anlci.gouv.fr"
   EMAIL_DEMO = "demo@eva.beta.gouv.fr"
   STRUCTURE_DEMO = "Structure démo ANLCI"
   EMAIL_DEMO_EN_ATTENTE = "nouveau.anlci@yopmail.fr"

--- a/app/views/components/prise_en_main/_etape_fin.html.arb
+++ b/app/views/components/prise_en_main/_etape_fin.html.arb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 render partial: "components/prise_en_main/carte_base", locals: {
-  etape_en_cours: "fin"
+  etape_en_cours: "fin",
+  email: Eva::EMAIL_SUPPORT
 }

--- a/config/locales/views/components.yml
+++ b/config/locales/views/components.yml
@@ -103,7 +103,6 @@ fr:
             Bravo ! Vous avez terminé ce tutoriel
 
             Nos équipes restent à votre disposition :  
-            - via <a href="mailto:support@eva.beta.gouv.fr" class="text-primary">support@eva.beta.gouv.fr</a>  
-            - via le chat (la petite bulle bleue en bas à droite de votre écran)
+            - via <a href="mailto:%{email}" class="text-primary">%{email}</a>  
     pastille:
       illettrisme_potentiel: Illettrisme potentiel

--- a/config/locales/views/compte_mailer.yml
+++ b/config/locales/views/compte_mailer.yml
@@ -40,9 +40,10 @@ fr:
 
         Depuis %{delai_relance} vous avez un accès gratuit à eva.
 
-        Eva est un outil d’évaluation ludique qui permet de détecter
-        l'illettrisme et de valoriser les %{cible_evaluation} que vous accompagnez
-        en vous appuyant sur leurs compétences transversales.
+        Eva est un outil d'évaluation ludique qui permet de détecter
+        difficultés avec les compétences de base et de valoriser les
+        %{cible_evaluation} que vous accompagnez en vous appuyant sur leurs
+        compétences transversales.
 
         ### Vous souhaitez essayer eva ? Découvrir les jeux, les réaliser puis visualiser les résultats ?
 

--- a/db/migrate/20250521170412_actualise_email_support.rb
+++ b/db/migrate/20250521170412_actualise_email_support.rb
@@ -1,0 +1,11 @@
+class ActualiseEmailSupport < ActiveRecord::Migration[7.2]
+  def up
+    email_support = Compte.find_by(email: 'support@eva.beta.gouv.fr')
+    email_support&.update_columns(email: 'eva@anlci.gouv.fr')
+  end
+
+  def down
+    email_support = Compte.find_by(email: 'eva@anlci.gouv.fr')
+    email_support&.update_columns(email: 'support@eva.beta.gouv.fr')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_15_133456) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_21_170412) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -163,7 +163,7 @@ describe 'Dashboard', type: :feature do
       it do
         expect(page).to have_content("Elle va bientôt vous permettre d'utiliser eva")
         infos_support =
-          'contacter Véronique au 06 01 02 03 04 ou par mail à support@eva.beta.gouv.fr'
+          'contacter Véronique au 06 01 02 03 04 ou par mail à eva@anlci.gouv.fr'
         expect(page).to have_content infos_support
       end
     end


### PR DESCRIPTION
Nous ne voulons plus utiliser support@eva.beta.gouv.fr

Maintenant, une seule adresse de contact : eva@anlci.gouv.fr

Cette PR fait aussi deux autres trucs : 
- actualiser aussi le texte du mail de relance
