### PR TITLE
♻️ Renomme l'usage 'Eva: entreprises' en 'EVAPRO' 

### DIFF
--- a/app/admin/header.rb
+++ b/app/admin/header.rb
@@ -8,7 +8,7 @@ module ActiveAdmin
         return super unless current_compte.present?
 
         partial =
-          if current_compte.structure&.eva_entreprises?
+          if current_compte.structure&.evapro?
             "components/header"
           else
             "components/header_eva"

--- a/app/assets/javascripts/toggle_usage_structure.js
+++ b/app/assets/javascripts/toggle_usage_structure.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', function() {
   if (usageRadios.length > 0 && opcoFieldWrapper) {
     function toggleOpcoField() {
       const selectedUsage = document.querySelector('input[name="structure_locale[usage]"]:checked')?.value;
-      if (selectedUsage === 'Eva: entreprises') {
+      if (selectedUsage === 'EVAPRO') {
         opcoFieldWrapper.style.display = '';
       } else {
         opcoFieldWrapper.style.display = 'none';

--- a/app/controllers/inscription/structures_controller.rb
+++ b/app/controllers/inscription/structures_controller.rb
@@ -126,7 +126,7 @@ class Inscription::StructuresController < ApplicationController
 
   def redirige_vers_usage_ou_creer
     if structure_params[:type_structure] == "entreprise"
-      @compte.usage = AvecUsage::USAGE_ENTREPRISES
+      @compte.usage = AvecUsage::USAGE_EVAPRO
       creer_nouvelle_structure
     elsif etape_usage_inscription_active?
       session[:structure_params_inscription] = structure_params.to_h
@@ -203,7 +203,7 @@ class Inscription::StructuresController < ApplicationController
     @compte.etape_inscription = :complet
 
     if @compte.save
-      CampagneCreateur.new(@structure, @compte).cree_campagne_opco! if @structure.eva_entreprises?
+      CampagneCreateur.new(@structure, @compte).cree_campagne_opco! if @structure.evapro?
       redirige_vers_etape_inscription(@compte)
     else
       render_parametrage

--- a/app/models/campagne_createur.rb
+++ b/app/models/campagne_createur.rb
@@ -16,7 +16,7 @@ class CampagneCreateur
 
   def doit_creer_campagne?
     @structure.is_a?(StructureLocale) &&
-      @structure.eva_entreprises? &&
+      @structure.evapro? &&
       @structure.opco.present?
   end
 

--- a/app/models/compte.rb
+++ b/app/models/compte.rb
@@ -93,7 +93,7 @@ class Compte < ApplicationRecord
   end
 
   def utilisateur_entreprise?
-    !!structure&.eva_entreprises?
+    !!structure&.evapro?
   end
 
   # Aligné sur Ability : profil restreint tant que la validation structure n'est pas finalisée.

--- a/app/models/concerns/avec_usage.rb
+++ b/app/models/concerns/avec_usage.rb
@@ -2,16 +2,17 @@ module AvecUsage
   extend ActiveSupport::Concern
 
   USAGE_BENEFICIAIRES = "Eva: bénéficiaires".freeze
-  USAGE_ENTREPRISES = "Eva: entreprises".freeze
-  USAGE = [ USAGE_BENEFICIAIRES, USAGE_ENTREPRISES ].freeze
+  USAGE_EVAPRO = "EVAPRO".freeze
+  USAGE = [ USAGE_BENEFICIAIRES, USAGE_EVAPRO ].freeze
 
   included do
     validates :usage, inclusion: { in: USAGE }, allow_blank: true
   end
 
-  def eva_entreprises?
-    usage == "Eva: entreprises"
+  def evapro?
+    usage == USAGE_EVAPRO
   end
+  alias_method :eva_entreprises?, :evapro?
 
   def eva_beneficiaires?
     usage == "Eva: bénéficiaires"

--- a/app/models/fabrique_structure.rb
+++ b/app/models/fabrique_structure.rb
@@ -6,7 +6,7 @@ class FabriqueStructure
     structure.assign_attributes(attributs_structure)
     structure.validation_inscription = validation_inscription
 
-    structure.type_structure = "entreprise" if structure.usage == AvecUsage::USAGE_ENTREPRISES
+    structure.type_structure = "entreprise" if structure.usage == AvecUsage::USAGE_EVAPRO
 
     structure.save
     structure

--- a/app/models/structure.rb
+++ b/app/models/structure.rb
@@ -102,9 +102,10 @@ allow_blank: true
     errors.add(:siret, :taken) if Structure.where.not(id: id).exists?(siret: siret)
   end
 
-  def eva_entreprises?
+  def evapro?
     false
   end
+  alias_method :eva_entreprises?, :evapro?
 
   def self.ransack_unaccent_attributes
     %w[nom]

--- a/app/models/structure_locale.rb
+++ b/app/models/structure_locale.rb
@@ -58,9 +58,9 @@ class StructureLocale < Structure
   def affecte_usage_entreprise_si_necessaire
     return unless ENV["ACTIVE_EVAPRO"].present?
     return unless type_structure == "entreprise"
-    return if eva_entreprises?
+    return if evapro?
 
-    self.usage = AvecUsage::USAGE_ENTREPRISES
+    self.usage = AvecUsage::USAGE_EVAPRO
   end
 
   def display_name
@@ -71,9 +71,10 @@ class StructureLocale < Structure
     CIBLE_EVALUATION[type_structure&.to_sym] || "bénéficiaires"
   end
 
-  def eva_entreprises?
-    usage == AvecUsage::USAGE_ENTREPRISES
+  def evapro?
+    usage == AvecUsage::USAGE_EVAPRO
   end
+  alias_method :eva_entreprises?, :evapro?
 
   def metabase_dashboard
     23

--- a/app/views/admin/comptes/_modal_verification.html.erb
+++ b/app/views/admin/comptes/_modal_verification.html.erb
@@ -1,6 +1,6 @@
 
 <%
-  usage_evapro = current_compte.structure&.eva_entreprises?
+  usage_evapro = current_compte.structure&.evapro?
   modal_classes = "fr-modal-verification"
   modal_classes += " evapro_admin" if usage_evapro
 %>

--- a/app/views/inscription/structures/_form_usage.html.erb
+++ b/app/views/inscription/structures/_form_usage.html.erb
@@ -10,7 +10,7 @@
       ) %>
     <% end %>
     <%= form_with url: inscription_structure_path, method: :patch, local: true, html: { class: "form-usage-card" } do |f| %>
-      <%= hidden_field_tag "structure_locale[usage]", AvecUsage::USAGE_ENTREPRISES %>
+      <%= hidden_field_tag "structure_locale[usage]", AvecUsage::USAGE_EVAPRO %>
       <%= render CardUsageComponent.new(
         titre: t("inscription.structures.show.usage.evapro.titre"),
         description: t("inscription.structures.show.usage.evapro.description"),

--- a/config/initializers/active_admin_evapro_admin_class.rb
+++ b/config/initializers/active_admin_evapro_admin_class.rb
@@ -15,7 +15,7 @@ module ActiveAdminEvaproAdminClass
     current_compte = if respond_to?(:controller) && controller.respond_to?(:current_compte)
       controller.current_compte
     end
-    @__evapro_admin_layout = current_compte&.structure&.eva_entreprises?
+    @__evapro_admin_layout = current_compte&.structure&.evapro?
   end
 end
 

--- a/db/migrate/20260408100000_renomme_usage_eva_entreprises_en_evapro.rb
+++ b/db/migrate/20260408100000_renomme_usage_eva_entreprises_en_evapro.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class RenommeUsageEvaEntreprisesEnEvapro < ActiveRecord::Migration[7.2]
+  ANCIEN_USAGE = "Eva: entreprises"
+  NOUVEL_USAGE = "EVAPRO"
+
+  def up
+    execute <<~SQL.squish
+      UPDATE structures
+      SET usage = '#{NOUVEL_USAGE}'
+      WHERE usage = '#{ANCIEN_USAGE}'
+    SQL
+
+    execute <<~SQL.squish
+      UPDATE comptes
+      SET usage = '#{NOUVEL_USAGE}'
+      WHERE usage = '#{ANCIEN_USAGE}'
+    SQL
+  end
+
+  def down
+    execute <<~SQL.squish
+      UPDATE structures
+      SET usage = '#{ANCIEN_USAGE}'
+      WHERE usage = '#{NOUVEL_USAGE}'
+    SQL
+
+    execute <<~SQL.squish
+      UPDATE comptes
+      SET usage = '#{ANCIEN_USAGE}'
+      WHERE usage = '#{NOUVEL_USAGE}'
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_02_152415) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_08_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/spec/controllers/admin/evaluations_controller_spec.rb
+++ b/spec/controllers/admin/evaluations_controller_spec.rb
@@ -5,7 +5,7 @@ describe Admin::EvaluationsController, type: :controller do
     let(:structure) do
       create(:structure_locale,
              type_structure: "entreprise",
-             usage: AvecUsage::USAGE_ENTREPRISES)
+             usage: AvecUsage::USAGE_EVAPRO)
     end
     let(:compte_connecte) { create(:compte_admin, structure: structure) }
     let(:campagne) { create(:campagne, compte: compte_connecte) }

--- a/spec/controllers/inscription/structures_controller_spec.rb
+++ b/spec/controllers/inscription/structures_controller_spec.rb
@@ -230,12 +230,12 @@ describe Inscription::StructuresController, type: :controller do
           structure_params.merge(type_structure: "entreprise")
         end
 
-        it "affecte l'usage 'Eva: entreprises' à la structure" do
+        it "affecte l'usage 'EVAPRO' à la structure" do
           patch :update, params: { structure: structure_params_entreprise, commit: "creer" }
 
           structure_creée.reload
           expect(structure_creée.type_structure).to eq("entreprise")
-          expect(structure_creée.usage).to eq("Eva: entreprises")
+          expect(structure_creée.usage).to eq("EVAPRO")
         end
       end
 
@@ -336,12 +336,12 @@ describe Inscription::StructuresController, type: :controller do
 
         it "crée la structure avec l'usage entreprises et redirige vers le dashboard" do
           patch :update, params: {
-            structure_locale: { usage: AvecUsage::USAGE_ENTREPRISES },
+            structure_locale: { usage: AvecUsage::USAGE_EVAPRO },
             commit: "creer_avec_usage"
           }
 
           structure_creée.reload
-          expect(structure_creée.usage).to eq(AvecUsage::USAGE_ENTREPRISES)
+          expect(structure_creée.usage).to eq(AvecUsage::USAGE_EVAPRO)
           expect(response).to redirect_to(admin_dashboard_path)
         end
       end

--- a/spec/controllers/nouvelles_structures_controller_spec.rb
+++ b/spec/controllers/nouvelles_structures_controller_spec.rb
@@ -13,7 +13,7 @@ describe NouvellesStructuresController, type: :controller do
         code_postal: "75001",
         siret: "12345678901234",
         type_structure: "entreprise",
-        usage: "Eva: entreprises",
+        usage: "EVAPRO",
         idcc: [ "3", "18" ]
       }
     }
@@ -54,12 +54,12 @@ describe NouvellesStructuresController, type: :controller do
 usage: nil })
         end
 
-        it "affecte l'usage 'Eva: entreprises' à la structure" do
+        it "affecte l'usage 'EVAPRO' à la structure" do
           post :create, params: { compte: compte_params_entreprise }
 
           structure = Compte.last.structure
           expect(structure.type_structure).to eq("entreprise")
-          expect(structure.usage).to eq("Eva: entreprises")
+          expect(structure.usage).to eq("EVAPRO")
         end
       end
     end

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -274,7 +274,7 @@ describe 'Dashboard', type: :feature do
     let!(:structure_entreprise) do
       create :structure_locale,
              type_structure: "entreprise",
-             usage: "Eva: entreprises",
+             usage: "EVAPRO",
              code_postal: "75012"
     end
     let!(:compte) do

--- a/spec/features/admin/structure_locale_spec.rb
+++ b/spec/features/admin/structure_locale_spec.rb
@@ -101,7 +101,7 @@ visible: :all
         visit new_admin_structure_locale_path
         fill_in :structure_locale_nom, with: 'Entreprise test'
         select 'Entreprise'
-        choose 'Eva: entreprises'
+        choose 'EVAPRO'
         fill_in :structure_locale_code_postal, with: '92100'
         fill_in :structure_locale_siret, with: '12345678901234'
         click_on 'Créer une structure'

--- a/spec/models/campagne_createur_spec.rb
+++ b/spec/models/campagne_createur_spec.rb
@@ -7,7 +7,7 @@ describe CampagneCreateur, type: :model do
     create(:structure_locale,
            nom: "ma super structure",
            type_structure: "entreprise",
-           usage: "Eva: entreprises",
+           usage: "EVAPRO",
            opco: opco)
   end
   let(:createur) { described_class.new(structure_entreprise, compte) }
@@ -87,7 +87,7 @@ describe CampagneCreateur, type: :model do
         let(:structure_sans_opco) do
           create(:structure_locale,
                  type_structure: "entreprise",
-                 usage: "Eva: entreprises",
+                 usage: "EVAPRO",
                  opco: nil)
         end
         let(:createur_sans_opco) { described_class.new(structure_sans_opco, compte) }
@@ -97,7 +97,7 @@ describe CampagneCreateur, type: :model do
         end
       end
 
-      context "quand l'usage n'est pas Eva: entreprises" do
+      context "quand l'usage n'est pas EVAPRO" do
         let(:structure_mauvais_usage) do
           create(:structure_locale,
                  type_structure: "entreprise",
@@ -115,7 +115,7 @@ describe CampagneCreateur, type: :model do
         let(:structure_administrative) do
           create(:structure_administrative,
                  type_structure: "entreprise",
-                 usage: "Eva: entreprises",
+                 usage: "EVAPRO",
                  opco: opco)
         end
         let(:createur_structure_administrative) {
@@ -131,7 +131,7 @@ describe CampagneCreateur, type: :model do
         let(:structure_non_entreprise) do
         create(:structure_locale,
                  type_structure: "mission_locale",
-                 usage: "Eva: entreprises",
+                 usage: "EVAPRO",
                  opco: opco)
         end
         let(:createur_non_entreprise) { described_class.new(structure_non_entreprise, compte) }
@@ -146,7 +146,7 @@ describe CampagneCreateur, type: :model do
         let(:structure_ineligible) do
           create(:structure_locale,
                type_structure: "mission_locale",
-               usage: "Eva: entreprises",
+               usage: "EVAPRO",
                  opco: opco)
         end
         let(:createur_ineligible) { described_class.new(structure_ineligible, compte) }

--- a/spec/models/compte_spec.rb
+++ b/spec/models/compte_spec.rb
@@ -179,7 +179,7 @@ describe Compte do
       let(:structure) do
         build(:structure_locale,
               type_structure: "entreprise",
-              usage: "Eva: entreprises")
+              usage: "EVAPRO")
       end
       let(:compte) { build(:compte, structure: structure) }
 

--- a/spec/models/structure_locale_spec.rb
+++ b/spec/models/structure_locale_spec.rb
@@ -58,17 +58,17 @@ describe StructureLocale, type: :model do
   describe '#usage' do
     it do
       expect(subject).to validate_inclusion_of(:usage).in_array([ "Eva: bénéficiaires",
-                                                                   "Eva: entreprises" ])
+                                                                   "EVAPRO" ])
     end
   end
 
-  describe '#eva_entreprises?' do
+  describe '#evapro?' do
     context 'quand la structure est une entreprise' do
       let(:structure) do
-        described_class.new(type_structure: "entreprise", usage: "Eva: entreprises")
+        described_class.new(type_structure: "entreprise", usage: "EVAPRO")
       end
 
-      it { expect(structure).to be_eva_entreprises }
+      it { expect(structure).to be_evapro }
     end
 
     context 'quand la structure n\'est pas une entreprise' do
@@ -76,7 +76,7 @@ describe StructureLocale, type: :model do
         described_class.new(type_structure: "mission_locale", usage: "Eva: bénéficiaires")
       end
 
-      it { expect(structure).not_to be_eva_entreprises }
+      it { expect(structure).not_to be_evapro }
     end
 
     context 'quand le type est entreprise mais l\'usage est bénéficiaires' do
@@ -84,15 +84,15 @@ describe StructureLocale, type: :model do
         described_class.new(type_structure: "entreprise", usage: "Eva: bénéficiaires")
       end
 
-      it { expect(structure).not_to be_eva_entreprises }
+      it { expect(structure).not_to be_evapro }
     end
 
     context "quand le type n'est pas entreprise mais l'usage est entreprises" do
       let(:structure) do
-        described_class.new(type_structure: "mission_locale", usage: "Eva: entreprises")
+        described_class.new(type_structure: "mission_locale", usage: "EVAPRO")
       end
 
-      it { expect(structure).to be_eva_entreprises }
+      it { expect(structure).to be_evapro }
     end
   end
 
@@ -120,21 +120,21 @@ describe StructureLocale, type: :model do
                               type_structure: "entreprise", usage: nil)
         end
 
-        it "affecte l'usage 'Eva: entreprises'" do
+        it "affecte l'usage 'EVAPRO'" do
           structure.affecte_usage_entreprise_si_necessaire
-          expect(structure.usage).to eq("Eva: entreprises")
+          expect(structure.usage).to eq("EVAPRO")
         end
       end
 
-      context 'quand le type_structure est entreprise et usage est déjà "Eva: entreprises"' do
+      context 'quand le type_structure est entreprise et usage est déjà "EVAPRO"' do
         let(:structure) do
           described_class.new(nom: "Test", code_postal: "75012", siret: "12345678901234",
-                              type_structure: "entreprise", usage: "Eva: entreprises")
+                              type_structure: "entreprise", usage: "EVAPRO")
         end
 
         it "ne modifie pas l'usage existant" do
           structure.affecte_usage_entreprise_si_necessaire
-          expect(structure.usage).to eq("Eva: entreprises")
+          expect(structure.usage).to eq("EVAPRO")
         end
       end
 
@@ -144,9 +144,21 @@ describe StructureLocale, type: :model do
                               type_structure: "entreprise", usage: "Eva: bénéficiaires")
         end
 
-        it "force l'usage à 'Eva: entreprises'" do
+        it "force l'usage à 'EVAPRO'" do
           structure.affecte_usage_entreprise_si_necessaire
-          expect(structure.usage).to eq("Eva: entreprises")
+          expect(structure.usage).to eq("EVAPRO")
+        end
+      end
+
+      context 'quand la valeur historique "Eva: entreprises" est encore présente' do
+        let(:structure) do
+          described_class.new(nom: "Test", code_postal: "75012", siret: "12345678901234",
+                              type_structure: "entreprise", usage: "Eva: entreprises")
+        end
+
+        it "normalise l'usage vers EVAPRO" do
+          structure.affecte_usage_entreprise_si_necessaire
+          expect(structure.usage).to eq("EVAPRO")
         end
       end
 


### PR DESCRIPTION
[Ticket EVA-936](https://captive-team.atlassian.net/browse/EVA-936?atlOrigin=eyJpIjoiOWE3YmYwMDMyNmEyNDlhZjkxMjhiNTgzYTBkM2M3OGQiLCJwIjoiaiJ9)

Modifie les références et les validations associées à l'usage des structures pour refléter ce changement. Cela inclut les contrôleurs, modèles, vues et tests. Assure également la compatibilité avec les anciennes valeurs pour une transition en douceur.