### PR TITLE
🐛 Corrige l'affichage de la légende des barres segmentées

### DIFF
--- a/config/locales/components/barre_segmentee.yml
+++ b/config/locales/components/barre_segmentee.yml
@@ -1,4 +1,4 @@
 fr:
   barre_segmentee:
-    legende: "Réussite : %{reussite}, Échec : %{echec}, Non passés : %{non_passees}, Total : %{total}"
+    legende: "Réussite : %{reussite}, Échec : %{echec}, Non passés : %{non_passees}, Total : %{total}"
     score: "Score %{score}%"

--- a/spec/components/barre_segmentee_component_spec.rb
+++ b/spec/components/barre_segmentee_component_spec.rb
@@ -25,7 +25,7 @@ describe BarreSegmenteeComponent, type: :component do
     expect(page).to have_content("Réussite : #{nombre_questions_reussies}")
     expect(page).to have_content("Échec : #{nombre_questions_echecs}")
     expect(page).to have_content("Non passés : #{nombre_questions_non_passees}")
-    expect(page).to have_content("Total : #{component.nombre_questions_total}")
+    expect(page).to have_content("Total : #{component.nombre_questions_total}")
     expect(page).to have_content("Score #{pourcentage_reussite}%")
   end
 


### PR DESCRIPTION
Dans le cas ou il y a 10 tests

## Avant
<img width="854" alt="Capture d’écran 2025-06-12 à 17 20 02" src="https://github.com/user-attachments/assets/4677056a-161c-4ba2-97f6-c20145a1b6d6" />

## Après
<img width="856" alt="Capture d’écran 2025-06-12 à 17 20 11" src="https://github.com/user-attachments/assets/6f296de5-163a-4c51-9523-6f125829fe4d" />
