### PR TITLE
💄 Place l'icon "lien extern" bien à droite sur toutes les sources d'aide

### DIFF
--- a/app/assets/stylesheets/admin/pages/aide/_sources_aide.scss
+++ b/app/assets/stylesheets/admin/pages/aide/_sources_aide.scss
@@ -18,16 +18,20 @@
       width: 111px;
     }
 
-    .titre {
-      font-weight: bold;
-      margin-bottom: .5rem;
-    }
+    .details {
+      width: 100%;
 
-    .description {
-      font-style: italic;
-      p {
-        line-height: 1rem;
-        font-size: .875rem;
+      .titre {
+        font-weight: bold;
+        margin-bottom: .5rem;
+      }
+
+      .description {
+        font-style: italic;
+        p {
+          line-height: 1rem;
+          font-size: .875rem;
+        }
       }
     }
 


### PR DESCRIPTION
## Avant
<img width="1017" alt="Capture d’écran 2025-05-22 à 11 46 35" src="https://github.com/user-attachments/assets/c296feba-06c6-43b4-b295-8de7391069fd" />

## Après
<img width="956" alt="Capture d’écran 2025-05-22 à 15 47 34" src="https://github.com/user-attachments/assets/9bda63ca-943f-4ee7-9ca2-45e26c6b91d6" />
