### PR TITLE
🌐 Ajustement du libellé du filtre des dates de fin pour inciter à comprendre que la date n'est pas inclue

### DIFF
--- a/app/assets/javascripts/filtres_dates.js
+++ b/app/assets/javascripts/filtres_dates.js
@@ -12,7 +12,7 @@ function convertir_champ(input, label) {
 function utilise_date_picker_du_dsfr(filtre) {
   if (!filtre) return;
 
-  filtre.querySelectorAll('label').forEach((label) => label.remove());
+  filtre.querySelectorAll('label').forEach(label => label.remove());
   const champs = filtre.querySelectorAll('input');
   convertir_champ(champs[0], I18n.t('admin.date_depuis'));
   convertir_champ(champs[1], I18n.t('admin.date_jusqua'));

--- a/config/locales/date.yml
+++ b/config/locales/date.yml
@@ -1,7 +1,7 @@
 fr:
   admin:
-    date_depuis: créé(e) depuis le
-    date_jusqua: jusqu'au
+    date_depuis: Créé(e) depuis le
+    date_jusqua: Créé(e) avant le
   date:
     formats: &formats
       sans_heure: "%d %b %Y"


### PR DESCRIPTION
<img width="365" alt="Capture d’écran 2025-07-03 à 14 53 29" src="https://github.com/user-attachments/assets/7970c274-9d89-4a70-88bb-e85c1dbba119" />
