### PR TITLE
✨ Ajoute la gestion de l'usage et de l'OPCO pour les structures administratives

### DIFF
--- a/app/admin/structures_administratives.rb
+++ b/app/admin/structures_administratives.rb
@@ -3,7 +3,7 @@ ActiveAdmin.register StructureAdministrative do
     current_compte.anlci? || current_compte.administratif?
   }
 
-  permit_params :nom, :parent_id, :siret
+  permit_params :nom, :parent_id, :siret, :usage, :opco_id
 
   filter :nom, filters: [ :contains_unaccent, :eq ]
   filter :created_at

--- a/app/assets/javascripts/toggle_usage_structure.js
+++ b/app/assets/javascripts/toggle_usage_structure.js
@@ -1,23 +1,44 @@
 document.addEventListener('DOMContentLoaded', function() {
-  const usageRadios = document.querySelectorAll('input[name="structure_locale[usage]"]');
-  const opcoField = document.getElementById('opco_field');
-  const opcoFieldWrapper = opcoField?.closest('.input');
-  
-  if (usageRadios.length > 0 && opcoFieldWrapper) {
-    function toggleOpcoField() {
-      const selectedUsage = document.querySelector('input[name="structure_locale[usage]"]:checked')?.value;
-      if (selectedUsage === 'EVAPRO') {
-        opcoFieldWrapper.style.display = '';
-      } else {
-        opcoFieldWrapper.style.display = 'none';
+  [ 'structure_locale', 'structure_administrative' ].forEach(function(modelName) {
+    const usageRadios = document.querySelectorAll(`input[name="${modelName}[usage]"]`);
+    const opcoField = document.getElementById('opco_field');
+    const opcoFieldWrapper = opcoField?.closest('.input');
+    const opcoLabel = document.getElementById('opco_label');
+    const parentField = document.getElementById(`${modelName}_parent_id`);
+    const parentFieldWrapper = parentField?.closest('.input');
+
+    if (usageRadios.length > 0) {
+      function toggleOpcoField() {
+        const selectedUsage = document.querySelector(`input[name="${modelName}[usage]"]:checked`)?.value;
+        const evaproSelected = selectedUsage === 'EVAPRO';
+        if (opcoFieldWrapper) {
+          opcoFieldWrapper.style.display = evaproSelected ? '' : 'none';
+        }
+        if (opcoField) {
+          opcoField.required = evaproSelected;
+        }
+        if (opcoFieldWrapper) {
+          opcoFieldWrapper.classList.toggle("required", evaproSelected);
+        }
+        if (opcoLabel) {
+          let requiredMarker = opcoLabel.querySelector("abbr[title='obligatoire']");
+          if (evaproSelected && !requiredMarker) {
+            requiredMarker = document.createElement("abbr");
+            requiredMarker.setAttribute("title", "obligatoire");
+            requiredMarker.textContent = "*";
+            opcoLabel.appendChild(requiredMarker);
+          } else if (!evaproSelected && requiredMarker) {
+            requiredMarker.remove();
+          }
+        }
+        if (parentFieldWrapper) {
+          parentFieldWrapper.style.display = evaproSelected ? 'none' : '';
+        }
       }
+
+      toggleOpcoField();
+      usageRadios.forEach(radio => radio.addEventListener('change', toggleOpcoField));
     }
-    
-    toggleOpcoField();
-    
-    usageRadios.forEach(radio => {
-      radio.addEventListener('change', toggleOpcoField);
-    });
-  }
+  });
 });
 

--- a/app/assets/stylesheets/admin/composants/_select2.scss
+++ b/app/assets/stylesheets/admin/composants/_select2.scss
@@ -13,3 +13,8 @@
     padding-left: 0;
   }
 }
+
+select.opco-select + .select2 .select2-selection__rendered {
+  flex-direction: row;
+  justify-content: flex-start;
+}

--- a/app/inputs/select_input.rb
+++ b/app/inputs/select_input.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class SelectInput < Formtastic::Inputs::SelectInput
+  def initialize(builder, template, object, object_name, method, options)
+    super
+    evalue_collection_callable
+    applique_placeholder_select2
+  end
+
+  private
+
+  def evalue_collection_callable
+    collection = @options[:collection]
+    return unless collection.respond_to?(:call)
+
+    @options[:collection] = template.instance_exec(&collection)
+  end
+
+  def applique_placeholder_select2
+    placeholder = placeholder_text
+    return if placeholder.blank?
+
+    renseigne_donnees_select2(placeholder)
+    force_include_blank_texte(placeholder)
+  end
+
+  def renseigne_donnees_select2(placeholder)
+    data = input_data_options
+    data[:placeholder] ||= placeholder
+    data[:allow_clear] = true if data[:allow_clear].nil?
+  end
+
+  def force_include_blank_texte(placeholder)
+    @options[:include_blank] = placeholder if @options[:include_blank] == true
+  end
+
+  def input_data_options
+    @options[:input_html] ||= {}
+    @options[:input_html][:data] ||= {}
+  end
+
+  def placeholder_text
+    @options[:placeholder] || include_blank_text
+  end
+
+  def include_blank_text
+    return nil unless @options[:include_blank].is_a?(String)
+
+    @options[:include_blank]
+  end
+end

--- a/app/models/structure_administrative.rb
+++ b/app/models/structure_administrative.rb
@@ -1,4 +1,9 @@
 class StructureAdministrative < Structure
+  include AvecUsage
+
+  validates :usage, presence: true
+  validates :opco, presence: true, if: :evapro?
+
   def metabase_dashboard
     53
   end

--- a/app/views/admin/structures/_show.html.arb
+++ b/app/views/admin/structures/_show.html.arb
@@ -10,6 +10,14 @@ div class: "row" do
       div class: "panel" do
         attributes_table_for structure do
           row :nom
+          if structure.instance_of?(StructureAdministrative)
+            row :usage
+            if structure.opco.present?
+              row("Opérateur de compétences") do
+                structure.opco.nom
+              end
+            end
+          end
           if structure.instance_of?(StructureLocale)
             row :type_structure do
               traduction_type_structure(structure.type_structure)

--- a/app/views/admin/structures_administratives/_form.html.arb
+++ b/app/views/admin/structures_administratives/_form.html.arb
@@ -5,6 +5,16 @@ active_admin_form_for [ :admin, resource ] do |f|
             as: :siret,
             required: resource.new_record?,
             hint: t("admin.structures.structures_locales.form.siret_hint")
+    f.input :usage, as: :radio, collection: StructureAdministrative::USAGE
+    f.input :opco_id, as: :select,
+            collection: Opco.order(:nom).map { |opco| [ opco.nom, opco.id ] },
+            include_blank: t("formtastic.placeholders.structure.opco_id"),
+            input_html: {
+              id: "opco_field",
+              class: "select2 opco-select"
+            },
+            label_html: { id: "opco_label" },
+            required: false
     if can?(:manage, Compte)
       f.input :parent_id, as: :select, collection: StructureAdministrative.all
     end

--- a/config/locales/models/structure.yml
+++ b/config/locales/models/structure.yml
@@ -33,6 +33,7 @@ fr:
         statut_siret_true: vérifié
         statut_siret_false: non vérifié
         opco: Opérateur de compétences
+        opco_id: Opérateur de compétences
         date_verification_siret: Date vérification SIRET
         region: Région
         code_commune: Code (INSEE) de la commune
@@ -84,6 +85,7 @@ fr:
       structure: &placeholders_structure
         nom: Mission locale de Montpellier
         code_postal: "34000"
+        opco_id: Sélectionnez une option
       structure_administrative:
         <<: *placeholders_structure
       structure_locale:

--- a/db/migrate/20260421120000_initialise_usage_structures_administratives.rb
+++ b/db/migrate/20260421120000_initialise_usage_structures_administratives.rb
@@ -1,0 +1,14 @@
+class InitialiseUsageStructuresAdministratives < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL.squish
+      UPDATE structures
+      SET usage = 'Eva: bénéficiaires'
+      WHERE type = 'StructureAdministrative'
+        AND (usage IS NULL OR usage = '')
+    SQL
+  end
+
+  def down
+    # Pas de rollback de données pour éviter d'effacer une valeur potentiellement valide.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_09_152506) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_21_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/spec/features/admin/structure_administrative_spec.rb
+++ b/spec/features/admin/structure_administrative_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'Admin - Structure administrative', type: :feature do
   context 'en tant que superadmin' do
     let(:compte_superadmin) { create(:compte_superadmin) }
+    let!(:opco) { create(:opco, nom: "OPCO Test") }
     let!(:structure) {
           create :structure_administrative, :avec_admin, nom: 'Ma structure',
   siret: '12345678901234'
@@ -49,6 +50,13 @@ role: :conseiller
     end
 
     describe 'création' do
+      it "propose uniquement les usages Eva bénéficiaires et EVAPRO" do
+        visit new_admin_structure_administrative_path
+
+        usages = all("input[name='structure_administrative[usage]']", visible: :all).map(&:value)
+        expect(usages).to contain_exactly(AvecUsage::USAGE_BENEFICIAIRES, AvecUsage::USAGE_EVAPRO)
+      end
+
       it 'permet de créer une structure avec le même SIRET' do
         visit new_admin_structure_administrative_path
 
@@ -59,6 +67,22 @@ role: :conseiller
         structure = Structure.order(:created_at).last
         expect(structure.nom).to eq 'Nouvelle structure'
         expect(structure.siret).to eq '12345678901234'
+        expect(structure.usage).to eq AvecUsage::USAGE_BENEFICIAIRES
+      end
+
+      it "permet de créer une structure EVAPRO rattachée à un OPCO" do
+        visit new_admin_structure_administrative_path
+
+        fill_in :structure_administrative_nom, with: "Nouvelle structure EVAPRO"
+        fill_in :structure_administrative_siret, with: "12345678901231"
+        find("input[name='structure_administrative[usage]'][value='EVAPRO']").choose
+        find("#opco_field", visible: :all).find("option", text: opco.nom).select_option
+        click_on "Créer une structure"
+
+        structure = Structure.order(:created_at).last
+        expect(structure.nom).to eq "Nouvelle structure EVAPRO"
+        expect(structure.usage).to eq AvecUsage::USAGE_EVAPRO
+        expect(structure.opco).to eq(opco)
       end
     end
 

--- a/spec/models/structure_administrative_spec.rb
+++ b/spec/models/structure_administrative_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe StructureAdministrative, type: :model do
+  describe "validations usage/opco" do
+    it "est invalide sans usage" do
+      structure = build(:structure_administrative, usage: nil)
+
+      expect(structure).not_to be_valid
+      expect(structure.errors[:usage]).to be_present
+    end
+
+    it "est invalide avec un usage hors liste" do
+      structure = build(:structure_administrative, usage: "AUTRE_USAGE")
+
+      expect(structure).not_to be_valid
+      expect(structure.errors[:usage]).to be_present
+    end
+
+    it "requiert un opco en usage EVAPRO" do
+      structure = build(:structure_administrative, usage: AvecUsage::USAGE_EVAPRO, opco: nil)
+
+      expect(structure).not_to be_valid
+      expect(structure.errors[:opco]).to be_present
+    end
+
+    it "accepte EVAPRO quand un opco est présent" do
+      structure = build(:structure_administrative, usage: AvecUsage::USAGE_EVAPRO,
+opco: create(:opco))
+
+      expect(structure).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
[Ticket EVA-951](https://captive-team.atlassian.net/browse/EVA-951)

- Permet l'enregistrement des paramètres `usage` et `opco_id` dans le modèle `StructureAdministrative`.
- Met à jour le formulaire d'administration pour inclure ces nouveaux champs.
- Ajoute des validations pour garantir la présence de `usage` et d'`opco` lorsque l'usage est `EVAPRO`.
- Crée une migration pour initialiser les valeurs d'usage pour les structures administratives existantes.