### PR TITLE
EVA-974 page actualites cassee dans evapro 2

### DIFF
--- a/app/assets/stylesheets/admin/composants/_tables.scss
+++ b/app/assets/stylesheets/admin/composants/_tables.scss
@@ -1,5 +1,8 @@
 .index_as_table {
   overflow-x: auto;
+  // Ceci est un hack pour éviter que les shadow des éléments enfants soient éffacées à cause de l'overflow-x ⬆️
+  padding: 0.5rem;
+  margin: -0.5rem;
 }
 
 table.index_table {

--- a/app/assets/stylesheets/admin/pages/evaluation/_index_evapro.scss
+++ b/app/assets/stylesheets/admin/pages/evaluation/_index_evapro.scss
@@ -41,6 +41,10 @@ body.index.admin_evaluations.evapro_admin #active_admin_content #main_content_wr
   }
 }
 
+.index.evapro_admin #active_admin_content #main_content_wrapper #main_content .paginated_collection {
+  width: 100%;
+}
+
 @media (max-width: 768px) {
   .admin_evaluations.index.evapro_admin #active_admin_content #main_content_wrapper #main_content .paginated_collection {
     padding-left: 1rem;


### PR DESCRIPTION
<img width="979" height="603" alt="Capture d’écran 2026-04-22 à 14 50 40" src="https://github.com/user-attachments/assets/8737e013-bb21-4aa3-b0be-d3b03897e6de" />
