### PR TITLE
EVA-976 : 🐛 Corrige le scroll horizontal sur les pages listes evapro (vues admin)

### DIFF
--- a/app/assets/stylesheets/admin/layout/_main_structure.scss
+++ b/app/assets/stylesheets/admin/layout/_main_structure.scss
@@ -25,7 +25,7 @@ body.logged_in.evapro_admin.admin_evaluations #active_admin_content #main_conten
   display: flex;
   padding: $dsfr-spacing-4w 0 $dsfr-spacing-7w 0;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: stretch;
   gap: $dsfr-spacing-8w;
   flex: 1 0 0;
 }


### PR DESCRIPTION
- remplace align-items: flex-start par stretch