### PR TITLE
🔧 Empêche l'utilisation de "OPCO" dans les traductions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,9 @@ jobs:
           name: Lint typographie des locales
           command: bundle exec rake locale_typography
       - run:
+          name: Lint utilisation de OPCO dans les locales
+          command: bundle exec rake locale_opco
+      - run:
           name: Stylelint (CSS/SCSS)
           command: npm run lint:css
 

--- a/bin/lint_locale_opco
+++ b/bin/lint_locale_opco
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../config/environment"
+
+Linters::LocaleOpco.run

--- a/config/locales/models/opco.yml
+++ b/config/locales/models/opco.yml
@@ -28,7 +28,7 @@ fr:
         opco_parcours_type:
           attributes:
             parcours_type_id:
-              deja_associe_a_cet_opco: Ce parcours type est déjà associé à cet OPCO
+              deja_associe_a_cet_opco: Ce parcours type est déjà associé à cet opérateur de compétences
   formtastic:
     actions:
       opco:

--- a/lib/linters/locale_opco.rb
+++ b/lib/linters/locale_opco.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module Linters
+  # Vérifie l'absence du mot "OPCO" dans les fichiers de traduction YAML
+  # Le mot "OPCO" doit être remplacé par "Opérateur de Compétences"
+  class LocaleOpco
+    Violation = Struct.new(:file, :key_path, :message, :snippet, keyword_init: true)
+
+    def initialize(locales_dir: nil)
+      @locales_dir = locales_dir || Rails.root.join("config/locales")
+    end
+
+    def check
+      violations = []
+      Dir.glob(@locales_dir.join("**/*.yml")).each do |path|
+        violations.concat(check_file(path))
+      end
+      violations
+    end
+
+    def check_file(path)
+      violations = []
+      data = YAML.load_file(path, aliases: true)
+      return violations unless data.is_a?(Hash)
+
+      collect_violations(data, path.to_s, [], violations)
+      violations
+    end
+
+    def self.run(locales_dir: nil)
+      new(locales_dir: locales_dir).tap do |linter|
+        violations = linter.check
+        linter.report(violations)
+        exit(1) if violations.any?
+      end
+    end
+
+    def report(violations, io: $stderr)
+      return if violations.empty?
+
+      report_header(violations.size, io)
+      violations.each { |v| report_violation(v, io) }
+    end
+
+    def report_header(count, io)
+      io.puts "Utilisation de OPCO : #{count} violation(s) trouvée(s)."
+      io.puts "Le mot « OPCO » est interdit. Utiliser plutôt : « Opérateur de Compétences »"
+      io.puts
+    end
+
+    def report_violation(v, io)
+      io.puts "  #{v.file} (#{v.key_path.join('.')})"
+      io.puts "    #{v.message}"
+      io.puts "    Extrait : #{v.snippet.inspect}" if v.snippet
+      io.puts
+    end
+
+    private
+
+    def collect_violations(obj, file, key_path, violations)
+      case obj
+      when Hash
+        obj.each do |key, value|
+          collect_violations(value, file, key_path + [ key.to_s ], violations)
+        end
+      when Array
+        obj.each_with_index do |item, index|
+          collect_violations(item, file, key_path + [ "[#{index}]" ], violations)
+        end
+      when String
+        check_string(obj, file, key_path, violations)
+      end
+    end
+
+    def check_string(str, file, key_path, violations)
+      # Cherche le mot "OPCO" (avec limites de mots pour éviter les faux positifs)
+      str.scan(/\bOPCO\b/) do
+        msg = "Le mot « OPCO » est interdit. Utiliser plutôt : « Opérateur de Compétences »"
+        violations << Violation.new(
+          file: file,
+          key_path: key_path,
+          message: msg,
+          snippet: extract_snippet(str, Regexp.last_match.offset(0)[0], 30)
+        )
+      end
+    end
+
+    def extract_snippet(str, position, context = 30)
+      start = [ 0, position - context ].max
+      finish = [ str.length, position + context ].min
+      snippet = str[start...finish]
+      snippet = "…#{snippet}" if start.positive?
+      snippet = "#{snippet}…" if finish < str.length
+      snippet
+    end
+  end
+end

--- a/lib/tasks/locale_opco.rake
+++ b/lib/tasks/locale_opco.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+namespace :locale_opco do
+  desc "Vérifie l'absence du mot 'OPCO' dans les traductions \
+    (doit être remplacé par 'Opérateur de Compétences')"
+  task check: :environment do
+    Linters::LocaleOpco.run
+  end
+end
+
+task locale_opco: "locale_opco:check"


### PR DESCRIPTION
Il faut utiliser plutôt "Opérateur de Compétence"

On ajoute un linter pour éviter d'avoir une erreur à l'avenir