### PR TITLE
Masque les boutons menu des campagnes sur la page structure

### DIFF
--- a/app/assets/stylesheets/admin/pages/_structure.scss
+++ b/app/assets/stylesheets/admin/pages/_structure.scss
@@ -100,6 +100,9 @@
         }
         .col-actions {
           background-image: none;
+          .bouton-menu {
+            display: none;
+          }
         }
       }
     }

--- a/app/views/admin/structures/_mes_campagnes.html.arb
+++ b/app/views/admin/structures/_mes_campagnes.html.arb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 div class: "bloc-mes-campagnes fr-mt-8v" do
-  h3 "Campagnes"
+  h3 "Campagnes", class: "mb-0"
   if campagnes.present?
-    table_for campagnes, class: "index_table" do
+    table_for campagnes, class: "index_table p-0" do
       column :libelle do |campagne|
         link_to campagne.libelle, admin_campagne_path(campagne)
       end


### PR DESCRIPTION
## Avant :
<img width="631" height="661" alt="Capture d’écran 2025-09-17 à 11 34 10" src="https://github.com/user-attachments/assets/17c820f2-1dd5-4379-bae6-deca5565de8b" />

## Après : 
<img width="645" height="488" alt="Capture d’écran 2025-09-17 à 11 33 51" src="https://github.com/user-attachments/assets/02fff1c9-6ddd-4b74-8495-6bf0faaead09" />
