### PR TITLE
🐛 Corrige le double soulignement du lien de l'email dans la recherche de structure dans l'onboarding

### DIFF
--- a/app/assets/stylesheets/admin/pages/inscription/_recherche.scss
+++ b/app/assets/stylesheets/admin/pages/inscription/_recherche.scss
@@ -22,7 +22,6 @@
 
     &-email {
       color: var(--text-mention-grey);
-      text-decoration: underline;
 
       &:hover,
       &:focus {


### PR DESCRIPTION
**AVANT :** 

<img width="1376" height="236" alt="Capture d’écran 2026-04-15 à 12 05 38" src="https://github.com/user-attachments/assets/98e65c1f-5058-452d-b344-594f0fa2ab1d" />

**APRES :**

<img width="593" height="177" alt="Capture d’écran 2026-04-15 à 14 39 08" src="https://github.com/user-attachments/assets/dc410a7f-b9e7-40b7-bc19-037c5657c04e" />

