### PR TITLE
⚡️ Supprime les rédactions de la mémoire juste après l'export des évaluations

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -112,6 +112,9 @@ ActiveAdmin.register Evaluation do
         ]
         @collection = @collection.limit!(Evaluation::LIMITE_EXPORT_XLS)
       end
+    end
+
+    after_filter do |sheet|
       @reponses_redaction_par_evaluation = nil
     end
   end


### PR DESCRIPTION
Alors qu'avant elles étaient conservées en mémoire jusqu'au prochain export.