### PR TITLE
💄 Diminue l'espacement avant 'Choissisez un rôle :'

### DIFF
--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -161,5 +161,9 @@ img {
   h1 {
     margin: $dsfr-spacing-0;
   }
+
+  p {
+    margin: 0;
+  }
 }
 


### PR DESCRIPTION
<img width="600" height="684" alt="Capture d’écran 2025-09-24 à 11 14 57" src="https://github.com/user-attachments/assets/80c73784-6944-4609-9c23-03c6942e2b55" />
