### PR TITLE
🐛 Restitution sociodémo : Affiche le nom technique du choix si son libellé n'est pas trouvé

### DIFF
--- a/app/models/question_qcm.rb
+++ b/app/models/question_qcm.rb
@@ -13,7 +13,8 @@ class QuestionQcm < Question
   accepts_nested_attributes_for :choix, allow_destroy: true
 
   def restitue_reponse(nom_technique_reponse)
-    choix.find { |c| c.nom_technique == nom_technique_reponse }.intitule
+    reponse = choix.find { |c| c.nom_technique == nom_technique_reponse }
+    reponse.present? ? reponse.intitule : nom_technique_reponse
   end
 
   def intitule_reponse(reponse)

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -69,6 +69,21 @@ describe Question, type: :model do
         expect(question.reload.restitue_reponse('choix_1')).to eq 'intitule'
       end
     end
+
+    context "quand la reponse est un des choix d'un qcm inconnu" do
+      let(:choix1) do
+        create :choix,
+               :bon,
+               nom_technique: 'choix_1',
+               intitule: 'intitule'
+      end
+      let(:question) { create :question_qcm, choix: [ choix1 ] }
+
+      it "retourne l'intitulé de la réponse" do
+        expect(question.reload.restitue_reponse('nom_technique_inconnu'))
+          .to eq 'nom_technique_inconnu'
+      end
+    end
   end
 
   describe '#json_audio_fields' do


### PR DESCRIPTION

rollbar https://app.rollbar.com/a/eva-betagouv/fix/item/eva-serveur/90