### PR TITLE
🐛 Corrige les classes bootstrap des utilities qui n'ont pas été converties

### DIFF
--- a/app/assets/stylesheets/admin/_bg.scss
+++ b/app/assets/stylesheets/admin/_bg.scss
@@ -21,3 +21,7 @@
     color: $info-425;
   }
 }
+
+.bg-orange {
+  background-color: $eva_orange;
+}

--- a/app/assets/stylesheets/admin/_utilities.scss
+++ b/app/assets/stylesheets/admin/_utilities.scss
@@ -1,3 +1,35 @@
+.position-relative {
+  position: relative;
+}
+
+.position-absolute {
+  position: absolute;
+}
+
+.border {
+  border: 1px solid $grey-425;
+}
+
+.border-orange {
+  border: 1px solid $eva_orange;
+}
+
+.border-right-0 {
+  border-right: 0 !important;
+}
+
+.border-top-0 {
+  border-top: 0 !important;
+}
+
+.border-bottom-0 {
+  border-bottom: 0 !important;
+}
+
+.border-left-0 {
+  border-left: 0 !important;
+}
+
 .bord-rouge {
   border: 2px solid $warning-425;
 }

--- a/app/views/admin/dashboard/mise_en_action/_bloc_evaluations_sans_mise_en_action.arb
+++ b/app/views/admin/dashboard/mise_en_action/_bloc_evaluations_sans_mise_en_action.arb
@@ -1,4 +1,4 @@
-div class: "evaluations-sans-mise-en-action panel p-0 border border-orange" do
+div class: "evaluations-sans-mise-en-action panel fr-p-0 border-orange" do
   if evaluations.present?
     render "admin/dashboard/mise_en_action/avec_evaluations", evaluations: evaluations
   else

--- a/app/views/admin/evaluations/_details_evaluation.html.arb
+++ b/app/views/admin/evaluations/_details_evaluation.html.arb
@@ -3,7 +3,7 @@ div id: "evaluation__details", class: "row" do
     h1 render NomAnonymisableComponent.new(resource.beneficiaire)
     h2 t(".titre"), class: "titre"
     div class: "card carte__conteneur", id: resource.id.to_s do
-      div class: "row m-0" do
+      div class: "row fr-m-0" do
         div class: "col col-6 card-informations" do
           div class: "row" do
             div class: "col-1" do
@@ -44,7 +44,7 @@ div id: "evaluation__details", class: "row" do
         end
       end
       unless resource.complete?
-        div class: "row m-0" do
+        div class: "row fr-m-0" do
           div class: "container card__banner bg-alerte d-flex" do
             div(class: "col-2 d-flex align-items-center justify-content-center") do
               image_tag "attention_icone.svg", class: "banner__icone", alt: "Attention"
@@ -62,7 +62,7 @@ div id: "evaluation__details", class: "row" do
         end
       end
       if resource.illettrisme_potentiel?
-        div class: "row m-0" do
+        div class: "row fr-m-0" do
           scope = "admin.evaluations.details_evaluation"
           render partial: "suivi_accompagnement_illettrisme", locals: { scope: scope }
         end

--- a/app/views/admin/evaluations/_informations_complementaires.arb
+++ b/app/views/admin/evaluations/_informations_complementaires.arb
@@ -1,4 +1,4 @@
-div class: "row m-0" do
+div class: "row fr-m-0" do
   div class: "col col-6 card-informations" do
     if statistiques.temps_total
       div class: "row" do

--- a/app/views/admin/structures/_mes_campagnes.html.arb
+++ b/app/views/admin/structures/_mes_campagnes.html.arb
@@ -1,7 +1,7 @@
 div class: "bloc-mes-campagnes fr-mt-8v" do
   h3 "Campagnes", class: "fr-mb-0"
   if campagnes.present?
-    table_for campagnes, class: "bloc-mes-campagnes__table index_table p-0" do
+    table_for campagnes, class: "bloc-mes-campagnes__table index_table fr-p-0" do
       column :libelle do |campagne|
         link_to campagne.libelle, admin_campagne_path(campagne)
       end

--- a/app/views/components/prise_en_main/_carte_base.html.arb
+++ b/app/views/components/prise_en_main/_carte_base.html.arb
@@ -7,7 +7,7 @@ options = { class: "fr-btn fr-btn--md" }.merge(options_lien)
 carte_entete_classes = "d-flex align-items-center justify-content-between bg-orange"
 
 div class: "carte-prise-en-main" do
-  div class: "carte__etape border border-right-0 border-orange" do
+  div class: "carte__etape border-orange border-right-0" do
     div class: "carte__entete #{carte_entete_classes}" do
       div class: "carte__titres" do
         h2 t("etapes.#{etape_en_cours}.titre", scope: scope)
@@ -53,7 +53,7 @@ div class: "carte-prise-en-main" do
 
         li do
           render(EllipseComponent.new(statut))
-          para class: "m-0 progression__etape text-#{statut}" do
+          para class: "fr-m-0 progression__etape text-#{statut}" do
             text_node t("etapes.progression.#{etape}", scope: scope)
             span t(statut, scope: scope), class: "fr-sr-only"
           end


### PR DESCRIPTION
…rties pour utiliser le DSFR :

- p-0
- m-0
- border
- border-orange
- position-absolute
- position-relative

Screenshot du localhost : 
<img width="1377" height="1191" alt="Capture d’écran 2026-04-29 à 11 04 57" src="https://github.com/user-attachments/assets/7fa5c6d8-1e79-47d7-90bc-f2b61e54a70b" />

Screenshot de la prod : 
<img width="1440" height="1157" alt="Capture d’écran 2026-04-29 à 11 04 58" src="https://github.com/user-attachments/assets/edc5bcf9-1dd0-4e8b-9a3f-bcab40814e4d" />

