### PR TITLE
💄 Ajoute un padding de 1rem sur la version mobile du tableau des evaluations eva

### DIFF
--- a/app/assets/stylesheets/admin/pages/_evaluations.scss
+++ b/app/assets/stylesheets/admin/pages/_evaluations.scss
@@ -220,3 +220,29 @@ body.logged_in.evapro_admin.admin_evaluations.index #active_admin_content {
     @include tronque;
   }
 }
+
+@media (max-width: 854px) {
+  body.logged_in.active_admin.admin_evaluations.index:not(.evapro_admin) {
+    #title_bar #titlebar_left {
+      padding: 1rem 1.5rem;
+    }
+    #active_admin_content.with_sidebar #main_content_wrapper #main_content {
+      padding: 1rem 1.5rem;
+    }
+
+    .fr-table__container {
+      border: 1px solid $grey-625; // Ajoute une bordure au tableau sur le container afin de le rendre visible au scroll horizontal
+    }
+    .fr-table.dsfr-table-active-admin table {
+      border: 0; // évite une 2e bordure qui casse visuellement sur le header du tableau
+    }
+    
+    .dsfr-table-active-admin table.index_table tbody tr td:first-child {
+      border-left: none !important; // évite une 2e bordure de gauche du tableau
+    }
+
+    .dsfr-table-active-admin table.index_table tbody tr td:last-child {
+      border-right: none !important; // évite une 2e bordure de droite du tableau
+    }
+  }
+}


### PR DESCRIPTION
- Ajoute également des border sur le suivi du scroll (Overridé par active admin)

<img width="294" height="473" alt="Capture d’écran 2026-04-27 à 15 21 27" src="https://github.com/user-attachments/assets/47184862-991e-4d66-a1a1-d356b6f87541" />
