### PR TITLE
✨ Ajoute un filtre par SIRET pour les structures

### DIFF
--- a/app/admin/structures_locales.rb
+++ b/app/admin/structures_locales.rb
@@ -12,6 +12,7 @@ ActiveAdmin.register StructureLocale do
          as: :select,
          collection: ApplicationController.helpers.collection_types_structures
   filter :code_postal
+  filter :siret
   filter :region,
          as: :select,
          collection: proc { Structure.distinct.order(:region).pluck(:region) }

--- a/app/models/structure.rb
+++ b/app/models/structure.rb
@@ -115,6 +115,10 @@ allow_blank: true
     %w[nom]
   end
 
+  ransacker :siret, formatter: proc { |v| v.to_s.gsub(/\s+/, "") } do |parent|
+    parent.table[:siret]
+  end
+
   def effectif
     Compte.where(structure: self).count
   end

--- a/app/views/inscription/structures/_form_rejoindre.html.erb
+++ b/app/views/inscription/structures/_form_rejoindre.html.erb
@@ -22,7 +22,7 @@
             <% end %>
           </div>
         <% end %>
-        
+
         <%= form.input :structure_confirmee, as: :boolean, label: t("inscription.structures.show.confirme_structure"), required: false %>
         <% unless @compte.cree_via_invitation_acceptee? %>
           <p class="structure-confirmation-mention fr-mt-2w"><%= t("inscription.structures.show.mention_acces") %></p>

--- a/app/views/inscription/structures/_structure_info_card.html.erb
+++ b/app/views/inscription/structures/_structure_info_card.html.erb
@@ -1,16 +1,16 @@
 <div class="structure-info-card">
   <ul class="structure-info-card__list">
     <li class="structure-info-card__info">
-      <span class="structure-info-card__label">Numéro SIRET :</span> <span class="structure-info-card__value"><%= structure.siret %></span>
+      <span class="structure-info-card__label">Numéro SIRET :</span> <span class="structure-info-card__value"><%= structure.siret %></span>
     </li>
     <li class="structure-info-card__info">
-      <span class="structure-info-card__label">Raison sociale :</span> <span class="structure-info-card__value"><%= structure&.raison_sociale %></span>
+      <span class="structure-info-card__label">Raison sociale :</span> <span class="structure-info-card__value"><%= structure&.raison_sociale %></span>
     </li>
     <li class="structure-info-card__info">
-      <span class="structure-info-card__label">Dénomination :</span> <span class="structure-info-card__value"><%= structure&.nom %></span>
+      <span class="structure-info-card__label">Dénomination :</span> <span class="structure-info-card__value"><%= structure&.nom %></span>
     </li>
     <li class="structure-info-card__info">
-      <span class="structure-info-card__label">Adresse :</span> <span class="structure-info-card__value"><%= adresse_ou_code_postal(structure) %></span>
+      <span class="structure-info-card__label">Adresse :</span> <span class="structure-info-card__value"><%= adresse_ou_code_postal(structure) %></span>
     </li>
   </ul>
 </div>

--- a/config/locales/models/structure.yml
+++ b/config/locales/models/structure.yml
@@ -31,7 +31,7 @@ fr:
         updated_at: Mise à jour le
         nom: Nom de structure
         code_postal: Code Postal
-        siret: SIRET de l'organisation que vous représentez
+        siret: SIRET
         statut_siret: Statut SIRET
         statut_siret_true: vérifié
         statut_siret_false: non vérifié

--- a/spec/features/admin/structure_locale_spec.rb
+++ b/spec/features/admin/structure_locale_spec.rb
@@ -10,6 +10,21 @@ describe 'Admin - Structure locale', type: :feature do
       before { visit admin_structures_locales_path }
 
       it { expect(page).to have_content 'Ma structure' }
+
+      describe 'filtre par siret' do
+        let!(:structure_avec_siret) {
+          create :structure_locale, nom: 'Structure SIRET', siret: '85170326400024'
+        }
+        let!(:autre_structure) { create :structure_locale, nom: 'Autre structure' }
+
+        it 'trouve une structure en saisissant le siret avec des espaces' do
+          fill_in 'q[siret_cont]', with: '851 703 264 00024'
+          click_on 'Filtrer'
+
+          expect(page).to have_content 'Structure SIRET'
+          expect(page).not_to have_content 'Autre structure'
+        end
+      end
     end
 
     describe 'show' do
@@ -18,7 +33,7 @@ describe 'Admin - Structure locale', type: :feature do
       end
       let!(:compte) do
         create :compte, structure: structure, statut_validation: statut_validation,
-role: :conseiller
+               role: :conseiller
       end
       let(:statut_validation) { :en_attente }
 
@@ -40,7 +55,7 @@ role: :conseiller
 
           fill_in "invitation_email", with: "invite@eva.fr", visible: :all
           fill_in "invitation_message_#{structure.id}", with: "Bienvenue dans l'équipe.",
-visible: :all
+                  visible: :all
 
           find("button", text: "Envoyer l'invitation", visible: :all).click
 


### PR DESCRIPTION
<img width="316" height="524" alt="Capture d’écran 2026-05-07 à 18 45 40" src="https://github.com/user-attachments/assets/3764cc0f-95a3-4b15-b3b4-bd42f653fa6b" />

J'ai renommé la traduction de l'attribut :siret. L'ancienne traduction était un reliquat de l'ancien embarquement