### PR TITLE
Refactorise les composants Tableau et Badges

### DIFF
--- a/app/assets/stylesheets/admin/composants/_tableau.scss
+++ b/app/assets/stylesheets/admin/composants/_tableau.scss
@@ -1,6 +1,8 @@
-.tableau-boutons-action {
-  direction: rtl;
+.fr-table__content td.tableau-boutons-action {
+  text-align: right;
+}
 
+.tableau-boutons-action {
   .menu-actions {
     @include menu-actions();
 

--- a/app/assets/stylesheets/admin/composants/_tables.scss
+++ b/app/assets/stylesheets/admin/composants/_tables.scss
@@ -9,9 +9,6 @@ table.index_table {
 
   .col-actions {
     text-align: right;
-    .bouton-menu {
-      display: inline-flex;
-    }
   }
 
   thead {

--- a/app/assets/stylesheets/admin/mixins/_buttons.scss
+++ b/app/assets/stylesheets/admin/mixins/_buttons.scss
@@ -7,7 +7,7 @@
   &, &:link, &:visited {
     background-image: none;
   }
-  display: flex;
+  display: inline-flex;
   justify-content: center;
   cursor: pointer;
   font-family: $font-texte;

--- a/app/components/badge_component.rb
+++ b/app/components/badge_component.rb
@@ -15,6 +15,6 @@ class BadgeComponent < ViewComponent::Base
   end
 
   def display_icon_class
-    @display_icon ? "" : "fr-badge--no-icon"
+    @display_icon ? nil : "fr-badge--no-icon"
   end
 end

--- a/app/components/badge_component.rb
+++ b/app/components/badge_component.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 class BadgeComponent < ViewComponent::Base
-  def initialize(contenu:, html_class:, display_icon: false, taille: nil)
+  def initialize(contenu:, class_couleur:, display_icon: false, taille: nil)
     @contenu = contenu
-    @html_class = html_class
+    @class_couleur = class_couleur
     @display_icon = display_icon
     @taille = taille
   end
 
   def css_classes
-    classes = [ "fr-badge", @html_class, display_icon_class ]
+    classes = [ "fr-badge", @class_couleur, display_icon_class ]
     classes << "fr-badge--#{@taille}" if @taille.present?
     classes.compact.join(" ")
   end

--- a/app/components/statut_campagne_component.html.erb
+++ b/app/components/statut_campagne_component.html.erb
@@ -1,11 +1,11 @@
 <%= render BadgeComponent.new(
   contenu: @campagne_active ? "ACTIVE" : "INACTIVE",
-  html_class: @campagne_active ? "fr-badge--green-emeraude" : ""
+  class_couleur: @campagne_active ? "fr-badge--green-emeraude" : ""
 ) %>
 
 <% if @campagne_privee %>
   <%= render BadgeComponent.new(
     contenu: "PRIVÉE",
-    html_class: "fr-badge--blue-cumulus"
+    class_couleur: "fr-badge--blue-cumulus"
   ) %>
 <% end %>

--- a/app/components/tableau_component.html.erb
+++ b/app/components/tableau_component.html.erb
@@ -14,9 +14,9 @@
             <% collection.each_with_index do |item, index| %>
               <tr id="table-0-row-key-<%= index + 1 %>" data-row-key="<%= index + 1 %>">
                 <% colonnes.each do |colonne| %>
-                  <td class="<%= colonne[:td_class] %>">
+                  <%= tag.td(class: colonne[:td_class].presence) do %>
                     <%= view_context.capture(item, &colonne[:block]) %>
-                  </td>
+                  <% end %>
                 <% end %>
               </tr>
             <% end %>

--- a/app/components/tableau_component.rb
+++ b/app/components/tableau_component.rb
@@ -4,7 +4,7 @@ class TableauComponent < ViewComponent::Base
     @colonnes = []
   end
 
-  def colonne(titre: nil, td_class: nil, &block)
+  def colonne(titre: nil, td_class: "", &block)
     @colonnes << { titre: titre, td_class: td_class, block: block }
   end
 

--- a/app/helpers/evaluation_helper.rb
+++ b/app/helpers/evaluation_helper.rb
@@ -81,7 +81,7 @@ module EvaluationHelper
   def construit_badge(contenu, niveau)
     render BadgeComponent.new(
       contenu: contenu,
-      html_class: couleur_badges_positionnement(niveau),
+      class_couleur: couleur_badges_positionnement(niveau),
       display_icon: false,
       taille: "sm"
     )

--- a/app/views/admin/structures/_show.html.arb
+++ b/app/views/admin/structures/_show.html.arb
@@ -23,7 +23,7 @@ div class: "row" do
                 contenu: traduction_autorisation_creation_campagne(
                   resource.autorisation_creation_campagne
                 ),
-                html_class: badge_class(structure.autorisation_creation_campagne))
+                class_couleur: badge_class(structure.autorisation_creation_campagne))
               )
             end
             row :region

--- a/app/views/admin/ui_kit/badge.html.erb
+++ b/app/views/admin/ui_kit/badge.html.erb
@@ -10,7 +10,7 @@
   <div class="fr-mb-3w">Taille par defaut (md):
     <%= render BadgeComponent.new(
       contenu: "Nouveau",
-      html_class: "fr-badge--success",
+      class_couleur: "fr-badge--success",
       display_icon: true
     ) %>
   </div>
@@ -18,7 +18,7 @@
   <div class="fr-mb-2w">Taille sm:
     <%= render BadgeComponent.new(
       contenu: "Nouveau",
-      html_class: "fr-badge--success",
+      class_couleur: "fr-badge--success",
       display_icon: true,
       taille: "sm"
     ) %>
@@ -29,7 +29,7 @@
   <div class="fr-mb-3w">Taille par defaut (md):
     <%= render BadgeComponent.new(
       contenu: "Terminé",
-      html_class: "fr-badge--info",
+      class_couleur: "fr-badge--info",
       display_icon: false
     ) %>
   </div>
@@ -37,7 +37,7 @@
   <div class="fr-mb-3w">Taille sm:
     <%= render BadgeComponent.new(
       contenu: "Terminé",
-      html_class: "fr-badge--info",
+      class_couleur: "fr-badge--info",
       display_icon: false,
       taille: "sm"
     ) %>
@@ -45,15 +45,15 @@
 
   <h2>Différents types</h2>
   <div class="fr-mb-2w">
-    <%= render BadgeComponent.new(contenu: "Succès", html_class: "fr-badge--success", display_icon: true) %>
+    <%= render BadgeComponent.new(contenu: "Succès", class_couleur: "fr-badge--success", display_icon: true) %>
   </div>
   <div class="fr-mb-2w">
-    <%= render BadgeComponent.new(contenu: "Erreur", html_class: "fr-badge--error", display_icon: true) %>
+    <%= render BadgeComponent.new(contenu: "Erreur", class_couleur: "fr-badge--error", display_icon: true) %>
   </div>
   <div class="fr-mb-2w">
-    <%= render BadgeComponent.new(contenu: "Info", html_class: "fr-badge--info", display_icon: true) %>
+    <%= render BadgeComponent.new(contenu: "Info", class_couleur: "fr-badge--info", display_icon: true) %>
   </div>
   <div class="fr-mb-2w">
-    <%= render BadgeComponent.new(contenu: "Warning", html_class: "fr-badge--warning", display_icon: true) %>
+    <%= render BadgeComponent.new(contenu: "Warning", class_couleur: "fr-badge--warning", display_icon: true) %>
   </div>
 </div> 

--- a/spec/components/badge_component_spec.rb
+++ b/spec/components/badge_component_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe BadgeComponent, type: :component do
+  subject(:component) do
+    described_class.new(
+      contenu: contenu,
+      html_class: html_class,
+      display_icon: display_icon,
+      taille: taille
+    )
+  end
+
+  let(:contenu) { "Nouveau" }
+  let(:html_class) { "fr-badge--success" }
+  let(:display_icon) { false }
+  let(:taille) { nil }
+
+  it "rend correctement le badge avec ses classes par défaut" do
+    render_inline(component)
+
+    expect(page).to have_css(".fr-badge.fr-badge--success.fr-badge--no-icon")
+    expect(page).to have_content(contenu)
+  end
+
+  context "quand display_icon est true" do
+    let(:display_icon) { true }
+
+    it "ne met pas la classe fr-badge--no-icon" do
+      render_inline(component)
+
+      expect(page).to have_css(".fr-badge.fr-badge--success")
+      expect(page).not_to have_css(".fr-badge--no-icon")
+    end
+  end
+
+  context "quand une taille est spécifiée" do
+    let(:taille) { "sm" }
+
+    it "ajoute la classe correspondant à la taille" do
+      render_inline(component)
+
+      expect(page).to have_css(".fr-badge.fr-badge--success.fr-badge--no-icon.fr-badge--sm")
+    end
+  end
+
+  context "quand html_class est vide" do
+    let(:html_class) { "" }
+
+    it "rend un badge sans la classe spécifique" do
+      render_inline(component)
+
+      expect(page).to have_css(".fr-badge.fr-badge--no-icon")
+      expect(page).not_to have_css(".fr-badge--success")
+    end
+  end
+end

--- a/spec/components/badge_component_spec.rb
+++ b/spec/components/badge_component_spec.rb
@@ -6,14 +6,14 @@ describe BadgeComponent, type: :component do
   subject(:component) do
     described_class.new(
       contenu: contenu,
-      html_class: html_class,
+      class_couleur: class_couleur,
       display_icon: display_icon,
       taille: taille
     )
   end
 
   let(:contenu) { "Nouveau" }
-  let(:html_class) { "fr-badge--success" }
+  let(:class_couleur) { "fr-badge--success" }
   let(:display_icon) { false }
   let(:taille) { nil }
 
@@ -46,7 +46,7 @@ describe BadgeComponent, type: :component do
   end
 
   context "quand html_class est vide" do
-    let(:html_class) { "" }
+    let(:class_couleur) { "" }
 
     it "rend un badge sans la classe spécifique" do
       render_inline(component)


### PR DESCRIPTION
Screen sur firefox :
<img width="1917" height="1052" alt="Capture d’écran 2025-07-31 à 12 23 42" src="https://github.com/user-attachments/assets/752fb00d-8836-416c-a1dc-f2820c44f5cb" />

Screen sur chrome :
<img width="1907" height="952" alt="Capture d’écran 2025-07-31 à 12 23 53" src="https://github.com/user-attachments/assets/9ebafdb7-011b-4c13-9d11-f49e7e1a3fd5" />
