### PR TITLE
EVA-999 : Erreur 500 sur la page questionnaires

### DIFF
--- a/app/admin/questionnaires.rb
+++ b/app/admin/questionnaires.rb
@@ -1,5 +1,3 @@
-require "zip"
-
 ActiveAdmin.register Questionnaire do
   menu parent: "Parcours", if: proc { can? :manage, Compte }
 
@@ -7,7 +5,15 @@ ActiveAdmin.register Questionnaire do
                 questionnaires_questions_attributes: %i[id question_id _destroy]
 
   filter :libelle, filters: [ :contains_unaccent, :eq ]
-  filter :questions
+  filter :questions_id,
+         as: :search_select_filter,
+         label: "Question",
+         url: proc { admin_questions_path },
+         fields: %i[libelle nom_technique],
+         display_name: "display_name",
+         method_model: Question,
+         minimum_input_length: 2,
+         order_by: "libelle_asc"
 
   member_action :export_questions, method: :get
 

--- a/app/views/admin/questions/index.json.jbuilder
+++ b/app/views/admin/questions/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @questions do |question|
+  json.extract! question, :id, :libelle, :nom_technique
+  json.display_name question.display_name
+end

--- a/spec/features/admin/questionnaire_spec.rb
+++ b/spec/features/admin/questionnaire_spec.rb
@@ -9,6 +9,22 @@ describe 'Admin - Questionnaire', type: :feature do
     before { visit admin_questionnaires_path }
 
     it { expect(page).to have_content 'Numératie et Litératie' }
+
+    context "avec filtre par question" do
+      let(:question_associee) { create(:question_saisie, libelle: "Question filtre") }
+      let!(:questionnaire_filtre) do
+        create(:questionnaire, libelle: "Questionnaire filtré", questions: [ question_associee ])
+      end
+      let!(:questionnaire_hors_filtre) {
+ create(:questionnaire, libelle: "Questionnaire non filtré") }
+
+      it "charge l'index sans erreur 500 et applique le filtre" do
+        visit admin_questionnaires_path(q: { questions_id_eq: question_associee.id })
+
+        expect(page).to have_content("Questionnaire filtré")
+        expect(page).not_to have_content("Questionnaire non filtré")
+      end
+    end
   end
 
   describe 'création' do


### PR DESCRIPTION
Le filtre `questions` sur l’index admin des Questionnaires provoquait une erreur 500 (`undefined method 'questions' for Ransack::Search`) car la clé de filtre n’était pas compatible avec Ransack dans ce contexte d’association.

Le filtre a été remplacé par une configuration explicite en `search_select_filter`
(`questions_id`) pour éviter le chargement massif des questions à l’ouverture de l’index.
