### PR TITLE
💄 Corrige l'espacement des boutons des campagnes du tableau de bord

### DIFF
--- a/app/assets/stylesheets/admin/pages/dashboard/_dashboard.scss
+++ b/app/assets/stylesheets/admin/pages/dashboard/_dashboard.scss
@@ -68,6 +68,7 @@
           flex: 3;
           display: flex;
           justify-content: space-between;
+          gap: 0.25rem;
           color: $eva_dark_blue_grey;
           line-height: 1.5rem;
 


### PR DESCRIPTION
## Avant
<img width="663" height="93" alt="Capture d’écran 2025-09-11 à 11 03 16" src="https://github.com/user-attachments/assets/d0d84e2b-8e32-41b7-9558-7d0af225e663" />

## Après
<img width="690" height="112" alt="Capture d’écran 2025-09-11 à 11 00 54" src="https://github.com/user-attachments/assets/b710db07-135c-4ff9-8cc7-f5dbaa4e9e6b" />
