### PR TITLE
EVA-1000 : Bug dans l'étape cafe de la place d'une campagne

### DIFF
--- a/app/models/transcription.rb
+++ b/app/models/transcription.rb
@@ -1,18 +1,10 @@
 class Transcription < ApplicationRecord
   has_one_attached :audio
 
-  validate :audio_type
-
   AUDIOS_CONTENT_TYPES = [ "audio/mpeg", "audio/mp4" ].freeze
 
   enum :categorie, { intitule: 0, modalite_reponse: 1, consigne: 2 }
-
-  def audio_type
-    return unless audio.attached? && !audio.content_type.in?(AUDIOS_CONTENT_TYPES)
-
-    errors.add(:audio, "doit être un fichier MP3 ou MP4")
-    audio.purge
-  end
+  validates :audio, blob: { content_type: AUDIOS_CONTENT_TYPES }
 
   def audio_url
     cdn_for(audio)

--- a/app/models/transcription.rb
+++ b/app/models/transcription.rb
@@ -2,10 +2,11 @@ class Transcription < ApplicationRecord
   has_one_attached :audio
 
   AUDIOS_CONTENT_TYPES = [ "audio/mpeg", "audio/mp4" ].freeze
+  AUDIO_EXTENSIONS = %w[.mp3 .mp4].freeze
 
   enum :categorie, { intitule: 0, modalite_reponse: 1, consigne: 2 }
   validates :audio, blob: { content_type: AUDIOS_CONTENT_TYPES }
-
+  validate :audio_extension
   def audio_url
     cdn_for(audio)
   end
@@ -23,5 +24,13 @@ class Transcription < ApplicationRecord
 
   def complete?
     ecrit.present? && audio&.attached?
+  end
+
+  def audio_extension
+    return unless audio.attached?
+    extension = audio.blob.filename.extension_with_delimiter&.downcase
+
+    return if extension.in?(AUDIO_EXTENSIONS)
+    errors.add(:audio, :invalid_extension)
   end
 end

--- a/config/locales/models/transcription.yml
+++ b/config/locales/models/transcription.yml
@@ -1,0 +1,8 @@
+fr:
+  activerecord:
+    errors:
+      models:
+        transcription:
+          attributes:
+            audio:
+              content_type: "doit être un fichier MP3 ou MP4"

--- a/config/locales/models/transcription.yml
+++ b/config/locales/models/transcription.yml
@@ -6,3 +6,4 @@ fr:
           attributes:
             audio:
               content_type: "doit être un fichier MP3 ou MP4"
+              invalid_extension: "doit avoir une extension valide (.mp3, .mp4)"

--- a/spec/models/transcription_spec.rb
+++ b/spec/models/transcription_spec.rb
@@ -31,6 +31,73 @@ RSpec.describe Transcription, type: :model do
     end
   end
 
+  describe "#audio_extension" do
+    let(:transcription) { described_class.new }
+
+    context "quand aucun audio n'est attaché" do
+      it "n'ajoute pas d'erreur" do
+        transcription.valid?
+
+        expect(transcription.errors[:audio]).to be_empty
+      end
+    end
+
+    context "quand l'extension est .mp3" do
+      it "est valide" do
+        transcription.audio.attach(
+          io: Rails.root.join("spec/support/alcoolique.mp3").open,
+          filename: "audio.mp3",
+          content_type: "audio/mpeg"
+        )
+
+        expect(transcription).to be_valid
+        expect(transcription.errors[:audio]).to be_empty
+      end
+    end
+
+    context "quand l'extension est en majuscule (.MP3)" do
+      it "est valide (downcase appliqué)" do
+        transcription.audio.attach(
+          io: Rails.root.join("spec/support/alcoolique.mp3").open,
+          filename: "audio.MP3",
+          content_type: "audio/mpeg"
+        )
+
+        expect(transcription).to be_valid
+        expect(transcription.errors[:audio]).to be_empty
+      end
+    end
+
+    context "quand le fichier n'a pas d'extension" do
+      it "est invalide sur invalid_extension" do
+        transcription.audio.attach(
+          io: Rails.root.join("spec/support/alcoolique.mp3").open,
+          filename: "audio_sans_extension",
+          content_type: "audio/mpeg"
+        )
+
+        expect(transcription).not_to be_valid
+        expect(transcription.errors.details[:audio]).to include(error: :invalid_extension)
+        expect(transcription.errors[:audio]).to include(
+              "doit avoir une extension valide (.mp3, .mp4)"
+              )
+      end
+    end
+
+    context "quand l'extension n'est pas autorisée (.wav)" do
+      it "est invalide sur invalid_extension" do
+        transcription.audio.attach(
+          io: Rails.root.join("spec/support/alcoolique.mp3").open,
+          filename: "audio.wav",
+          content_type: "audio/mpeg"
+        )
+
+        expect(transcription).not_to be_valid
+        expect(transcription.errors.details[:audio]).to include(error: :invalid_extension)
+      end
+    end
+  end
+
   describe '.complete?' do
     let(:transcription) { described_class.new }
 

--- a/spec/models/transcription_spec.rb
+++ b/spec/models/transcription_spec.rb
@@ -14,18 +14,20 @@ RSpec.describe Transcription, type: :model do
     it 'ne valide pas un audio de type wav' do
       transcription.audio.attach(io: Rails.root.join('spec/support/bravo.wav').open,
                                  filename: 'bravo.wav')
+
       expect(transcription.valid?).to be(false)
       expect(transcription.errors[:audio]).to include('doit être un fichier MP3 ou MP4')
-      transcription.save
-      expect(transcription.audio).not_to be_attached
     end
 
     it 'valide un audio de type mp3' do
       transcription.audio.attach(io: Rails.root.join('spec/support/alcoolique.mp3').open,
                                  filename: 'alcoolique.mp3')
+
       expect(transcription.valid?).to be(true)
       transcription.save
       expect(transcription.audio).to be_attached
+      expect(transcription.audio.blob.filename.to_s).to eq("alcoolique.mp3")
+      expect(transcription.audio.blob.content_type).to eq("audio/mpeg")
     end
   end
 


### PR DESCRIPTION
- ♻️ Utilise le validateur blob d’ActiveStorage pour valider le type audio des transcriptions (pour être cohérent sur le reste de l'app)
- 🐛 Ajoute une validation sur l'extention du fichier audio dans le model transcription.
Ce changement évite d’accepter des fichiers sans extension, qui peuvent ensuite casser le chargement côté front (sélection du chargeur basée sur l’extension de l’URL).

**Erreur Rollbar : https://app.rollbar.com/a/eva-betagouv/fix/item/eva/1296#detail**