### PR TITLE
✨ Accepte le parametre terminee_le sur l'api evaluation/fin

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ L'api est accessible au point `/api`
 
 `POST /api/evaluations/:id/fin`
 
+```json
+{
+  "terminee_le":"2021-10-03T22:15:24+02:00"
+}
+```
+
 **Réponse**
 
 ```json

--- a/app/controllers/api/evaluations/fins_controller.rb
+++ b/app/controllers/api/evaluations/fins_controller.rb
@@ -7,7 +7,8 @@ module Api
         @competences = []
 
         evaluation = Evaluation.find(params[:evaluation_id])
-        evaluation.update terminee_le: DateTime.now
+        terminee_le = params[:terminee_le]&.to_datetime || DateTime.now
+        evaluation.update terminee_le: terminee_le
 
         return unless evaluation.campagne.affiche_competences_fortes?
 

--- a/spec/requests/evaluations/fin_evaluations_spec.rb
+++ b/spec/requests/evaluations/fin_evaluations_spec.rb
@@ -16,11 +16,28 @@ describe 'Fin Evaluation API', type: :request do
     before { campagne.situations_configurations.create situation: situation_inventaire }
 
     context 'met à jour la date de fin' do
-      before { post "/api/evaluations/#{evaluation.id}/fin" }
+      context "sans paramètre terminee_le (dépreciée)" do
+        it 'utilise DateTime.now par défaut' do
+          date_figee = DateTime.new(2024, 3, 10, 15, 45)
+          Timecop.freeze(date_figee) do
+            post "/api/evaluations/#{evaluation.id}/fin"
 
-      it do
-        expect(evaluation.reload.terminee_le).not_to eql(nil)
-        expect(response).to have_http_status(:ok)
+            expect(evaluation.reload.terminee_le).to eq(date_figee)
+            expect(response).to have_http_status(:ok)
+          end
+        end
+      end
+
+      context 'avec un paramètre terminee_le' do
+        let(:date_fin_custom) { DateTime.new(2024, 1, 15, 14, 30) }
+
+        it 'utilise la valeur fournie' do
+          post "/api/evaluations/#{evaluation.id}/fin",
+               params: { terminee_le: date_fin_custom.iso8601 }
+
+          expect(evaluation.reload.terminee_le).to eq(date_fin_custom)
+          expect(response).to have_http_status(:ok)
+        end
       end
     end
 


### PR DESCRIPTION
Par défaut, on garde l'enregistrement de DateTime.new pour laisser le temps aux clients de se mettre à jours.