### PR TITLE
🐛 💄 Fix une largeur max 100% aux champs de type select2

### DIFF
--- a/app/assets/stylesheets/admin/composants/_forms.scss
+++ b/app/assets/stylesheets/admin/composants/_forms.scss
@@ -234,6 +234,8 @@ form:not(.filter_form) .select2-container {
 }
 .select2 {
   &-container {
+    max-width: 100%;
+
     .select2-selection {
       @include base-input();
       height: 2.5rem;


### PR DESCRIPTION
## Avant
<img width="323" alt="Capture d’écran 2025-05-28 à 16 42 14" src="https://github.com/user-attachments/assets/ec937a31-6ee0-45e9-912a-9d47e8700994" />

## Après
<img width="315" alt="Capture d’écran 2025-05-28 à 16 42 20" src="https://github.com/user-attachments/assets/03133450-8fd4-4324-a874-4502817e492f" />
