### PR TITLE
Corrige différents retours

### DIFF
--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -181,12 +181,6 @@ img {
   }
 }
 
-.sr-only { // surcharge de la class definie par bootstrap
-  user-select: none;
-  pointer-events: none;
-  cursor: not-allowed;
-}
-
 .modal-role-utilisateur {
   margin-bottom: inherit;
   display: flex;

--- a/app/assets/stylesheets/admin/composants/_filtres.scss
+++ b/app/assets/stylesheets/admin/composants/_filtres.scss
@@ -13,9 +13,6 @@
           }
         }
       }
-      .select2-selection {
-        padding: .5rem 0.5rem;
-      }
     }
 
     .buttons {

--- a/app/assets/stylesheets/admin/pages/_actualite.scss
+++ b/app/assets/stylesheets/admin/pages/_actualite.scss
@@ -30,7 +30,7 @@
         margin-bottom: 2rem;
       }
 
-      .actualite__illustration {
+      .actualite-complete__illustration {
         img {
           width: 100%;
 
@@ -88,7 +88,7 @@
   }
 }
 
-.actualite__contenu {
+.actualite-complete__contenu {
   @include make-col(3, 5);
   @include make-col-offset(1, 5);
 
@@ -103,10 +103,8 @@
   a {
     color: $eva_main_blue;
   }
-}
 
-@media (max-width: 768px) {
-  .actualite__contenu {
+  @media (max-width: 768px) {
     flex: 1;
     max-width: 100%;
     margin: 0;

--- a/app/components/carte_mise_en_action.html.erb
+++ b/app/components/carte_mise_en_action.html.erb
@@ -1,4 +1,4 @@
-<li id="<%= @ressource.id %>" class="carte__conteneur position-relative pb-0">
+<li id="<%= @ressource.id %>" class="carte__conteneur position-relative fr-pb-0">
   <div class="card carte-liste <%= @carte_deroulee ? "carte--deroulee" : "" %>">
     <div class="row w-100 no-gutters d-flex justify-content-between align-items-center">
       <div class='col d-flex'>

--- a/app/components/evaluation/competence_transversale_component.erb
+++ b/app/components/evaluation/competence_transversale_component.erb
@@ -6,7 +6,7 @@
     <div class="description-competence">
       <div class="jauge">
         <div class="remplissage remplissage-<%= @interpretation %>">
-          <span class="sr-only"><%= t(".niveau.#{@interpretation}") %></span>
+          <span class="fr-sr-only"><%= t(".niveau.#{@interpretation}") %></span>
         </div>
       </div>
       <span class="image-competence">

--- a/app/components/pastille_component.html.erb
+++ b/app/components/pastille_component.html.erb
@@ -5,7 +5,7 @@
           data-placement='right'
           onmousedown='event.preventDefault();'
           title="<%= @tooltip_content %>">
-          <span class="sr-only"><%= @tooltip_content%></span>
+          <span class="fr-sr-only"><%= @tooltip_content%></span>
   </button>
 <% else %>
   <span class="ellipse ellipse--<%= @couleur %>"> </span>

--- a/app/components/qcm.html.erb
+++ b/app/components/qcm.html.erb
@@ -14,10 +14,10 @@
       </ul>
     </fieldset>
     <div class="fr-mt-3v d-flex justify-content-end">
-      <button type="button" class="fr-btn fr-btn--secondary fr-btn--sm bouton-fermer mr-1">
+      <button type="button" class="fr-btn fr-btn--secondary fr-btn--sm bouton-fermer fr-mr-2v">
         <%= t(".action_fermer") %>
       </button>
-      <button type="button" class="fr-btn fr-btn--sm valide-qcm mr-0 bouton--desactive">
+      <button type="button" class="fr-btn fr-btn--sm valide-qcm fr-mr-0 bouton--desactive">
         <%= t(".action_valider") %>
       </button>
     </div>

--- a/app/components/recherche_structure_component.html.erb
+++ b/app/components/recherche_structure_component.html.erb
@@ -13,8 +13,8 @@
 
   <% if @ville_ou_code_postal.present? %>
     <% if @structures_code_postal.present? %>
-      <ul class="pl-0" title="<%= t(".titre_resultats", count: @structures_code_postal.size, code_postal: @code_postal) %>">
-      <h3 class="description-liste-structures mt-4"><%= t(".titre_resultats", count: @structures_code_postal.size, code_postal: @code_postal) %></h3>
+      <ul class="fr-pl-0" title="<%= t(".titre_resultats", count: @structures_code_postal.size, code_postal: @code_postal) %>">
+      <h3 class="description-liste-structures fr-mt-8v"><%= t(".titre_resultats", count: @structures_code_postal.size, code_postal: @code_postal) %></h3>
       <% @structures_code_postal.each do |structure| %>
         <%= render(RejoindreStructureComponent.new(structure, @current_compte)) %>
       <% end %>
@@ -24,8 +24,8 @@
     <% end %>
 
     <% if @structures.present? %>
-      <ul class="pl-0" title="<%= t(".titre_resultats_proches", count: @structures.size) %>">
-      <h3 class="description-liste-structures mt-4"><%= t(".titre_resultats_proches", count: @structures.size) %></h3>
+      <ul class="fr-pl-0" title="<%= t(".titre_resultats_proches", count: @structures.size) %>">
+      <h3 class="description-liste-structures fr-mt-8v"><%= t(".titre_resultats_proches", count: @structures.size) %></h3>
       <% @structures.each do |structure| %>
         <%= render(RejoindreStructureComponent.new(structure, @current_compte)) %>
       <% end %>
@@ -35,7 +35,7 @@
     <% end %>
 
     <% if @structures.empty? && @structures_code_postal.empty? %>
-      <p class="mt-4"><%= t(".aucun_resultat") %></p>
+      <p class="fr-mt-8v"><%= t(".aucun_resultat") %></p>
       <%= render BoutonAjouterUneStructureComponent.new(@current_compte) %>
     <% end %>
 

--- a/app/views/admin/actualites/_show.html.arb
+++ b/app/views/admin/actualites/_show.html.arb
@@ -1,11 +1,11 @@
 div class: "actualite-complete" do
   h1 actualite.titre
 
-  div class: "actualite__illustration" do
+  div class: "actualite-complete__illustration" do
     image_tag cdn_for(actualite.illustration), alt: "" if actualite.illustration.attached?
   end
 
-  div class: "actualite__contenu" do
+  div class: "actualite-complete__contenu" do
     md actualite.contenu
   end
 end

--- a/app/views/admin/campagnes/_votre_code_campagne.html.erb
+++ b/app/views/admin/campagnes/_votre_code_campagne.html.erb
@@ -1,7 +1,7 @@
 <%# frozen_string_literal: true %>
 
 <div id="votre_code_campagne" class="row">
-  <div class="col mx-auto">
+  <div class="col fr-mx-auto">
     <h2>Votre code campagne</h2>
     <%= render CartePartageCodeComponent.new(
       libelle_code: Campagne.human_attribute_name("code"),

--- a/app/views/admin/dashboard/eva/_bloc_evaluations.html.erb
+++ b/app/views/admin/dashboard/eva/_bloc_evaluations.html.erb
@@ -14,7 +14,7 @@
 
   <ul class="fr-m-0 fr-p-0">
   <% evaluations.each do |evaluation| %>
-    <li class="row w-100 no-gutters d-flex align-items-center position-relative pb-0">
+    <li class="row w-100 no-gutters d-flex align-items-center position-relative fr-pb-0">
       <div class='col'>
         <%= render(CarteComponent.new(admin_evaluation_path(evaluation))) do %>
           <div class='col d-flex'>

--- a/app/views/admin/dashboard/mise_en_action/_avec_evaluations.html.erb
+++ b/app/views/admin/dashboard/mise_en_action/_avec_evaluations.html.erb
@@ -5,9 +5,9 @@
       <%= t(".action") %>
     <% end %>
   </div>
-  <div class='px-3'>
+  <div class='fr-px-3v'>
     <div class='d-flex align-items-center question'>
-      <%= image_tag "point_interrogation.svg", class: "mr-3", alt: "" %>
+      <%= image_tag "point_interrogation.svg", class: "fr-mr-3v", alt: "" %>
       <div>
         <%= md(t(".introduction")) %>
         <span id="question-diagnostics"><%= md(t(".question")) %></span>

--- a/app/views/admin/evaluations/_beneficiaire.erb
+++ b/app/views/admin/evaluations/_beneficiaire.erb
@@ -8,7 +8,7 @@
     <% end %>
     <%= render(NomAnonymisableComponent.new(evaluation.beneficiaire)) %>
   </div>
-  <div class= "evaluation__code-beneficiaire <%= presence_pastille? ? "" : "ml-0" %>">
+  <div class= "evaluation__code-beneficiaire <%= presence_pastille? ? "" : "fr-ml-0" %>">
     <%= evaluation.beneficiaire.code_beneficiaire %>
   </div>
 </div>

--- a/app/views/admin/evaluations/_details_evaluation.html.arb
+++ b/app/views/admin/evaluations/_details_evaluation.html.arb
@@ -1,5 +1,5 @@
 div id: "evaluation__details", class: "row" do
-  div class: "col col-6 mx-auto evaluation__details--panel" do
+  div class: "col col-6 fr-mx-auto evaluation__details--panel" do
     h1 render NomAnonymisableComponent.new(resource.beneficiaire)
     h2 t(".titre"), class: "titre"
     div class: "card carte__conteneur", id: resource.id.to_s do

--- a/app/views/components/_banniere_solutions_illettrisme.html.erb
+++ b/app/views/components/_banniere_solutions_illettrisme.html.erb
@@ -1,5 +1,5 @@
 <div class="banniere-solutions-illettrisme d-flex">
-  <%= image_tag "information.svg", class: "mr-3", alt: "" unless asterisque %>
+  <%= image_tag "information.svg", class: "fr-mr-3v", alt: "" unless asterisque %>
   <div class="banniere__description font-italic">
     <% if asterisque %>
       <span id="asterisque">*</span>

--- a/app/views/components/_input_choix_parcours.html.erb
+++ b/app/views/components/_input_choix_parcours.html.erb
@@ -1,6 +1,6 @@
 <div class="choix-item" tabindex="0">
   <p class='choix-item__titre'>
-    <span class="sr-only"><%= t("admin.campagnes.form.choix_parcours") %> : <%= parcours_type.libelle %></span>
+    <span class="fr-sr-only"><%= t("admin.campagnes.form.choix_parcours") %> : <%= parcours_type.libelle %></span>
     <span aria-hidden="true"><%= parcours_type.libelle %></span>
   </p>
 

--- a/app/views/components/_input_option_personnalisation.html.erb
+++ b/app/views/components/_input_option_personnalisation.html.erb
@@ -1,7 +1,7 @@
 <div class="choix-item" tabindex="0">
   <div class='choix-item__container'>
     <p class='choix-item__titre'>
-      <span class="sr-only"><%= t("admin.campagnes.form.module_optionnel") %> : <%= t(".#{option}.nom") %></span>
+      <span class="fr-sr-only"><%= t("admin.campagnes.form.module_optionnel") %> : <%= t(".#{option}.nom") %></span>
       <span aria-hidden="true"><%= t(".#{option}.nom") %> ·</span>
       <span class="choix-item__duree">
         Durée moyenne : <%= t(".#{option}.duree_moyenne") %>

--- a/app/views/components/_input_type_programme.html.erb
+++ b/app/views/components/_input_type_programme.html.erb
@@ -7,7 +7,7 @@
     <% end %>
   </div>
   <p class="choix-item__titre">
-    <span class="sr-only"><%= t("admin.campagnes.form.choix_type_programme") %> : <%= t(".#{programme}.libelle") %></span>
+    <span class="fr-sr-only"><%= t("admin.campagnes.form.choix_type_programme") %> : <%= t(".#{programme}.libelle") %></span>
     <span aria-hidden="true"><%= t(".#{programme}.libelle") %></span>
   </p>
   <div class="choix-item__description">

--- a/app/views/components/_recherche_compte.html.erb
+++ b/app/views/components/_recherche_compte.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%= form_with id: locals[:form_id], url: locals[:form_url], class: "hidden" do |f| %>
-    <label class="sr-only" for="<%= locals[:autocomplete_id] %>"><%= t(".#{locals[:translation_scope]}.libelle_champ_recherche") %></label>
+    <label class="fr-sr-only" for="<%= locals[:autocomplete_id] %>"><%= t(".#{locals[:translation_scope]}.libelle_champ_recherche") %></label>
   <div id="<%= locals[:container_id] %>" class="champ-recherche" ></div>
   <%= f.hidden_field locals[:hidden_field_name] %>
 <% end %>

--- a/app/views/components/prise_en_main/_carte_base.html.arb
+++ b/app/views/components/prise_en_main/_carte_base.html.arb
@@ -55,7 +55,7 @@ div class: "carte-prise-en-main" do
           render(EllipseComponent.new(statut))
           para class: "m-0 progression__etape text-#{statut}" do
             text_node t("etapes.progression.#{etape}", scope: scope)
-            span t(statut, scope: scope), class: "sr-only"
+            span t(statut, scope: scope), class: "fr-sr-only"
           end
         end
       end

--- a/config/initializers/active_admin_filter_namespaces.rb
+++ b/config/initializers/active_admin_filter_namespaces.rb
@@ -1,0 +1,13 @@
+# Empêche les inputs top-level (ex. ::SelectInput dans app/inputs/) d'écraser
+# ActiveAdmin::Inputs::Filters::SelectInput dans les sidebars de filtres.
+# Sans ce reordering, Formtastic résout `as: :select` à ::SelectInput via
+# Object.const_get et le module ActiveAdmin::Inputs::Filters::Base
+# (qui produit <div class="filter_form_field ...">) n'est pas appliqué.
+Rails.application.config.to_prepare do
+  ActiveAdmin::Filters::FormBuilder.input_namespaces = [
+    ::ActiveAdmin::Inputs::Filters,
+    ::ActiveAdmin::Inputs,
+    ::Object,
+    ::Formtastic::Inputs
+  ]
+end


### PR DESCRIPTION
- Après avoir retiré les utilities de bootstrap, certaines classes ne sont plus : px-, mx-auto, se-only
- Corrige les actualités
- Corrige les filtres