### PR TITLE
Corrige l'expérience utilisateur·isse des CMR

### DIFF
--- a/app/admin/beneficiaire.rb
+++ b/app/admin/beneficiaire.rb
@@ -9,7 +9,7 @@ ActiveAdmin.register Beneficiaire do
   config.sort_order = "created_at_desc"
   config.batch_actions = true
 
-  batch_action :lier do |beneficiaire_ids|
+  batch_action :lier, if: proc { can?(:lier, Beneficiaire) } do |beneficiaire_ids|
     beneficiaires = Beneficiaire.where(id: beneficiaire_ids)
 
     if beneficiaires.size < 2
@@ -44,7 +44,7 @@ ActiveAdmin.register Beneficiaire do
   end
 
   index do
-    selectable_column
+    selectable_column if can?(:lier, Beneficiaire)
     column :nom do |beneficiaire|
       render partial: "nom_beneficiaire", locals: { beneficiaire: beneficiaire }
     end

--- a/app/admin/comptes.rb
+++ b/app/admin/comptes.rb
@@ -26,7 +26,7 @@ ActiveAdmin.register Compte do
          display_name: "display_name",
          minimum_input_length: 2,
          order_by: "nom_asc",
-         if: proc { can? :manage, Compte }
+         if: proc { current_compte.anlci? }
   filter :role,
          as: :select,
          collection: proc { collection_roles }

--- a/app/models/ability_utilisateur.rb
+++ b/app/models/ability_utilisateur.rb
@@ -106,6 +106,7 @@ class AbilityUtilisateur
   def droits_cmr
     can :read, :all
     cannot(%i[update create destroy], :all)
+    can(%i[update], compte)
     cannot(:read, AnnonceGenerale)
     cannot(:read, SourceAide)
     cannot(:lier, Beneficiaire)

--- a/app/models/ability_utilisateur.rb
+++ b/app/models/ability_utilisateur.rb
@@ -107,8 +107,8 @@ class AbilityUtilisateur
     can :read, :all
     cannot(%i[update create destroy], :all)
     cannot(:read, AnnonceGenerale)
-    cannot(:read, Beneficiaire)
     cannot(:read, SourceAide)
+    cannot(:lier, Beneficiaire)
     cannot(%i[mise_en_action supprimer_responsable_suivi ajouter_responsable_suivi
               renseigner_qualification],
            Evaluation)

--- a/app/views/admin/structures/_membres.html.erb
+++ b/app/views/admin/structures/_membres.html.erb
@@ -1,20 +1,18 @@
 <% url = new_compte_registration_url(structure_id: resource.id) %>
-<% if current_compte.au_moins_admin? %>
-  <div id="bloc-membres" class="fr-mt-8v">
-    <div class="titre-panel-avec-bouton">
-      <h3><%= t(".titre") %></h3>
-      <%= link_to t(".voir_membres"), admin_comptes_path("q[structure_id_eq]": resource.id) %>
-    </div>
-    <div class="panel panel-invitation">
-      <div class="container-instructions">
-        <div class="panel-invitation-message">
-          <%= md t(".invitation") %>
-        </div>
-        <div>
-          <%= render BoutonCopierComponent.new(libelle: I18n.t("actions.copier_url"), texte: url, style: "white-space: nowrap") %>
-        </div>
-      </div>
-      <a class="panel-invitation-lien" target="_blank" href="<%= url %>"><%= url %></a>
-    </div>
+<div id="bloc-membres" class="fr-mt-8v">
+  <div class="titre-panel-avec-bouton">
+    <h3><%= t(".titre") %></h3>
+    <%= link_to t(".voir_membres"), admin_comptes_path("q[structure_id_eq]": resource.id) %>
   </div>
-<% end %>
+  <div class="panel panel-invitation">
+    <div class="container-instructions">
+      <div class="panel-invitation-message">
+        <%= md t(".invitation") %>
+      </div>
+      <div>
+        <%= render BoutonCopierComponent.new(libelle: I18n.t("actions.copier_url"), texte: url, style: "white-space: nowrap") %>
+      </div>
+    </div>
+    <a class="panel-invitation-lien" target="_blank" href="<%= url %>"><%= url %></a>
+  </div>
+</div>

--- a/spec/integrations/ability_spec.rb
+++ b/spec/integrations/ability_spec.rb
@@ -159,7 +159,8 @@ describe Ability do
     it { is_expected.not_to be_able_to(%i[create update destroy], Actualite) }
     it { is_expected.not_to be_able_to(:read, AnnonceGenerale) }
     it { is_expected.not_to be_able_to(:read, SourceAide) }
-    it { is_expected.not_to be_able_to(:read, Beneficiaire) }
+    it { is_expected.to be_able_to(:read, Beneficiaire) }
+    it { is_expected.not_to be_able_to(:lier, Beneficiaire) }
     it { is_expected.not_to be_able_to(:supprimer_responsable_suivi, Evaluation) }
     it { is_expected.not_to be_able_to(:renseigner_qualification, Evaluation) }
     it { is_expected.not_to be_able_to(:ajouter_responsable_suivi, Evaluation) }


### PR DESCRIPTION
- Le rôle CMR peut naviguer d'une structure vers la liste de ses comptes.
( On a en fait ouvert cette fonctionnalité à tous les rôles)
<img width="708" height="252" alt="Capture d’écran 2025-09-04 à 17 03 20" src="https://github.com/user-attachments/assets/26431fb7-65dd-4a2b-aed7-91f0ef50130c" />

- Le rôle CMR peut filtrer les comptes par structure
<img width="353" height="729" alt="Capture d’écran 2025-09-04 à 17 44 38" src="https://github.com/user-attachments/assets/a8a09796-b20e-4ec2-b479-4de214d051e6" />

- Les CMR peuvent voir les bénéficiaires mais pas les lier.
- Un CMR peut modifier son propre compte.
<img width="1232" height="424" alt="Capture d’écran 2025-09-04 à 17 43 35" src="https://github.com/user-attachments/assets/0e2cdb7b-fbf0-4885-9944-d34508a3d372" />
