### PR TITLE
🐞 Restreint l'accès aux sources d'aide aux superadmins uniquement

### DIFF
--- a/app/components/navigation_component.rb
+++ b/app/components/navigation_component.rb
@@ -315,9 +315,7 @@ class NavigationComponent < ViewComponent::Base
   end
 
   def can_read_aide?
-    return false unless can?(:read, ActiveAdmin::Page, name: "Aide", namespace_name: "admin")
-
-    en_attente_restreint? || can?(:read, SourceAide)
+    can?(:read, ActiveAdmin::Page, name: "Aide", namespace_name: "admin")
   end
 
   def current_compte_structure_present?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -55,7 +55,6 @@ class Ability < AbilityUtilisateur
   def droit_page
     can :read, ActiveAdmin::Page, name: "Aide", namespace_name: "admin"
     can :read, ActiveAdmin::Page, name: "Dashboard", namespace_name: "admin"
-    can :read, SourceAide unless compte&.charge_mission_regionale?
   end
 
   def droits_comptes_refuses(compte)

--- a/spec/components/navigation_component_spec.rb
+++ b/spec/components/navigation_component_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe NavigationComponent, type: :component do
       expect(page).to have_link("Évaluations")
       expect(page).to have_link("Comptes")
       expect(page).to have_link("Aide")
+      expect(page).not_to have_button("Accompagnement")
+      expect(page).not_to have_link("Sources d'aide", visible: :all)
     end
   end
 
@@ -49,11 +51,13 @@ RSpec.describe NavigationComponent, type: :component do
   context "quand le compte est charge_mission_regionale" do
     let(:compte) { create(:compte_charge_mission_regionale, :acceptee, :structure_avec_admin) }
 
-    it "n'affiche pas le lien Aide (lecture SourceAide interdite)" do
+    it "affiche le lien Aide mais pas le menu Accompagnement" do
       render_inline(component)
 
       expect(page).to have_link("Tableau de bord", href: "/admin")
-      expect(page).not_to have_link("Aide")
+      expect(page).to have_link("Aide")
+      expect(page).not_to have_button("Accompagnement")
+      expect(page).not_to have_link("Sources d'aide", visible: :all)
     end
   end
 

--- a/spec/integrations/ability_spec.rb
+++ b/spec/integrations/ability_spec.rb
@@ -155,6 +155,7 @@ describe Ability do
       expect(subject).to be_able_to(:create, Compte.new)
       expect(subject).not_to be_able_to(:create, Beneficiaire)
       expect(subject).to be_able_to(:update, compte.structure)
+      expect(subject).not_to be_able_to(:read, SourceAide)
     end
 
     context 'peut gérer mes collègues' do
@@ -402,6 +403,7 @@ describe Ability do
       expect(subject).to be_able_to(:read, ActiveAdmin::Page.new(:admin, 'Dashboard', {}))
       expect(subject).not_to be_able_to(:read,
                                         ActiveAdmin::Page.new(:admin, 'recherche_structure', {}))
+      expect(subject).not_to be_able_to(:read, SourceAide)
       expect(subject).to be_able_to(:fusionner, Beneficiaire)
     end
 


### PR DESCRIPTION
Le compte démo, les conseillers et les admins pouvaient voir le menu « Source d'aide »

<img width="1282" height="283" alt="Capture d’écran 2026-04-02 à 17 58 00" src="https://github.com/user-attachments/assets/075653b4-e7d3-44d0-ae38-6780984603c8" />
