### PR TITLE
💄 Espacement du titre du bloc campagne de la page structure

### DIFF
--- a/app/views/admin/structures/_mes_campagnes.html.arb
+++ b/app/views/admin/structures/_mes_campagnes.html.arb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 div class: "bloc-mes-campagnes fr-mt-8v" do
-  h3 "Campagnes", class: "mb-0"
+  h3 "Campagnes", class: "fr-mb-0"
   if campagnes.present?
     table_for campagnes, class: "index_table p-0" do
       column :libelle do |campagne|
@@ -19,11 +19,8 @@ div class: "bloc-mes-campagnes fr-mt-8v" do
       end
     end
   else
-    div "Pas de campagne à afficher pour le moment. Pour créer une campagne, rendez-vous sur ",
-        class: "panel" do
-      span do
-        link_to "cette page.", new_admin_campagne_path
-      end
+    para class: "panel fr-mt-4v" do
+        t(".pas_de_campagne", lien: link_to(t(".nom_lien"), new_admin_campagne_path)).html_safe
     end
   end
 end

--- a/config/locales/views/structures.yml
+++ b/config/locales/views/structures.yml
@@ -29,6 +29,8 @@ fr:
         voir_membres: Voir la liste
       mes_campagnes:
         voir: Voir
+        pas_de_campagne: Pas de campagne à afficher pour le moment. Pour créer une campagne, rendez-vous sur %{lien}.
+        nom_lien: cette page
     structures_locales:
       form:
         titre:


### PR DESCRIPTION
## Dans le cas où il n'y a pas de campagne

<img width="653" height="196" alt="Capture d’écran 2025-10-01 à 13 08 40" src="https://github.com/user-attachments/assets/b1a4b77a-847a-4bfd-85d3-7dfc5b2b2506" />

## Avec des campagnes
<img width="647" height="477" alt="Capture d’écran 2025-10-01 à 13 08 56" src="https://github.com/user-attachments/assets/f0b44a3f-a9df-4cb4-8c09-9edf40f0a6da" />
