### PR TITLE
🔥 Supprime l'affichage de la date d'anonymisation d'une évaluation

### DIFF
--- a/app/views/admin/evaluations/_informations_complementaires.arb
+++ b/app/views/admin/evaluations/_informations_complementaires.arb
@@ -34,16 +34,6 @@ div class: "row m-0" do
         end
       end
     end
-    if resource.anonyme?
-      div class: "row" do
-        div class: "col col-1" do
-          span Evaluation.human_attribute_name("anonymisee_le")
-        end
-        div class: "col col-2" do
-          span l(resource.anonymise_le, format: :avec_heure)
-        end
-      end
-    end
     div class: "row" do
       div class: "col-1" do
         span t(".donnees_sociodemographiques")


### PR DESCRIPTION
Sinon ça plante, car cette date n'est plus stoquée en base