### PR TITLE
🐛 Corrige l'export xls des évaluations

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 20.13.1
+nodejs 20.19.4
 ruby 3.4.5

--- a/config/locales/models/evaluation.yml
+++ b/config/locales/models/evaluation.yml
@@ -117,4 +117,4 @@ fr:
         niveau_anlci_numeratie: ANLCI Numératie (diagnostic)
         positionnement_niveau_litteratie: Positionnement Littératie
         positionnement_niveau_numeratie: Positionnement Numératie
-        reponse_redaction: Réponse rédaction
+        reponses_redaction: Réponses rédaction


### PR DESCRIPTION
L'export xls des évaluations accumulait des colonnes de réponses

<img width="917" height="167" alt="Capture d’écran 2025-09-22 à 16 43 50" src="https://github.com/user-attachments/assets/41eafbd5-0a54-47a7-bf4f-cf8a8c15172a" />
