### PR TITLE
Revient à l'installation avec Google Chrome

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,4 @@
-https://github.com/Scalingo/apt-buildpack.git
-https://github.com/sunny/chromium-buildpack.git
 https://github.com/Scalingo/nodejs-buildpack.git
+https://github.com/Scalingo/apt-buildpack.git
+https://github.com/Captive-Studio/scalingo-buildpack-google-chrome.git
 https://github.com/Scalingo/ruby-buildpack.git

--- a/Aptfile
+++ b/Aptfile
@@ -1,20 +1,3 @@
 # Pour la manipulation d'image
 libvips-dev
 ffmpeg
-
-# Chromium dependencies
-libasound2
-libatk-bridge2.0-0
-libatk1.0-0
-libdrm2
-libgbm1
-libgtk-3-0
-libnss3
-libx11-xcb1
-libxcb-dri3-0
-libxcomposite1
-libxcursor1
-libxdamage1
-libxi6
-libxrandr2
-libxss1


### PR DESCRIPTION
Cette nouvelle installation avait fait monter la taille de l'image à 1,6G qui faisait dépasser la limite actuelle pour nos images.