### PR TITLE
💄 Permet d'afficher le nom de la structure et son adresse dans l'alerte d'invitation a une structure

### DIFF
--- a/app/assets/stylesheets/admin/pages/inscription/_nouveau_compte.scss
+++ b/app/assets/stylesheets/admin/pages/inscription/_nouveau_compte.scss
@@ -30,6 +30,10 @@
     p {
       margin-bottom: 0.25rem;
     }
+
+    .page-nouveau-compte-alerte-invitation__structure {
+      @include corps-de-texte-lg-regular;
+    }
   }
 }
 

--- a/app/views/inscription/nouveaux_comptes/show.html.erb
+++ b/app/views/inscription/nouveaux_comptes/show.html.erb
@@ -10,22 +10,16 @@
 <% content_for :classes_body, "page-nouveau-compte-body" %>
 <div class="page-nouveau-compte">
   <% if @invitation.present? %>
-    <div class="fr-mb-4w">
+    <div class="fr-mb-4w", style="width: 100%;">
       <%= dsfr_alert(
             type: :info,
-            title: safe_join(
-              [
-                h(t(".invitation_alerte_titre_intro")),
-                tag.span(class: "page-nouveau-compte-alerte-invitation__structure") do
-                  @invitation.structure.display_name
-                end
-              ],
-              tag.br
-            ),
-            close_button: true,
+            title: t(".invitation_alerte_titre_intro"),
             html_attributes: { class: "fr-mb-0 page-nouveau-compte-alerte-invitation" }
           ) do %>
-        <%= t(".invitation_alerte_description") %>
+        <p class="page-nouveau-compte-alerte-invitation__structure">
+          <%= @invitation.structure&.display_name %><br>
+          <%= @invitation.structure&.adresse %>
+        </p>
       <% end %>
     </div>
   <% end %>

--- a/config/locales/views/nouveaux_comptes.yml
+++ b/config/locales/views/nouveaux_comptes.yml
@@ -21,5 +21,5 @@ fr:
         label_cgu: "J'accepte les %{cgu_lien}"
         bouton_creer: Créer mon compte
         bouton_annuler: Annuler
-        invitation_alerte_titre_intro: "Invitation à rejoindre la structure :"
+        invitation_alerte_titre_intro: Invitation à rejoindre une structure
         invitation_alerte_description: Remplissez les informations demandées pour accéder à votre espace. Cela ne prend que quelques minutes.


### PR DESCRIPTION
Figma : https://www.figma.com/design/MKOnEepxsHdRUSBWaQDlBE/eva-by-Captive?node-id=25438-22301


<img width="1394" height="416" alt="Capture d’écran 2026-04-03 à 13 12 35" src="https://github.com/user-attachments/assets/d47787c9-96fc-4861-b41e-4bce856317ab" />

