### PR TITLE
🐛 Corrige deux coquilles et les liens vers les CGUs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,6 +2,7 @@ PROTOCOLE_SERVEUR=http
 HOTE_SERVEUR=localhost:3000
 URL_CLIENT=http://localhost:7700/jeu
 URL_SITE_VITRINE=https://eva.anlci.gouv.fr
+URL_COMPETENCES=https://eva.anlci.gouv.fr/competences
 LIEN_INSCRIPTION_PRESENTATION=https://eva.anlci.gouv.fr/formation-et-presentation/
 METABASE_SITE_URL=http://metabase.eva.anlci.gouv.fr
 METABASE_SECRET_KEY=<SECRET_METABASE>

--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,7 @@
 PROTOCOLE_SERVEUR=http
 HOTE_SERVEUR=localhost:3000
 URL_CLIENT=http://localhost:7700/jeu
+URL_SITE_VITRINE=https://eva.anlci.gouv.fr
 LIEN_INSCRIPTION_PRESENTATION=https://eva.anlci.gouv.fr/formation-et-presentation/
 METABASE_SITE_URL=http://metabase.eva.anlci.gouv.fr
 METABASE_SECRET_KEY=<SECRET_METABASE>

--- a/app/components/evaluation/alert_annexe_component.rb
+++ b/app/components/evaluation/alert_annexe_component.rb
@@ -3,8 +3,8 @@
 class Evaluation
   class AlertAnnexeComponent < ViewComponent::Base
     def initialize
-      @lien_referentiel = "https://eva.anlci.gouv.fr/referentiels/"
-      @lien_positionnement = "https://eva.anlci.gouv.fr/positionnement/"
+      @lien_referentiel = "#{ENV['URL_SITE_VITRINE']}/referentiels/"
+      @lien_positionnement = "#{ENV['URL_SITE_VITRINE']}/positionnement/"
     end
   end
 end

--- a/app/components/evaluation/alert_interpreter_resultats_component.rb
+++ b/app/components/evaluation/alert_interpreter_resultats_component.rb
@@ -6,7 +6,7 @@ class Evaluation
       @badges = %i[profil1 profil2 profil3 profil4 profil4_plus]
       @scope = "admin.restitutions.numeratie"
       @scope_badge = "admin.restitutions.references"
-      @lien = "https://eva.anlci.gouv.fr/les-referentiels-devaluation/"
+      @lien = "#{ENV['URL_SITE_VITRINE']}/les-referentiels-devaluation/"
     end
   end
 end

--- a/config/locales/activeadmin.yml
+++ b/config/locales/activeadmin.yml
@@ -48,7 +48,7 @@ fr:
         new:
           title: Rejoindre la structure
           instruction: Merci de renseigner vos informations.
-          description: Nous enverons un email à la personne admininstratrice de votre structure pour qu'elle vous autorise l'accès complet.
+          description: Nous enverrons un e-mail à la personne administratrice de votre structure pour qu'elle vous autorise l'accès complet.
           nouvelle_structure_html: Si vous ne trouvez pas votre structure, <a href="%{lien}">enregistrez-la ici</a>
       passwords:
         edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get "pro_connect/callback" => "pro_connect#callback"
   get "demo" => "demo#show"
   post "demo/connect" => "demo#connect"
+  get "cgu" => redirect("#{ENV['URL_SITE_VITRINE']}/condition-generales-dutilisation/")
 
   ActiveAdmin.routes(self)
   get '/admin/structures/:id', to: 'structures#show'
@@ -32,7 +33,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :controle_syntheses_restitutions, only: :index
-    
+
     # UI Kit routes
     get '/ui_kit', to: 'ui_kit#index'
     get '/ui_kit/mise_en_avant', to: 'ui_kit#mise_en_avant'
@@ -60,7 +61,7 @@ Rails.application.routes.draw do
     get '/ui_kit/tableau', to: 'ui_kit#tableau'
     get '/ui_kit/tag', to: 'ui_kit#tag'
     get '/ui_kit/toggle', to: 'ui_kit#toggle'
-    
+
     namespace :positionnement do
       resources :parties do
         resource :reponses, only: [:show], defaults: { format: 'xls' }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,14 +14,14 @@ SourceAide.find_or_create_by(titre: 'Guide de prise en main') do |source_aide|
 end
 SourceAide.find_or_create_by(titre: 'Exemples de fiches de restitution') do |source_aide|
   source_aide.description= "Plusieurs exemples de restitution eva selon les niveaux alerte illettrisme\n\nFichiers PDF de 4 pages"
-  source_aide.url= 'https://eva.anlci.gouv.fr/centre-daide'
+  source_aide.url= "#{ENV['URL_SITE_VITRINE']}/centre-daide"
   source_aide.categorie= :prise_en_main
   source_aide.type_document= :repertoire
   source_aide.position=2
 end
 SourceAide.find_or_create_by(titre: 'Foire Aux Questions') do |source_aide|
   source_aide.description= "Retrouver les réponses aux questions les plus fréquentes sur notre site public."
-  source_aide.url= 'https://eva.anlci.gouv.fr/centre-daide'
+  source_aide.url= "#{ENV['URL_SITE_VITRINE']}/centre-daide"
   source_aide.categorie= :prise_en_main
   source_aide.type_document= :repertoire
   source_aide.position=3
@@ -40,7 +40,7 @@ SourceAide.find_or_create_by(titre: 'Document d’interprétation des résultats
 end
 SourceAide.find_or_create_by(titre: 'Mode hors ligne - explication et activation') do |source_aide|
   source_aide.description= "Si vous avez besoins de faire passer des évaluations dans des endroits non connectés à internet, c'est possible. Vous trouverez ici toutes les informations pour activer et utiliser ce mode de fonctionnement."
-  source_aide.url= 'https://eva.anlci.gouv.fr/mode-hors-ligne/'
+  source_aide.url= "#{ENV['URL_SITE_VITRINE']}/mode-hors-ligne/"
   source_aide.categorie= :animer_restituer
   source_aide.type_document= :web_doc
 end


### PR DESCRIPTION
<img width="649" height="957" alt="Capture d’écran 2025-09-17 à 10 03 08" src="https://github.com/user-attachments/assets/5022d00f-a718-4ce5-a86c-c829d1f0f355" />

J'ai introduit une variable d'env pour connaitre l'url du site vitrine (qui est différente de celle du site pro depuis qu'on est passé à un sous-domaine.

Cette variable est utilisé pour rediriger la route cgu vers le site vitrine et aussi dans la page annexe des restitutions.

<img width="995" height="205" alt="Capture d’écran 2025-09-17 à 10 12 19" src="https://github.com/user-attachments/assets/30f9bd54-d267-4098-a54c-5280158c3a66" />
<img width="883" height="315" alt="Capture d’écran 2025-09-17 à 10 19 40" src="https://github.com/user-attachments/assets/aac14bfc-5ae6-451d-b5c6-7354e6978adf" />

