### PR TITLE
🐛 Termine de remplacer le nom de l'évaluation par le nom du bénéficiaire

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ L'api est accessible au point `/api`
 {
   "nom": "Roger",
   "code_campagne": "Mon code de campagne",
-  "terminee_le": "2021-10-06T16:13:24+0000"
+  "debutee_le": "2021-10-03T22:15:24+0000",
+  "terminee_le": "2021-10-03T22:25:24+0000"
 }
 ```
 
@@ -91,7 +92,8 @@ L'api est accessible au point `/api`
   "id": "51b4b749-7ac2-40b4-b8f8-b8c9e5663c69",
   "nom": "Roger",
   "telephone": null,
-  "terminee_le": "2021-10-03T22:15:24.000+02:00",
+  "debutee_le": "2021-10-03T22:15:24.000+02:00",
+  "terminee_le": "2021-10-03T22:25:24.000+02:00",
   "updated_at": "2021-10-08T09:27:09.754+02:00"
 }
 ```
@@ -104,8 +106,6 @@ L'api est accessible au point `/api`
 
 ```json
 {
-  "email":"Roger@structure.fr",
-  "telephone":"06",
   "terminee_le":"2021-10-03T22:15:24+02:00"
   "age":"23",
   "genre":"Femme",
@@ -121,12 +121,10 @@ L'api est accessible au point `/api`
   "anonymise_le": "2021-10-06T17:04:49.780+02:00",
   "campagne_id": "09209dea-0fa7-40ea-aba8-cbadc1957f4d",
   "created_at": "2021-10-03T20:51:18.490+02:00",
-  "email": "Roger@structure.fr",
   "id": "569cdc17-554d-4227-acfe-1d5d3a4afdbc",
   "nom": "Roger",
-  "telephone": "06",
   "terminee_le": "2021-10-06T16:13:24.000+02:00",
-  "updated_at": "2021-10-08T09:16:38.943+02:00"
+  "updated_at": "2021-10-08T09:16:38.943+02:00",
   "age":"23",
   "genre":"Femme",
   "dernier_niveau_etude":"Niveau Collège",

--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register Evaluation do
 
   config.sort_order = "created_at_desc"
 
-  filter :nom
+  filter :beneficiaire
   filter :campagne_id,
          as: :search_select_filter,
          url: proc { admin_campagnes_path },
@@ -72,8 +72,8 @@ ActiveAdmin.register Evaluation do
     column("structure") { |evaluation| evaluation.campagne&.structure&.nom }
     column(:campagne) { |evaluation| evaluation.campagne&.libelle }
     column(:created_at) { |evaluation| I18n.l(evaluation.created_at, format: :sans_heure) }
-    column :nom
-    column("code_beneficiaire") { |evaluation| evaluation.beneficiaire&.code_beneficiaire }
+    column("nom_beneficiaire") { |evaluation| evaluation.beneficiaire.nom }
+    column("code_beneficiaire") { |evaluation| evaluation.beneficiaire.code_beneficiaire }
     column(:completude) do |evaluation|
       I18n.t(evaluation.completude, scope: "activerecord.attributes.evaluation")
     end

--- a/app/assets/stylesheets/admin/pages/_evaluations.scss
+++ b/app/assets/stylesheets/admin/pages/_evaluations.scss
@@ -30,11 +30,11 @@
     }
   }
 
-  .evaluation__code-personnel {
+  .evaluation__code-beneficiaire {
     margin-left: 1.75rem;
   }
 
-  .evaluation__code-personnel, .evaluation__parcours-type, .evaluation__created_at {
+  .evaluation__code-beneficiaire, .evaluation__parcours-type, .evaluation__created_at {
     color: $eva_dark_blue_grey;
     @include texte-xs();
     font-style: normal;
@@ -72,7 +72,7 @@
     height: 2.875rem;
     justify-content: space-between;
   }
-  .col-nom {
+  .col-beneficiaire {
     .ellipse {
       margin-right: .75rem;
     }

--- a/app/controllers/api/evaluations_controller.rb
+++ b/app/controllers/api/evaluations_controller.rb
@@ -48,11 +48,15 @@ module Api
     end
 
     def permit_params
-      params.permit(:id, :nom, :code_beneficiaire, :code_campagne, :terminee_le, :debutee_le,
-                    :beneficiaire_id, conditions_passation_attributes:
-                    %i[user_agent hauteur_fenetre_navigation largeur_fenetre_navigation],
-                    donnee_sociodemographique_attributes:
-                    %i[age genre dernier_niveau_etude derniere_situation])
+      permitted_params = [ :id, :code_beneficiaire, :code_campagne, :terminee_le, :debutee_le,
+                         :beneficiaire_id, conditions_passation_attributes:
+                         %i[user_agent hauteur_fenetre_navigation largeur_fenetre_navigation],
+                         donnee_sociodemographique_attributes:
+                         %i[age genre dernier_niveau_etude derniere_situation] ]
+
+      permitted_params << :nom if params[:id].blank?
+
+      params.permit(permitted_params)
     end
 
     def retrouve_ids_nested_attributes

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -27,7 +27,7 @@ class Evaluation < ApplicationRecord
   has_many :parties, dependent: :destroy
 
   before_validation :trouve_campagne_depuis_code
-  validates :nom, :debutee_le, :statut, presence: true
+  validates :debutee_le, :statut, presence: true
   validate :code_campagne_connu
 
   accepts_nested_attributes_for :conditions_passation
@@ -73,7 +73,7 @@ class Evaluation < ApplicationRecord
   scope :positionnement, -> { avec_type_de_programme(:positionnement) }
 
   def display_name
-    beneficiaire.nom
+    "#{beneficiaire.nom} - #{I18n.l(debutee_le, format: :avec_heure)}"
   end
 
   def anonyme?

--- a/app/models/restitution/base.rb
+++ b/app/models/restitution/base.rb
@@ -86,7 +86,7 @@ module Restitution
     end
 
     def display_name
-      "#{evaluation.nom} - #{situation.libelle}"
+      "#{evaluation.display_name} - #{situation.libelle}"
     end
 
     private

--- a/app/models/restitution/globale.rb
+++ b/app/models/restitution/globale.rb
@@ -22,8 +22,8 @@ module Restitution
       @evaluation.update interpretations.merge(completude: restitution_complete)
     end
 
-    def utilisateur
-      evaluation.nom
+    def beneficiaire
+      evaluation.beneficiaire.nom
     end
 
     def date

--- a/app/models/restitution/positionnement/export.rb
+++ b/app/models/restitution/positionnement/export.rb
@@ -19,9 +19,10 @@ module Restitution
 
       def nom_du_fichier
         evaluation = @partie.evaluation
-        code_de_campagne = evaluation.campagne.code.parameterize
-        nom_de_levaluation = evaluation.nom.parameterize.first(15)
-        nom_fichier_horodate("#{nom_de_levaluation}-#{code_de_campagne}", "xls")
+        date_debut = evaluation.debutee_le.strftime("%Y%m%d%H%M%S")
+        nom = evaluation.beneficiaire.nom.parameterize.first(25)
+        code_de_campagne = evaluation.campagne.code
+        "#{date_debut}-#{nom}-#{code_de_campagne}.xls"
       end
 
       private

--- a/app/views/admin/evaluations/_beneficiaire.erb
+++ b/app/views/admin/evaluations/_beneficiaire.erb
@@ -10,7 +10,7 @@
       <%= render(NomAnonymisableComponent.new(evaluation.beneficiaire)) %>
     <% end %>
   </div>
-  <div class= "evaluation__code-personnel <%= presence_pastille? ? "" : "ml-0" %>">
+  <div class= "evaluation__code-beneficiaire <%= presence_pastille? ? "" : "ml-0" %>">
     <%= evaluation.beneficiaire.code_beneficiaire %>
   </div>
 </div>

--- a/app/views/admin/evaluations/_entete_page.arb
+++ b/app/views/admin/evaluations/_entete_page.arb
@@ -7,7 +7,7 @@ div class: "en-tete-page" do
         span image_tag "eva-logo.svg", alt: "logo EVA"
       end
       span class: "nom-evalue" do
-        restitution_globale.utilisateur
+        restitution_globale.beneficiaire
       end
     end
     div class: "col col-3 contexte" do

--- a/app/views/admin/evaluations/_index.html.arb
+++ b/app/views/admin/evaluations/_index.html.arb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 context.instance_eval do
-  column(:nom) do |evaluation|
-    render partial: "nom_evaluation", locals: { evaluation: evaluation }
+  column :beneficiaire do |evaluation|
+    render partial: "beneficiaire", locals: { evaluation: evaluation }
   end
 
   column :campagne do |evaluation|

--- a/app/views/admin/restitutions/_informations_generales_sidebar.html.arb
+++ b/app/views/admin/restitutions/_informations_generales_sidebar.html.arb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 attributes_table_for resource do
-  row :utilisateur do |restitution|
-    restitution.evaluation.nom
+  row Evaluation.human_attribute_name("beneficiaire") do |restitution|
+    restitution.evaluation.beneficiaire.nom
   end
   row :situation
   row :date

--- a/app/views/api/evaluations/_evaluation.jbuilder
+++ b/app/views/api/evaluations/_evaluation.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 json.id evaluation.id
-json.nom evaluation.nom
+json.nom evaluation.beneficiaire.nom
 json.campagne_id evaluation.campagne_id
 json.debutee_le evaluation.debutee_le
 json.terminee_le evaluation.terminee_le

--- a/config/locales/models/evaluation.yml
+++ b/config/locales/models/evaluation.yml
@@ -16,6 +16,7 @@ fr:
         other: Évaluations
     attributes:
       evaluation:
+        beneficiaire: Bénéficiaire
         created_at: Créée le
         debutee_le: Date
         terminee_le: Terminée le
@@ -24,7 +25,6 @@ fr:
         updated_at: Mise à jour le
         libelle: Libellé
         telephone: Téléphone
-        nom: Nom
         email: Email
         temps_total: Temps total
         complete: Complète
@@ -107,7 +107,7 @@ fr:
         structure: Structure
         campagne: Campagne
         created_at: Date
-        nom: Nom
+        nom_beneficiaire: Nom bénéficiaire
         code_beneficiaire: Code bénéficiaire
         completude: Passation complète ?
         synthese_competences_de_base: Niveau global

--- a/spec/controllers/api/evaluations_controller_spec.rb
+++ b/spec/controllers/api/evaluations_controller_spec.rb
@@ -5,40 +5,54 @@ require 'rails_helper'
 describe Api::EvaluationsController do
   let(:compte) { create :compte_admin }
   let(:campagne) { create :campagne, compte: compte }
-  let(:nom) { 'Evaluation de test nom' }
-  let(:evaluation_params) do
-    {
-      nom: nom,
-      debutee_le: DateTime.current,
-      code_campagne: campagne.code
-    }
+
+  describe "creation" do
+    context "avec un nom d'évaluation" do
+      let(:evaluation_params) do
+        {
+          nom: "Nom du bénéficiaire",
+          debutee_le: DateTime.current,
+          code_campagne: campagne.code
+        }
+      end
+
+      it "ajoute bien une evaluation à la création" do
+        expect do
+          post :create, params: evaluation_params
+        end.to change(Evaluation, :count).by(1)
+      end
+
+      it "lorsqu'on crée une evaluation, on crée un bénéficiaire" do
+        expect do
+          post :create, params: evaluation_params
+        end.to change(Beneficiaire, :count).by(1)
+      end
+    end
+
+    context "avec un code bénéficiaire" do
+      let(:beneficiaire) { create :beneficiaire }
+      let(:evaluation_params) do
+        {
+          code_beneficiaire: beneficiaire.code_beneficiaire,
+          debutee_le: DateTime.current,
+          code_campagne: campagne.code
+        }
+      end
+
+      it "ajoute l'évaluation au bénéficiaire" do
+        expect do
+          post :create, params: evaluation_params
+        end.to change(Evaluation, :count).by(1)
+        expect(Evaluation.last.beneficiaire).to eq(beneficiaire)
+      end
+    end
   end
 
-  describe 'creation' do
-    it 'ajoute bien une evaluation à la création' do
-      expect do
-        post :create, params: evaluation_params
-      end.to change(Evaluation, :count).by(1)
-    end
-
-    it "lorsqu'on crée une evaluation, on crée un bénéficiaire" do
-      expect do
-        post :create, params: evaluation_params
-      end.to change(Beneficiaire, :count).by(1)
-    end
-  end
-
-  describe 'update' do
-    it "mets à jour le nom de l'évaluation" do
-      evaluation = create :evaluation
-      put :update, params: { id: evaluation.id, nom: nom }
-      expect(evaluation.reload.nom).to eq(nom)
-    end
-
+  describe "update" do
     it "la mise à jour d'une évaluation ne change pas le nombre de bénéficiaire" do
       evaluation = create :evaluation
       expect do
-        put :update, params: { id: evaluation.id, nom: nom }
+        put :update, params: { id: evaluation.id, nom: "n'importe quel autre nom est ignoré" }
       end.not_to(change(Beneficiaire, :count))
       expect(response).to have_http_status(:success)
     end

--- a/spec/factories/evaluation.rb
+++ b/spec/factories/evaluation.rb
@@ -2,7 +2,6 @@
 
 FactoryBot.define do
   factory :evaluation do
-    nom { 'Roger' }
     campagne
     beneficiaire
     debutee_le { 1.hour.ago }

--- a/spec/features/admin/evaluation_spec.rb
+++ b/spec/features/admin/evaluation_spec.rb
@@ -185,7 +185,7 @@ describe 'Admin - Evaluation', type: :feature do
         let(:restitution_globale) do
           double(Restitution::Globale,
                  date: DateTime.now,
-                 utilisateur: 'Roger',
+                 beneficiaire: 'Roger',
                  efficience: 5,
                  restitutions: [ restitution ])
         end
@@ -388,7 +388,7 @@ describe 'Admin - Evaluation', type: :feature do
   end
 
   describe 'Edition' do
-    let(:evaluation) { create :evaluation, campagne: ma_campagne, nom: 'Ancien nom' }
+    let(:evaluation) { create :evaluation, campagne: ma_campagne }
     let!(:mon_collegue) do
       create :compte_admin, structure: mon_compte.structure, prenom: 'Liam', nom: 'Mercier'
     end
@@ -405,23 +405,21 @@ describe 'Admin - Evaluation', type: :feature do
       before do
         connecte(mon_compte)
         visit edit_admin_evaluation_path(evaluation)
-        fill_in :evaluation_nom, with: 'Nouveau Nom'
       end
 
-      context 'en changeant de campagne' do
+      context "peut changer de campagne" do
         it do
           within('#evaluation_campagne_input') { select 'Campagne autre structure' }
           click_on 'Enregistrer'
-          expect(evaluation.reload.nom).to eq 'Nouveau Nom'
-          expect(evaluation.campagne.libelle).to eq 'Campagne autre structure'
+          expect(evaluation.reload.campagne.libelle).to eq 'Campagne autre structure'
         end
       end
 
-      context 'sans mettre de campagne' do
+      context "ne peut pas enregistrer sans campagne" do
         it do
           within('#evaluation_campagne_input') { select '' }
           click_on 'Enregistrer'
-          expect(evaluation.reload.nom).to eq 'Ancien nom'
+          expect(evaluation.reload.campagne.libelle).to eq ma_campagne.libelle
         end
       end
 

--- a/spec/models/evaluation_spec.rb
+++ b/spec/models/evaluation_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 describe Evaluation do
-  it { is_expected.to validate_presence_of :nom }
   it { is_expected.to validate_presence_of :debutee_le }
   it { is_expected.to validate_presence_of :statut }
   it { is_expected.to belong_to :campagne }
@@ -219,6 +218,18 @@ describe Evaluation do
       expect(evaluation.beneficiaires_possibles).to include(evaluation.beneficiaire)
       expect(evaluation.beneficiaires_possibles).to include(autre_evaluation.beneficiaire)
       expect(evaluation.beneficiaires_possibles).not_to include(eval_autre_structure.beneficiaire)
+    end
+  end
+
+  describe "#display_name" do
+    let(:compte) { create :compte_admin }
+    let(:campagne) { create :campagne, compte: compte }
+    let(:beneficiaire) { create :beneficiaire, nom: "Toto Martin" }
+    let(:evaluation) { create :evaluation, beneficiaire: beneficiaire, campagne: campagne }
+
+    it "retourne le nom du bénéficiaire et la date" do
+      evaluation.debutee_le = Time.zone.local(2023, 1, 10, 12, 1, 0)
+      expect(evaluation.display_name).to eq("Toto Martin - 10 jan. 2023, 12:01")
     end
   end
 end

--- a/spec/models/restitution/globale_spec.rb
+++ b/spec/models/restitution/globale_spec.rb
@@ -9,11 +9,12 @@ describe Restitution::Globale do
   end
   let(:evaluation) { double }
 
-  describe "#utilisateur retourne le nom de l'évaluation" do
+  describe "#beneficiaire retourne le nom du bénéficiaire" do
     let(:restitutions) { [ double ] }
-    let(:evaluation) { double(nom: 'Jean Bon') }
+    let(:beneficiaire) { double(nom: 'Jean Bon') }
+    let(:evaluation) { double(beneficiaire: beneficiaire) }
 
-    it { expect(restitution_globale.utilisateur).to eq('Jean Bon') }
+    it { expect(restitution_globale.beneficiaire).to eq('Jean Bon') }
   end
 
   describe "#date retourne la date de l'évaluation" do

--- a/spec/models/restitution/positionnement/export_spec.rb
+++ b/spec/models/restitution/positionnement/export_spec.rb
@@ -16,7 +16,8 @@ describe Restitution::Positionnement::Export do
   let(:questions) { [ question1, question2 ] }
   let(:questionnaire) { create :questionnaire, questions: questions }
   let(:campagne) { create :campagne, code: 'CODE123' }
-  let(:evaluation) { create :evaluation, campagne: campagne }
+  let(:date_debut_evaluation) { Time.zone.local(2021, 1, 2, 8, 2, 4) }
+  let(:evaluation) { create :evaluation, campagne: campagne, debutee_le: date_debut_evaluation }
   let!(:partie) { create :partie, situation: situation, evaluation: evaluation }
 
   before do
@@ -251,7 +252,7 @@ describe Restitution::Positionnement::Export do
 
     it "genere le nom du fichier en fonction de l'évaluation" do
       Timecop.freeze(Time.zone.local(2025, 2, 28, 1, 2, 3)) do
-        expect(response_service.nom_du_fichier).to eq('20250228010203-roger-code123.xls')
+        expect(response_service.nom_du_fichier).to eq('20210102080204-roger-CODE123.xls')
       end
     end
   end


### PR DESCRIPTION
Cette Termine de remplacer le nom de l'évaluation par le nom du bénéficiaire. Elle prépare la suppression de la colonne `nom` de la table `evaluations`.

## Liste des évaluations
La colonne de la liste des évaluations s'appelle "Bénéficiaire" à la place de "Nom"
<img width="1299" height="404" alt="Capture d’écran 2025-08-22 à 17 05 34" src="https://github.com/user-attachments/assets/ee910c7d-713e-48e3-b38d-c135624f1c21" />

## Export des évaluation
L'export des évaluations : la colonne "Nom" a été renommé en "Nom du bénéficiaire"
<img width="529" height="203" alt="Capture d’écran 2025-08-22 à 17 06 47" src="https://github.com/user-attachments/assets/8a7b847c-a0cb-41a1-b935-03b197c19128" />

## Nom d'une évaluation
J'ai ajouté la date et l'heure de début de l'évaluation dans son display_name, en plus du nom du bénéficiaire :
<img width="954" height="338" alt="Capture d’écran 2025-08-22 à 17 23 35" src="https://github.com/user-attachments/assets/70e29cb8-2531-4e51-885a-17949c111c3c" />

## Consultation d'une restitution (visible seulement par les superadmins)
<img width="1275" height="840" alt="Capture d’écran 2025-08-22 à 17 28 08" src="https://github.com/user-attachments/assets/9d69e532-6593-4908-b689-741b385f92af" />

## Export PDF
C'est bien le nom du bénéficiaire qui est inscrit dans le PDF et non plus le nom de l'évaluation

## API
Cette modification a eu un impact sur l'API. J'ai préféré empêcher la modification du nom du bénéficiaire avec l'API Evaluation.

## Export restitution Numératie et Litteratie
Le nom du fichier contient la date de début de l'évaluation à la place de la date de téléchargement puis le nom du bénéficiaire (limité à 25 caractères) et le code campagne est conservé en majuscule :
<img width="869" height="55" alt="Capture d’écran 2025-08-22 à 17 46 49" src="https://github.com/user-attachments/assets/42d5645c-5d1a-4bb2-8131-7d36c9cb2b63" />



