### PR TITLE
🐛 Corrige la purge des comptes référencés dans des invitations

### DIFF
--- a/app/jobs/purge_comptes_supprimes_job.rb
+++ b/app/jobs/purge_comptes_supprimes_job.rb
@@ -44,5 +44,6 @@ class PurgeComptesSupprimesJob < ApplicationJob
     Evaluation.with_deleted.where(responsable_suivi: compte).update_all(responsable_suivi_id: nil)
     Beneficiaire.with_deleted.where(compte: compte).update_all(compte_id: nil)
     Campagne.with_deleted.where(compte: compte).find_each(&:really_destroy!)
+    Invitation.where(invitant: compte).or(Invitation.where(compte: compte)).delete_all
   end
 end

--- a/spec/jobs/purge_comptes_supprimes_job_spec.rb
+++ b/spec/jobs/purge_comptes_supprimes_job_spec.rb
@@ -71,6 +71,26 @@ describe PurgeComptesSupprimesJob, type: :job do
       expect(beneficiaire.reload.compte).to be_nil
     end
 
+    it "détruit un compte supprimé, invitant d'une invitation et détruit l'invitation" do
+      compte = create :compte_conseiller, structure: structure, deleted_at: 1.month.ago
+      invitation = create :invitation, invitant: compte, structure: structure
+
+      described_class.perform_now
+
+      expect(Compte.with_deleted.find_by(id: compte.id)).to be_nil
+      expect(Invitation.find_by(id: invitation.id)).to be_nil
+    end
+
+    it "détruit un compte supprimé, invité dans une invitation et détruit l'invitation" do
+      compte = create :compte_conseiller, structure: structure, deleted_at: 1.month.ago
+      invitation = create :invitation, :acceptee, compte: compte, structure: structure
+
+      described_class.perform_now
+
+      expect(Compte.with_deleted.find_by(id: compte.id)).to be_nil
+      expect(Invitation.find_by(id: invitation.id)).to be_nil
+    end
+
     it 'detruit un compte supprimé référencé par un bénéficiaire supprimé et retire ce lien' do
       compte = create :compte_conseiller, structure: structure, deleted_at: 1.month.ago
       beneficiaire = create :beneficiaire, compte: compte, deleted_at: 1.month.ago


### PR DESCRIPTION
prepare_destruction ne gérait pas les invitations, causant une violation de clé étrangère lors du really_destroy!.

https://app.rollbar.com/a/eva-betagouv/fix/item/eva-serveur/307#detail

Couvre les deux cas :
- compte référencé comme invitant
- compte référencé comme compte invité (invitation acceptée)