### PR TITLE
💄 Corrige le focus des boutons DSFR sur firefox.

### DIFF
--- a/app/assets/stylesheets/admin/_adaptation_dsfr.scss
+++ b/app/assets/stylesheets/admin/_adaptation_dsfr.scss
@@ -231,6 +231,11 @@ button.fr-link--close {
   box-shadow: none;
   font-weight: 400;
   border: none;
+
+  &:-moz-focusring,
+  &:focus-visible {
+    @include focus;
+  }
 }
 button.fr-link--close:not(.disabled):hover {
   @include light-decisions-background-transparent-hover;
@@ -273,6 +278,13 @@ body.evapro_admin .fr-btn:not(.fr-btn--secondary, .fr-btn--tertiary, .fr-btn--me
   align-self: flex-start; 
   min-height: 2.5rem;
   line-height: normal !important;
+}
+
+.fr-btn {
+  &:-moz-focusring,
+  &:focus-visible {
+    @include focus;
+  }
 }
 
 button,

--- a/app/assets/stylesheets/admin/composants/_navigation.scss
+++ b/app/assets/stylesheets/admin/composants/_navigation.scss
@@ -27,6 +27,11 @@
   .fr-nav__btn {
     background: transparent;
     border: 0;
+
+    &:-moz-focusring,
+    &:focus-visible {
+      @include focus;
+    }
   }
 
   .fr-nav__btn:hover,


### PR DESCRIPTION
ActiveAdmin inclut un normalize.css qui force le pseudo-élément :`-moz-focusring` sur tous les boutons Firefox, produisant un outline dotted. Ce comportement écrase le style DSFR `(:focus-visible)`. Problème pour `.fr-accordion__btn`