### PR TITLE
EVA-932 : Remettre les liens exploitables dans la restitution evapro

### DIFF
--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,6 +1,6 @@
 module UrlHelper
   # https://www.constructys.fr/ => constructys.fr
   def humanize_url(url)
-    url.gsub("https://", "").gsub("http://", "").gsub("www.", "").gsub("/", "")
+    url.gsub("https://", "").gsub("http://", "").gsub("www.", "").delete_suffix("/")
   end
 end

--- a/spec/helpers/url_helper_spec.rb
+++ b/spec/helpers/url_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe UrlHelper do
+  describe '#humanize_url' do
+    it 'retire https:// et www.' do
+      expect(helper.humanize_url('https://www.constructys.fr')).to eq('constructys.fr')
+    end
+
+    it 'retire http:// et www.' do
+      expect(helper.humanize_url('http://www.exemple.fr')).to eq('exemple.fr')
+    end
+
+    it 'retir le dernier /' do
+      expect(helper.humanize_url('constructys.fr/contacts/')).to eq('constructys.fr/contacts')
+    end
+
+    it 'laisse url inchangée sans protocole ni www.' do
+      expect(helper.humanize_url('constructys.fr/contacts')).to eq('constructys.fr/contacts')
+    end
+  end
+end


### PR DESCRIPTION
- Corrige les urls constructys.frcontacts -> constructys.fr/contacts (manquait un /)
- Supprime les derniers / en fin d'adresse pour ne pas avoir constructys.fr/contacts/ mais constructys.fr/contacts
- Ajout de test pour UrlHelper