### PR TITLE
🐛 Fix l'affichage des badges dans la liste des evaluations de positionnement

### DIFF
--- a/app/helpers/evaluation_helper.rb
+++ b/app/helpers/evaluation_helper.rb
@@ -59,8 +59,31 @@ module EvaluationHelper
   def traduit_niveau(evaluation, interpretation)
     scope = "activerecord.attributes.evaluation.interpretations"
     niveau = evaluation.send(interpretation)
-    return "Non testé" if niveau.blank?
+    return t("#{interpretation}.indetermine", scope: scope) if niveau.blank?
 
     t("#{interpretation}.#{niveau}", scope: scope)
+  end
+
+  def badge_positionnement(evaluation, competence)
+    if evaluation.campagne.avec_positionnement?(competence)
+      niveau = evaluation.send("positionnement_niveau_#{competence}")
+      contenu = traduit_niveau(evaluation, :"positionnement_niveau_#{competence}")
+    else
+      niveau = nil
+      contenu = t("activerecord.attributes.evaluation.interpretations.non_teste")
+    end
+
+    construit_badge(contenu, niveau)
+  end
+
+  private
+
+  def construit_badge(contenu, niveau)
+    render BadgeComponent.new(
+      contenu: contenu,
+      html_class: couleur_badges_positionnement(niveau),
+      display_icon: false,
+      taille: "sm"
+    )
   end
 end

--- a/app/views/admin/beneficiaires/_liste_evaluations_positionnement.html.erb
+++ b/app/views/admin/beneficiaires/_liste_evaluations_positionnement.html.erb
@@ -4,29 +4,14 @@
       <% evaluation.created_at.strftime("%d/%m/%Y") %>
     <%end %>
 
-    <% tableau.colonne(titre: "Littératie") do |evaluation|%>
-      <% niveau_litteratie = evaluation.positionnement_niveau_litteratie %>
-      <% contenu = traduit_niveau(evaluation, :positionnement_niveau_litteratie) %>
-
-      <%= render BadgeComponent.new(
-        contenu: contenu,
-        html_class: couleur_badges_positionnement(niveau_litteratie),
-        display_icon: false,
-        taille: "sm"
-      ) %>
+    <% tableau.colonne(titre: t(".litteratie")) do |evaluation| %>
+      <%= badge_positionnement(evaluation, :litteratie) %>
     <% end %>
 
-    <% tableau.colonne(titre: "Numératie") do |evaluation|%>
-      <% niveau_numeratie = evaluation.positionnement_niveau_numeratie %>
-      <% contenu = traduit_niveau(evaluation, :positionnement_niveau_numeratie) %>
-
-      <%= render BadgeComponent.new(
-        contenu: contenu,
-        html_class: couleur_badges_positionnement(niveau_numeratie),
-        display_icon: false,
-        taille: "sm"
-      ) %>
+    <% tableau.colonne(titre: t(".numeratie")) do |evaluation| %>
+      <%= badge_positionnement(evaluation, :numeratie) %>
     <% end %>
+
     <% tableau.colonne(td_class: "col-actions tableau-boutons-action") do |evaluation| %>
       <%= render MenuActionsComponent.new(
         { label: t("admin.evaluations.index.voir"), url: admin_evaluation_path(evaluation) },

--- a/config/locales/models/evaluation.yml
+++ b/config/locales/models/evaluation.yml
@@ -34,6 +34,7 @@ fr:
         beneficiaire: Bénéficiaire
         responsable_suivi: Responsable de suivi
         interpretations:
+          non_teste: Non testé
           synthese_competences_de_base:
             socle_clea: supérieur
             ni_ni: intermédiaire

--- a/config/locales/views/beneficiaire.yml
+++ b/config/locales/views/beneficiaire.yml
@@ -12,3 +12,5 @@ fr:
       liste_evaluations_positionnement:
         titre-evaluation-positionnement: "Évaluations de positionnement"
         created_at: "Date"
+        litteratie: "Littératie"
+        numeratie: "Numératie"

--- a/spec/helpers/evaluation_helper_spec.rb
+++ b/spec/helpers/evaluation_helper_spec.rb
@@ -15,4 +15,41 @@ describe EvaluationHelper do
       expect(niveau_bas?(:profil_autre)).to be false
     end
   end
+
+  describe "#badge_positionnement" do
+    let(:campagne) { instance_double(Campagne) }
+    let(:evaluation) { instance_double(Evaluation, campagne: campagne) }
+
+    before do
+      allow(helper).to receive(:construit_badge).and_return("<fr-badge />".html_safe)
+    end
+
+    context "quand la campagne a un positionnement pour la compétence" do
+      before do
+        allow(campagne).to receive(:avec_positionnement?).with(:litteratie).and_return(true)
+        allow(evaluation).to receive(:positionnement_niveau_litteratie).and_return("profil1")
+        allow(helper).to receive(:traduit_niveau)
+          .with(evaluation, :positionnement_niveau_litteratie)
+          .and_return("Profil 1")
+      end
+
+      it "construit un badge avec le contenu traduit et le niveau" do
+        helper.badge_positionnement(evaluation, :litteratie)
+
+        expect(helper).to have_received(:construit_badge).with("Profil 1", "profil1")
+      end
+    end
+
+    context "quand la campagne n’a pas de positionnement pour la compétence" do
+      before do
+        allow(campagne).to receive(:avec_positionnement?).with(:numeratie).and_return(false)
+      end
+
+      it "construit un badge avec 'Non testé' et niveau nil" do
+        helper.badge_positionnement(evaluation, :numeratie)
+
+        expect(helper).to have_received(:construit_badge).with("Non testé", nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Si une evaluation de positionnement litteratie et que la valeur positionnement_niveau_litteratie est nil, on doit afficher "pas de resultat." Idem pour la numeratie