### PR TITLE
Actualise le code postal quand on change le SIRET

### DIFF
--- a/app/models/mise_a_jour_siret.rb
+++ b/app/models/mise_a_jour_siret.rb
@@ -64,9 +64,15 @@ class MiseAJourSiret
     @structure.code_naf = resultat["activite_principale"]
     @structure.idcc = resultat.dig("complements", "liste_idcc") || []
     @structure.raison_sociale = resultat["nom_raison_sociale"] || resultat["nom_complet"]
+    met_a_jour_localisation(resultat)
+  end
+
+  def met_a_jour_localisation(resultat)
     etablissement = cherche_etablissement(resultat)
     @structure.adresse = etablissement&.dig("adresse")
-    @structure.code_postal = etablissement&.dig("code_postal") || StructureLocale::TYPE_NON_COMMUNIQUE
+    unless @structure.code_postal_changed?
+      @structure.code_postal = etablissement&.dig("code_postal") || StructureLocale::TYPE_NON_COMMUNIQUE
+    end
   end
 
   def cherche_etablissement(resultat)

--- a/app/models/mise_a_jour_siret.rb
+++ b/app/models/mise_a_jour_siret.rb
@@ -64,20 +64,18 @@ class MiseAJourSiret
     @structure.code_naf = resultat["activite_principale"]
     @structure.idcc = resultat.dig("complements", "liste_idcc") || []
     @structure.raison_sociale = resultat["nom_raison_sociale"] || resultat["nom_complet"]
-    @structure.adresse = recupere_adresse(resultat)
+    etablissement = cherche_etablissement(resultat)
+    @structure.adresse = etablissement&.dig("adresse")
+    @structure.code_postal = etablissement&.dig("code_postal") || StructureLocale::TYPE_NON_COMMUNIQUE
   end
 
-  def recupere_adresse(resultat)
+  def cherche_etablissement(resultat)
     siret_recherche = @structure.siret
 
-    # Vérifier si c'est le siège
-    return resultat.dig("siege", "adresse") if resultat.dig("siege", "siret") == siret_recherche
+    return resultat.dig("siege") if resultat.dig("siege", "siret") == siret_recherche
 
-    # Chercher dans les établissements correspondants
-    etablissement = resultat.dig("matching_etablissements")&.find do |etab|
+    resultat.dig("matching_etablissements")&.find do |etab|
       etab["siret"] == siret_recherche
     end
-
-    etablissement&.dig("adresse")
   end
 end

--- a/app/models/recherche_structure_par_siret.rb
+++ b/app/models/recherche_structure_par_siret.rb
@@ -39,16 +39,7 @@ class RechercheStructureParSiret
     mise_a_jour = MiseAJourSiret.new(structure)
     mise_a_jour.verifie_et_met_a_jour
     structure.nom = structure.raison_sociale if structure.raison_sociale.present?
-    structure.code_postal = extrait_code_postal(structure.adresse) || StructureLocale::TYPE_NON_COMMUNIQUE
 
     structure
-  end
-
-  def extrait_code_postal(adresse)
-    return nil if adresse.blank?
-
-    # Extrait le code postal de l'adresse (format : 5 chiffres)
-    match = adresse.match(/\b(\d{5})\b/)
-    match ? match[1] : nil
   end
 end

--- a/app/models/structure.rb
+++ b/app/models/structure.rb
@@ -134,8 +134,7 @@ allow_blank: true
 
     statut_initial = statut_siret
 
-    mise_a_jour = MiseAJourSiret.new(self)
-    siret_valide = mise_a_jour.verifie_et_met_a_jour
+    siret_valide = MiseAJourSiret.new(self).verifie_et_met_a_jour
 
     return if siret_valide || !verification_bloquante?(statut_initial)
 

--- a/spec/controllers/inscription/structures_controller_spec.rb
+++ b/spec/controllers/inscription/structures_controller_spec.rb
@@ -2,8 +2,9 @@ require "rails_helper"
 
 describe Inscription::StructuresController, type: :controller do
   let(:compte) {
- create(:compte_pro_connect, etape_inscription: "assignation_structure", structure: nil,
-siret_pro_connect: "13002526500013") }
+    create(:compte_pro_connect, etape_inscription: "assignation_structure", structure: nil,
+      siret_pro_connect: "13002526500013")
+  }
   let(:opco) { create(:opco, nom: "OPCO Test", idcc: [ "3" ]) }
 
   before do
@@ -16,7 +17,7 @@ siret_pro_connect: "13002526500013") }
         before do
           # Mock RechercheStructureParSiret pour retourner une structure non persistée
           structure = build(:structure_locale, siret: compte.siret_pro_connect, idcc: [ "3" ],
-nom: "Nom de la structure", raison_sociale: "Entreprise Test")
+            nom: "Nom de la structure", raison_sociale: "Entreprise Test")
           allow(RechercheStructureParSiret).to receive(:new).and_return(
             instance_double(RechercheStructureParSiret, call: structure)
           )
@@ -49,7 +50,8 @@ nom: "Nom de la structure", raison_sociale: "Entreprise Test")
 
       context "avec une structure existante (persistée)" do
         let!(:structure_existante) {
- create(:structure_locale, siret: compte.siret_pro_connect, idcc: [ "3" ]) }
+          create(:structure_locale, siret: compte.siret_pro_connect, idcc: [ "3" ])
+        }
 
         before do
           # Mock RechercheStructureParSiret pour retourner une structure persistée

--- a/spec/models/mise_a_jour_siret_spec.rb
+++ b/spec/models/mise_a_jour_siret_spec.rb
@@ -2,7 +2,12 @@ require "rails_helper"
 
 RSpec.describe MiseAJourSiret, type: :model do
   describe "#verifie_et_met_a_jour" do
-    let(:structure) { build(:structure, siret: "12345678901234") }
+    let(:structure) do
+      ## on simule la création d'une structure en base, sans la créer vraiment
+      structure = build(:structure, siret: "12345678901234")
+      structure.clear_changes_information
+      structure
+    end
     let(:client_sirene) { instance_double(Sirene::Client) }
     let(:mise_a_jour) { described_class.new(structure) }
 
@@ -69,6 +74,12 @@ RSpec.describe MiseAJourSiret, type: :model do
       it "met à jour le code postal" do
         mise_a_jour.verifie_et_met_a_jour
         expect(structure.code_postal).to eq("75001")
+      end
+
+      it "ne met pas à jour le code postal si il a déjà été modifié" do
+        structure.code_postal = "69001"
+        mise_a_jour.verifie_et_met_a_jour
+        expect(structure.code_postal).to eq("69001")
       end
 
       it "retourne true" do

--- a/spec/models/mise_a_jour_siret_spec.rb
+++ b/spec/models/mise_a_jour_siret_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe MiseAJourSiret, type: :model do
               "activite_principale" => "53.10Z",
               "siege" => {
                 "siret" => "12345678901234",
-                "adresse" => "123 RUE DE LA REPUBLIQUE 75001 PARIS"
+                "adresse" => "123 RUE DE LA REPUBLIQUE 75001 PARIS",
+                "code_postal" => "75001"
               },
               "matching_etablissements" => [],
               "complements" => {
@@ -65,6 +66,11 @@ RSpec.describe MiseAJourSiret, type: :model do
         expect(structure.adresse).to eq("123 RUE DE LA REPUBLIQUE 75001 PARIS")
       end
 
+      it "met à jour le code postal" do
+        mise_a_jour.verifie_et_met_a_jour
+        expect(structure.code_postal).to eq("75001")
+      end
+
       it "retourne true" do
         expect(mise_a_jour.verifie_et_met_a_jour).to be true
       end
@@ -95,6 +101,11 @@ RSpec.describe MiseAJourSiret, type: :model do
         mise_a_jour.verifie_et_met_a_jour
         expect(structure.raison_sociale).to be_nil
         expect(structure.adresse).to be_nil
+      end
+
+      it "ne met pas à jour le code postal" do
+        mise_a_jour.verifie_et_met_a_jour
+        expect(structure.code_postal).to eq("75012")
       end
 
       it "retourne false" do
@@ -144,7 +155,8 @@ RSpec.describe MiseAJourSiret, type: :model do
                 {
                   "siret" => "45132137600035",
                   "etat_administratif" => "F",
-                  "adresse" => "CC GALERIE 96 AU 102 AV ST OUEN 75018 PARIS"
+                  "adresse" => "CC GALERIE 96 AU 102 AV ST OUEN 75018 PARIS",
+                  "code_postal" => "75018"
                 }
               ]
             }
@@ -215,7 +227,8 @@ RSpec.describe MiseAJourSiret, type: :model do
               "matching_etablissements" => [
                 {
                   "siret" => "12345678901234",
-                  "adresse" => "456 AVENUE DES CHAMPS 69000 LYON"
+                  "adresse" => "456 AVENUE DES CHAMPS 69000 LYON",
+                  "code_postal" => "69000"
                 }
               ],
               "complements" => {
@@ -235,6 +248,7 @@ RSpec.describe MiseAJourSiret, type: :model do
         mise_a_jour.verifie_et_met_a_jour
         expect(structure.raison_sociale).to eq("ENTREPRISE TEST")
         expect(structure.adresse).to eq("456 AVENUE DES CHAMPS 69000 LYON")
+        expect(structure.code_postal).to eq("69000")
       end
     end
 
@@ -268,6 +282,7 @@ RSpec.describe MiseAJourSiret, type: :model do
         mise_a_jour.verifie_et_met_a_jour
         expect(structure.raison_sociale).to eq("ENTREPRISE TEST")
         expect(structure.adresse).to be_nil
+        expect(structure.code_postal).to eq(StructureLocale::TYPE_NON_COMMUNIQUE)
       end
     end
 


### PR DESCRIPTION
Au passage, corrige  la récupération de code postal.
En effet, ça ne marchait pas pour une adresse comme :

`CS 60742 153 RUE DE LA POMPE 75016 PARIS`

Le code précédent récupérait 60742 comme code_postal