### PR TITLE
🐛 Ajoute la création de campagnes spécifiques et génériques dans Camp…

### DIFF
--- a/app/admin/structures_locales.rb
+++ b/app/admin/structures_locales.rb
@@ -112,6 +112,7 @@ ActiveAdmin.register StructureLocale do
 
       if @structure_locale.update(permitted_params[:structure_locale])
         AffiliationOpcoService.new(@structure_locale).affilie_opcos
+        CampagneCreateur.new(@structure_locale, current_compte).cree_campagne_opco!
         redirect_to admin_structure_locale_path(@structure_locale),
 notice: "Structure mise à jour avec succès"
       else

--- a/app/models/campagne_createur.rb
+++ b/app/models/campagne_createur.rb
@@ -13,7 +13,16 @@ class CampagneCreateur
     parcours_type = trouve_parcours_type
     return unless parcours_type
 
-    cree_campagne(parcours_type)
+    # Si l'OPCO est financeur, créer d'abord la campagne générique si elle n'existe pas
+    if opco_financeur?
+      parcours_type_generique = ParcoursType.find_by(nom_technique: NOM_TECHNIQUE_GENERIQUE)
+      if parcours_type_generique && parcours_type != parcours_type_generique
+        cree_campagne_generique(parcours_type_generique)
+      end
+    end
+
+    # Créer la campagne spécifique si elle n'existe pas déjà
+    cree_campagne_si_manquante(parcours_type)
   end
 
   private
@@ -52,16 +61,58 @@ class CampagneCreateur
     @premier_opco_financeur ||= @structure.opcos.find(&:financeur?) || @structure.opcos.first
   end
 
-  def cree_campagne(parcours_type)
+  def cree_campagne(parcours_type, libelle: nil)
     campagne = Campagne.new(
-      libelle: libelle_campagne,
-      compte: @compte,
+      libelle: libelle || libelle_campagne_avec_opco,
+      compte: compte_pour_structure,
       parcours_type: parcours_type,
       type_programme: parcours_type.type_de_programme
     )
 
     campagne.save!
     campagne
+  end
+
+  def cree_campagne_si_manquante(parcours_type)
+    libelle = libelle_campagne_avec_opco
+    campagne_existante = trouve_campagne(parcours_type, libelle)
+    return campagne_existante if campagne_existante
+
+    cree_campagne(parcours_type)
+  end
+
+  def cree_campagne_generique(parcours_type)
+    campagne_existante = trouve_campagne(parcours_type, libelle_campagne)
+    return campagne_existante if campagne_existante
+
+    cree_campagne(parcours_type, libelle: libelle_campagne)
+  end
+
+  def trouve_campagne(parcours_type, libelle)
+    return nil if libelle.blank?
+
+    # Normaliser le libellé comme auto_strip_attributes avec squish: true le fait avant sauvegarde
+    # Le libellé en base est déjà normalisé par auto_strip_attributes
+    libelle_normalise = libelle.to_s.squish.downcase
+    return nil if libelle_normalise.blank?
+
+    Campagne.joins(:compte)
+            .where("LOWER(campagnes.libelle) = ?", libelle_normalise)
+            .where(comptes: { structure_id: @structure.id })
+            .where(parcours_type: parcours_type)
+            .first
+  end
+
+  def libelle_campagne_avec_opco
+    return libelle_campagne unless opco_financeur?
+
+    "#{libelle_campagne} (#{premier_opco_financeur.nom})"
+  end
+
+  def compte_pour_structure
+    return @compte if @compte.structure_id == @structure.id
+
+    @structure.admins.first || @compte
   end
 
   def libelle_campagne


### PR DESCRIPTION
…agneCreateur, avec gestion des doublons. Met à jour la méthode de création de campagne pour utiliser le compte approprié selon la structure.