### PR TITLE
🐛 Modifie l'installation de Chrome pour Puppeteer

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,3 @@
 https://github.com/Scalingo/nodejs-buildpack.git
 https://github.com/Scalingo/apt-buildpack.git
-https://github.com/Captive-Studio/scalingo-buildpack-google-chrome.git
 https://github.com/Scalingo/ruby-buildpack.git

--- a/Aptfile
+++ b/Aptfile
@@ -1,3 +1,6 @@
 # Pour la manipulation d'image
 libvips-dev
 ffmpeg
+
+# Installation des dépendances pour Puppeteer
+gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget libcairo-gobject2 libxinerama1 libgtk2.0-0 libpangoft2-1.0-0 libthai0 libpixman-1-0 libxcb-render0 libharfbuzz0b libdatrie1 libgraphite2-3 libgbm-dev


### PR DESCRIPTION
afin d'éviter l'erreur :
> Timed out after 30000 ms while trying to connect to the browser! Only Chrome at revision r706915 is guaranteed to work.

Cela suit la doc de Scalingo : https://doc.scalingo.com/languages/nodejs/puppeteer