### PR TITLE
💬 Corrige Lieur en Lien

### DIFF
--- a/app/admin/beneficiaire.rb
+++ b/app/admin/beneficiaire.rb
@@ -17,7 +17,7 @@ ActiveAdmin.register Beneficiaire do
     beneficiaire = beneficiaires.par_date_creation_asc.first
     beneficiaires_a_fusionner = beneficiaires.sauf_pour(beneficiaire.id)
 
-    LieurBeneficiaires.new(beneficiaire, beneficiaires_a_fusionner).call
+    LienBeneficiaires.new(beneficiaire, beneficiaires_a_fusionner).call
 
     redirect_to collection_path,
         notice: "Les évaluations ont été transférées vers le bénéficiaire le plus ancien."

--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -51,7 +51,7 @@ ActiveAdmin.register Evaluation do
       next
     end
 
-    LieurEvaluations.new(evaluations).call
+    LienEvaluations.new(evaluations).call
 
     redirect_to collection_path,
         notice: I18n.t("active_admin.batch_actions.evaluation.message_notice")

--- a/app/models/lien_beneficiaires.rb
+++ b/app/models/lien_beneficiaires.rb
@@ -1,4 +1,4 @@
-class LieurBeneficiaires
+class LienBeneficiaires
   attr_reader :beneficiaire, :beneficiaires_a_fusionner
 
   def initialize(beneficiaire, beneficiaires_a_fusionner)

--- a/app/models/lien_evaluations.rb
+++ b/app/models/lien_evaluations.rb
@@ -1,4 +1,4 @@
-class LieurEvaluations
+class LienEvaluations
   attr_reader :evaluations
 
   def initialize(evaluations)

--- a/spec/models/lien_beneficiaires_spec.rb
+++ b/spec/models/lien_beneficiaires_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe LieurBeneficiaires, type: :model do
+describe LienBeneficiaires, type: :model do
   describe '.call' do
     let(:beneficiaire) { instance_double(Beneficiaire, id: 1) }
     let(:beneficiaires) { class_double(Beneficiaire) }

--- a/spec/models/lien_evaluations_spec.rb
+++ b/spec/models/lien_evaluations_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe LieurEvaluations, type: :model do
+RSpec.describe LienEvaluations, type: :model do
   describe '#call' do
     let!(:beneficiaire_ancien) { create(:beneficiaire, created_at: 3.years.ago) }
     let!(:beneficiaire_recent) { create(:beneficiaire, created_at: 1.year.ago) }


### PR DESCRIPTION
Lieur n'étant pas un mot ayant du sens dans ce contexte, et comme on ne code pas en Anglais pour ne pas faire de fautes ou de non sens, il en est de même ici.