### PR TITLE
🐛 Améliore la gestion des structures lors de l'inscription un siret est doubloné

### DIFF
--- a/app/controllers/inscription/structures_controller.rb
+++ b/app/controllers/inscription/structures_controller.rb
@@ -44,6 +44,7 @@ class Inscription::StructuresController < ApplicationController
 
   def prepare_structure_si_necessaire
     return if @compte.siret_pro_connect.blank?
+    return if @compte.cree_via_invitation_acceptee? && @compte.structure.present?
 
     recherche_et_assigne_structure
     affilie_et_prepare_opcos
@@ -188,6 +189,9 @@ class Inscription::StructuresController < ApplicationController
 
   def associe_opcos_si_present
     return unless opco_id_params.present?
+
+    opco_id = opco_id_params.to_s
+    return if @structure.opco_id.present? && @structure.opco_id.to_s == opco_id
 
     @structure.validation_inscription = true
     @structure.opco_id = opco_id_params

--- a/app/models/structure.rb
+++ b/app/models/structure.rb
@@ -97,9 +97,7 @@ allow_blank: true
   end
 
   def siret_uniqueness
-    return if siret.blank?
-    return if errors[:siret].any?
-    return if persisted? && !siret_changed?
+    return if ignorer_verification_unicite_siret?
 
     errors.add(:siret, :taken) if Structure.where.not(id: id).exists?(siret: siret)
   end
@@ -131,6 +129,18 @@ allow_blank: true
   end
 
   private
+
+  # Si le SIRET n'a pas changé, ne pas re-vérifier l'unicité : des doublons historiques
+  # peuvent exister ; une re-validation bloquerait toute sauvegarde (ex. compte + nested).
+  def ignorer_verification_unicite_siret?
+    return true if siret.blank?
+    return true if errors[:siret].any?
+    return true if current_ability&.can?(:bypass_siret_uniqueness, self)
+    return true if persisted? && !siret_changed?
+
+    false
+  end
+
   def verifie_siret_si_necessaire
     return if siret.blank?
     return unless structure_locale?

--- a/spec/controllers/inscription/structures_controller_spec.rb
+++ b/spec/controllers/inscription/structures_controller_spec.rb
@@ -12,6 +12,37 @@ describe Inscription::StructuresController, type: :controller do
   end
 
   describe "GET show" do
+    context "compte issu d'une invitation acceptée avec structure déjà associée" do
+      let!(:structure_invitee) do
+        create(:structure_locale, :avec_admin, siret: "13002526500013")
+      end
+      let(:compte_invitation) do
+        create(:compte_conseiller,
+               structure: structure_invitee,
+               etape_inscription: "assignation_structure",
+               siret_pro_connect: "13002526500013",
+               statut_validation: :en_attente)
+      end
+
+      before do
+        create(:invitation, :acceptee, compte: compte_invitation, structure: structure_invitee,
+               invitant: create(:compte_admin, structure: structure_invitee))
+        sign_in compte_invitation
+        allow(RechercheStructureParSiret).to receive(:new).and_call_original
+      end
+
+      it "ne prépare pas la structure via affiliation OPCO (parcours invitation)" do
+        service_double = instance_double(AffiliationOpcoService)
+        allow(AffiliationOpcoService).to receive(:new).and_return(service_double)
+        allow(service_double).to receive(:affilie_opcos)
+
+        get :show
+
+        expect(AffiliationOpcoService).not_to have_received(:new)
+        expect(response).to have_http_status(:success)
+      end
+    end
+
     context "quand la structure n'est pas encore préparée" do
       context "avec une structure temporaire (non persistée)" do
         before do
@@ -434,6 +465,23 @@ structure_id: structure.id)
           expect(response).to have_http_status(:success)
         end
       end
+    end
+  end
+
+  describe "#associe_opcos_si_present" do
+    let(:opco) { create(:opco, nom: "OPCO Test", idcc: [ "3" ]) }
+    let(:structure) do
+      create(:structure_locale, opco: opco, siret: "13002526500013", idcc: [ "3" ])
+    end
+
+    before do
+      controller.instance_variable_set(:@structure, structure)
+    end
+
+    it "ne sauvegarde pas lorsque l'opco_id demandé est déjà celui de la structure" do
+      allow(controller).to receive(:opco_id_params).and_return(opco.id.to_s)
+      expect(structure).not_to receive(:save)
+      controller.send(:associe_opcos_si_present)
     end
   end
 end

--- a/spec/models/structure_spec.rb
+++ b/spec/models/structure_spec.rb
@@ -548,6 +548,49 @@ describe Structure, type: :model do
         end
       end
     end
+
+    context "quand un doublon SIRET existe déjà en base (données historiques)" do
+      let!(:structure_principale) { create(:structure_locale, siret: 999_999_999_999_99) }
+      let!(:autre_fiche) { create(:structure_locale, siret: 888_888_888_888_88) }
+
+      before { autre_fiche.update_columns(siret: structure_principale.siret) }
+
+      it "permet de sauvegarder sans changer le SIRET (pas de re-vérification :taken)" do
+        structure_principale.nom = "Nom mis à jour"
+        expect(structure_principale.save).to be true
+        expect(structure_principale.errors[:siret]).to be_blank
+      end
+    end
+
+    context 'quand le bypass est activé via current_ability' do
+      let!(:structure_existante) do
+        structure = build(:structure, siret: '12345678901234')
+        structure.save(validate: false)
+        structure
+      end
+
+      let(:nouvelle_structure) { build(:structure, siret: '12345678901234') }
+
+      before do
+        stub_ability = instance_double(Ability)
+        allow(stub_ability).to receive(:compte).and_return(nil)
+        allow(stub_ability).to receive(:can?).with(:bypass_siret_uniqueness,
+                                                   nouvelle_structure).and_return(true)
+
+        nouvelle_structure.current_ability = stub_ability
+        nouvelle_structure.valid?
+      end
+
+
+      it 'ignore la validation d’unicité et ne renvoie pas d’erreur :taken' do
+        message_taken = I18n.t('activerecord.errors.models.structure.attributes.siret.taken')
+        expect(nouvelle_structure.errors[:siret]).not_to include(message_taken)
+      end
+
+      it 'la structure reste valide' do
+        expect(nouvelle_structure).to be_valid
+      end
+    end
   end
 
   describe '#admins' do

--- a/spec/requests/inscription_invitation_embarquement_spec.rb
+++ b/spec/requests/inscription_invitation_embarquement_spec.rb
@@ -57,4 +57,50 @@ RSpec.describe "Parcours d'embarquement après invitation", type: :request do
     expect(compte.etape_inscription).to eq("complet")
     expect(compte.structure).to eq(structure)
   end
+
+  it "mène au tableau de bord sur la structure d'invitation si une autre fiche partage le SIRET" do
+    autre_fiche = create(:structure_locale, nom: "Autre fiche historique doublon SIRET",
+                                           siret: 999_999_999_999_99)
+    autre_fiche.update_columns(siret: structure.siret)
+    expect(Structure.avec_meme_siret_que(structure.siret).count).to eq(2)
+
+    post inscription_nouveau_compte_path, params: {
+      invitation_token: invitation.token,
+      compte: {
+        password: "Pass5678",
+        password_confirmation: "Pass5678"
+      }
+    }
+    follow_redirect!
+
+    patch inscription_informations_compte_path, params: {
+      compte: {
+        nom: "Martin",
+        prenom: "Claire",
+        email: "invite.embarquement@eva.fr",
+        cgu_acceptees: "1"
+      }
+    }
+    expect(response).to redirect_to(inscription_structure_path)
+    follow_redirect!
+
+    compte = Compte.find_by!(email: "invite.embarquement@eva.fr")
+    expect(compte.etape_inscription).to eq("assignation_structure")
+
+    patch inscription_structure_path, params: {
+      compte: {
+        structure_id: structure.id,
+        structure_confirmee: "1"
+      },
+      commit: I18n.t("inscription.structures.show.rejoindre")
+    }
+
+    expect(response).to redirect_to(admin_dashboard_path)
+    follow_redirect!
+
+    compte.reload
+    expect(compte.etape_inscription).to eq("complet")
+    expect(compte.structure_id).to eq(structure.id)
+    expect(compte.structure).to eq(structure)
+  end
 end


### PR DESCRIPTION


Ajoute une vérification pour éviter la préparation de la structure si le compte a été créé via une invitation acceptée et que la structure est déjà associée.