### PR TITLE
🐛 Corrige margin/padding suite à la suppression des utilities de bootstrap

### DIFF
--- a/app/components/evaluation/annexe_diagnostic_component.pdf.erb
+++ b/app/components/evaluation/annexe_diagnostic_component.pdf.erb
@@ -2,7 +2,7 @@
   <%= render Pdf::EntetePageComponent.new(**@entete_page_args) %>
 
   <div class="content">
-    <h2 class="text-center fr-my-4v evaluation__titre"><%= t(".titre") %></h2>
+    <h2 class="text-center fr-my-6v evaluation__titre"><%= t(".titre") %></h2>
     <div class="annexe_restitution__introduction annexe_restitution__introduction--diagnostic">
       <%= md t(".introduction") %>
       <div class="row">

--- a/app/components/evaluation/annexe_positionnement_component.pdf.erb
+++ b/app/components/evaluation/annexe_positionnement_component.pdf.erb
@@ -2,7 +2,7 @@
   <%= render Pdf::EntetePageComponent.new(**@entete_page_args) %>
 
   <div class="content">
-    <h2 class="text-center fr-my-4v evaluation__titre"><%= t(".titre") %></h2>
+    <h2 class="text-center fr-my-6v evaluation__titre"><%= t(".titre") %></h2>
     <div class="annexe_restitution__introduction">
       <%= md t(".introduction") %>
       <div class="annexe_restitution__blocs">

--- a/app/components/evaluation/bienvenue_component.pdf.erb
+++ b/app/components/evaluation/bienvenue_component.pdf.erb
@@ -2,7 +2,7 @@
   <div class="page adaptation-pdf profil">
     <%= render "admin/evaluations/eva/entete_page", restitution_globale: @restitution_globale %>
 
-    <h2 class="text-center fr-mt-5v fr-mb-4v evaluation__titre"><%= t("admin.evaluations.restitution_globale.autopositionnement.titre") %></h2>
+    <h2 class="text-center fr-mt-12v fr-mb-6v evaluation__titre"><%= t("admin.evaluations.restitution_globale.autopositionnement.titre") %></h2>
 
     <div class="panel">
       <div class="marges-page">

--- a/app/components/evaluation/competences_transversales_component.pdf.erb
+++ b/app/components/evaluation/competences_transversales_component.pdf.erb
@@ -1,7 +1,7 @@
 <div id="competences_transversales" class="page adaptation-pdf competences_transversales">
   <%= render "admin/evaluations/eva/entete_page", restitution_globale: @restitution_globale %>
 
-  <h2 class="text-center fr-my-4v evaluation__titre"><%= t(".titre") %></h2>
+  <h2 class="text-center fr-my-6v evaluation__titre"><%= t(".titre") %></h2>
   <% unless @completude_competences_transversales %>
     <%= render Evaluation::AlertIncompleteComponent.new %>
   <% end %>

--- a/app/components/evaluation/synthese_diagnostic_component.html.erb
+++ b/app/components/evaluation/synthese_diagnostic_component.html.erb
@@ -16,7 +16,7 @@
             niveau_numeratie: @niveau_cnef,
             referentiel: "cefr" %>
 
-      <div class="row fr-my-4v">
+      <div class="row fr-my-6v">
         <div class="col-auto badge"></div>
         <div class="col">
           <%= render "admin/evaluations/eva/metacompetences", categorie: :litteratie %>

--- a/app/components/evaluation/synthese_diagnostic_component.pdf.erb
+++ b/app/components/evaluation/synthese_diagnostic_component.pdf.erb
@@ -1,7 +1,7 @@
 <div class="page adaptation-pdf francais_mathematiques">
   <%= render "admin/evaluations/eva/entete_page", restitution_globale: @restitution_globale %>
 
-  <h2 class="text-center fr-mt-5v fr-mb-4v evaluation__titre"><%= t("titre", scope: "admin.restitutions.cefr") %></h2>
+  <h2 class="text-center fr-mt-12v fr-mb-6v evaluation__titre"><%= t("titre", scope: "admin.restitutions.cefr") %></h2>
   <% unless @completude_competences_de_base %>
     <%= render Evaluation::AlertIncompleteComponent.new %>
   <% end %>

--- a/app/components/qcm.html.erb
+++ b/app/components/qcm.html.erb
@@ -2,7 +2,7 @@
   <form>
     <fieldset class="fr-mb-0">
       <legend><%= @questionnaire.question %></legend>
-      <ul class="fr-mt-3v fr-p-0">
+      <ul class="fr-mt-4v fr-p-0">
         <% @questionnaire.reponses.each_value do |option| %>
           <li>
             <label>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,7 @@ module ApplicationHelper
   end
 
   def rapport_colonne_class
-    "col-4 fr-px-5 fr-mb-4"
+    "col-4 fr-px-12v fr-mb-6v"
   end
 
   def inline_svg_content(attachment, options = {})

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,10 +20,6 @@ module ApplicationHelper
     "#{signe}#{heure_minutes_secondes.map { |t| t.to_s.rjust(2, '0') }.join(':')}"
   end
 
-  def rapport_colonne_class
-    "col-4 fr-px-12v fr-mb-6v"
-  end
-
   def inline_svg_content(attachment, options = {})
     return unless attachment.attached?
 

--- a/app/views/admin/campagnes/_situation.html.arb
+++ b/app/views/admin/campagnes/_situation.html.arb
@@ -5,20 +5,20 @@ li class: "campagne-situation d-flex align-items-center" do
     situation_illustration(situation_configuration.situation, couleur_bord: couleur)
   end
   div class: "situation__texte" do
-    div class: "d-flex fr-mb-2" do
+    div class: "d-flex fr-mb-2v" do
       h3 class: "fr-text--bold fr-text--md fr-mb-0" do
         situation_configuration.situation.libelle
       end
       if questionnaire == Questionnaire::LIVRAISON_AVEC_REDACTION
-        render(Tag.new("+ #{t('.redaction')}", classes: "fr-ml-1 tag-categorie green"))
+        render(Tag.new("+ #{t('.redaction')}", classes: "fr-ml-1v tag-categorie green"))
       end
       if questionnaire == Questionnaire::SOCIODEMOGRAPHIQUE_AUTOPOSITIONNEMENT ||
         questionnaire == Questionnaire::SOCIODEMOGRAPHIQUE_AUTOPOSITIONNEMENT_SANTE
-        render(Tag.new("+ #{t('.autopositionnement')}", classes: "fr-ml-1 tag-categorie green"))
+        render(Tag.new("+ #{t('.autopositionnement')}", classes: "fr-ml-1v tag-categorie green"))
       end
       if questionnaire == Questionnaire::SOCIODEMOGRAPHIQUE_SANTE ||
         questionnaire == Questionnaire::SOCIODEMOGRAPHIQUE_AUTOPOSITIONNEMENT_SANTE
-        render(Tag.new("+ #{t('.sante')}", classes: "fr-ml-1 tag-categorie green"))
+        render(Tag.new("+ #{t('.sante')}", classes: "fr-ml-1v tag-categorie green"))
       end
     end
     para situation_configuration.situation.description

--- a/app/views/admin/dashboard/_dashboard.html.arb
+++ b/app/views/admin/dashboard/_dashboard.html.arb
@@ -9,7 +9,7 @@ if current_compte.validation_refusee?
 elsif prise_en_main.en_cours? &&
     current_compte.validation_acceptee? &&
     !current_compte.administratif?
-  section class: "fr-mb-5" do
+  section class: "fr-mb-12v" do
     div class: "row" do
       div class: "col-6 offset-1" do
         h2 t("admin.dashboard.prise_en_main.titre"), class: "text-center"

--- a/app/views/admin/dashboard/_tableau_de_bord_eva.html.arb
+++ b/app/views/admin/dashboard/_tableau_de_bord_eva.html.arb
@@ -9,7 +9,7 @@ if current_compte.validation_refusee?
 elsif prise_en_main.en_cours? &&
     current_compte.validation_acceptee? &&
     !current_compte.administratif?
-  section class: "fr-mb-5" do
+  section class: "fr-mb-12v" do
     div class: "row" do
       div class: "col-6 offset-1" do
         h2 t("admin.dashboard.prise_en_main.titre"), class: "text-center"

--- a/app/views/admin/dashboard/mise_en_action/_avec_evaluations.html.erb
+++ b/app/views/admin/dashboard/mise_en_action/_avec_evaluations.html.erb
@@ -5,9 +5,9 @@
       <%= t(".action") %>
     <% end %>
   </div>
-  <div class='fr-px-3v'>
+  <div class='fr-px-4v'>
     <div class='d-flex align-items-center question'>
-      <%= image_tag "point_interrogation.svg", class: "fr-mr-3v", alt: "" %>
+      <%= image_tag "point_interrogation.svg", class: "fr-mr-4v", alt: "" %>
       <div>
         <%= md(t(".introduction")) %>
         <span id="question-diagnostics"><%= md(t(".question")) %></span>

--- a/app/views/admin/evaluations/eva/_competence_niveau1.arb
+++ b/app/views/admin/evaluations/eva/_competence_niveau1.arb
@@ -9,7 +9,7 @@ div class: "col-auto badge" do
   end
 end
 div class: "col" do
-  h3 class: "restitution-h3 fr-mb-3 fr-mt-0" do
+  h3 class: "restitution-h3 fr-mb-4v fr-mt-0" do
     div t(:titre, scope: scope)
   end
 

--- a/app/views/admin/evaluations/eva/_correspondance_anlci.arb
+++ b/app/views/admin/evaluations/eva/_correspondance_anlci.arb
@@ -3,7 +3,7 @@ div id: "correspondance_anlci", class: "page adaptation-pdf correspondance_anlci
     render "admin/evaluations/eva/entete_page", restitution_globale: restitution_globale
 
     h2 t("titre", scope: "admin.restitutions.anlci"),
-       class: "text-center fr-mt-5 fr-mb-4 evaluation__titre"
+       class: "text-center fr-mt-12v fr-mb-6v evaluation__titre"
   else
     h2 t("titre", scope: "admin.restitutions.anlci"), class: "evaluation__titre"
   end
@@ -11,7 +11,7 @@ div id: "correspondance_anlci", class: "page adaptation-pdf correspondance_anlci
   div class: "panel panel--avec-references" do
     div class: "row no-gutters recommandation-anlci marges-page" do
       div class: "col-auto" do
-        image_tag "logo/anlci.svg", class: "pr-5", alt: t("logo_anlci")
+        image_tag "logo/anlci.svg", class: "fr-pr-12v", alt: t("logo_anlci")
       end
       div class: "col" do
         md t("recommandation", scope: "admin.restitutions.anlci")

--- a/app/views/admin/evaluations/eva/_details_evaluation.html.arb
+++ b/app/views/admin/evaluations/eva/_details_evaluation.html.arb
@@ -37,7 +37,7 @@ div id: "evaluation__details", class: "row" do
                     parties_selectionnees: params[:parties_selectionnees],
                     format: :pdf
                   },
-                  class: "fr-mt-2 fr-btn fr-btn--md",
+                  class: "fr-mt-2v fr-btn fr-btn--md",
                   style: "margin: auto;",
                   target: "_blank",
                   rel: "noopener")

--- a/app/views/admin/evaluations/eva/_metacompetences.arb
+++ b/app/views/admin/evaluations/eva/_metacompetences.arb
@@ -2,7 +2,7 @@ restitution_globale.interpretations_niveau2(categorie).each do |competence_nivea
   competence = competence_niveau.keys.first
   niveau = competence_niveau[competence]
   scope = "admin.restitutions.interpretations_niveau2.#{competence}"
-  h4 class: "fr-mt-4 fr-mb-3" do
+  h4 class: "fr-mt-6v fr-mb-4v" do
     t(:titre, scope: scope)
   end
   div do

--- a/app/views/admin/evaluations/eva/_questions.arb
+++ b/app/views/admin/evaluations/eva/_questions.arb
@@ -2,8 +2,8 @@ unless restitution.questions_redaction.empty?
   h4 t(:situation, scope: [ :admin, :evaluations, :questions ], situation: situation_libelle),
 class: "situation-redaction fr-mb-3"
   restitution.questions_redaction.each do |question, reponse|
-    div class: "row fr-mb-3" do
-      div class: "col-8 fr-mb-4" do
+    div class: "row fr-mb-4v" do
+      div class: "col-8 fr-mb-6v" do
         h5 t("admin.restitutions.reponse_expression_ecrite", question: question.libelle),
            class: "titre-redaction"
       end
@@ -12,16 +12,16 @@ class: "situation-redaction fr-mb-3"
       span class: "crochet-aide-redaction" do
         image_tag "crochet-aide-redaction.svg", alt: ""
       end
-      div class: "col-4 fr-mb-5" do
-        div simple_format(reponse), class: "fr-my-2 note-redaction" do
+      div class: "col-4 fr-mb-12v" do
+        div simple_format(reponse), class: "fr-my-2v note-redaction" do
           span class: "image-redaction" do
             image_tag "redaction.svg", alt: t("admin.restitutions.redaction")
           end
         end
       end
-      div class: "col-4 fr-mb-5" do
+      div class: "col-4 fr-mb-12v" do
         div class: "aide-redaction-container" do
-          div class: "fr-my-2 aide-redaction" do
+          div class: "fr-my-2v aide-redaction" do
             div md t("admin.restitutions.aide_interpretation_expression_ecrite")
             span class: "image-redaction" do
               image_tag "aide-redaction.svg", alt: ""

--- a/app/views/admin/evaluations/eva/_referentiel_europeen.arb
+++ b/app/views/admin/evaluations/eva/_referentiel_europeen.arb
@@ -10,7 +10,7 @@ div class: "referentiel_anlci bg-information" do
           div(class: "col texte-explications") { md t("explications-cefr", scope: scope) }
         end
       end
-      div class: "row pl-2 pb-3 pt-3 align-items-center" do
+      div class: "row fr-pl-2v fr-pb-4v fr-pt-4v align-items-center" do
         div class: "col-auto" do
           div t("francais", scope: scope)
           div t("ordre", scope: scope), class: "ordre"

--- a/app/views/admin/evaluations/eva/_restitution_globale.arb
+++ b/app/views/admin/evaluations/eva/_restitution_globale.arb
@@ -18,7 +18,7 @@ div class: "evaluation__restitution-globale #{class_css}" do
 
       if pdf
         h2 t(:titre, scope: [ :admin, :evaluations, :restitution_globale, :prise_en_main ]),
-class: "text-center fr-mt-5 fr-mb-4 evaluation__titre"
+class: "text-center fr-mt-12v fr-mb-6v evaluation__titre"
       else
         h2 t(:titre, scope: [ :admin, :evaluations, :restitution_globale, :prise_en_main ]),
 class: "evaluation__titre"
@@ -66,7 +66,7 @@ class: "evaluation__titre"
 
       if pdf
         h2 t("titre", scope: "admin.restitutions.litteratie"),
-           class: "text-center fr-mt-5 fr-mb-4 evaluation__titre"
+           class: "text-center fr-mt-12v fr-mb-6v evaluation__titre"
       else
         h2 t("titre", scope: "admin.restitutions.litteratie"), class: "evaluation__titre"
       end

--- a/app/views/admin/evaluations/eva/_suivi_accompagnement_illettrisme.erb
+++ b/app/views/admin/evaluations/eva/_suivi_accompagnement_illettrisme.erb
@@ -2,7 +2,7 @@
 <% reponse = mise_en_action_presenter.a_mise_en_action? && mise_en_action_presenter.mise_en_action_avec_qualification? ? "card__banner--succes" : "card__banner--en-attente" %>
 
 <div class="card__banner card__banner--illettrisme <%= reponse %>">
-  <div class= 'container d-flex fr-py-3v fr-px-4v'>
+  <div class= 'container d-flex fr-py-4v fr-px-6v'>
     <div class='d-flex align-items-center justify-content-center' aria-hidden="true">
       <%= inline_svg_tag "banner_icone_question.svg", class: "card__banner__icone" %>
     </div>

--- a/app/views/components/_banniere_solutions_illettrisme.html.erb
+++ b/app/views/components/_banniere_solutions_illettrisme.html.erb
@@ -1,5 +1,5 @@
 <div class="banniere-solutions-illettrisme d-flex">
-  <%= image_tag "information.svg", class: "fr-mr-3v", alt: "" unless asterisque %>
+  <%= image_tag "information.svg", class: "fr-mr-4v", alt: "" unless asterisque %>
   <div class="banniere__description font-italic">
     <% if asterisque %>
       <span id="asterisque">*</span>

--- a/app/views/components/prise_en_main/_carte_base.html.arb
+++ b/app/views/components/prise_en_main/_carte_base.html.arb
@@ -27,7 +27,8 @@ div class: "carte-prise-en-main" do
       end
       if lien_action
         alignement = etape_en_cours == "confirmation_email" ? "between" : "end"
-        div_class = "carte__action d-flex justify-content-#{alignement} align-items-center fr-mt-6"
+        div_class = "carte__action d-flex justify-content-#{alignement} \
+        align-items-center fr-mt-12v"
         div class: div_class do
           if etape_en_cours == "confirmation_email"
             span md t("etapes.#{etape_en_cours}.question",

--- a/docs/tech-dive-in/EVA-43-le-conseiller-peut-consulter-le-profil-numeratie-du-positionnement-dans-son-espace-admin/readme.md
+++ b/docs/tech-dive-in/EVA-43-le-conseiller-peut-consulter-le-profil-numeratie-du-positionnement-dans-son-espace-admin/readme.md
@@ -173,7 +173,7 @@ end
       render 'entete_page', restitution_globale: restitution_globale
 
       if pdf
-        h2 t('titre', scope: 'admin.restitutions.numeratie'), class: 'text-center fr-mt-5 fr-mb-4'
+        h2 t('titre', scope: 'admin.restitutions.numeratie'), class: 'text-center fr-mt-12v fr-mb-6v'
       else
         h2 t('titre', scope: 'admin.restitutions.numeratie'),
            class: titre_avec_aide_illettrisme.to_s


### PR DESCRIPTION
Cela fait suite au retour d'Etienne sur Slack : https://eva-beta.slack.com/archives/CGE5S197C/p1778703372571379?thread_ts=1777972279.953139&cid=CGE5S197C

J'ai refait une passe complete sur les classes de margin padding pour vérifier la correspondance avec le DSFR
- px- py- pt- pb- pl- pr-
- mx- my- mt- mb ml- mr-

Je suis parti des commits originaux qui changeait les classes bootstrap en dsfr pour corriger les equivalents invalide. exemple : "fr-my-4v" -> "fr-my-6v" car a l'origine il y avait "my-4"

En suivant ce tableau de correspondance :

| Bootstrap v4 | px   | DSFR         |
|--------------|------|--------------|
| `*-0`        | 0    | `fr-*-0`     |
| `*-1`        | 4px  | `fr-*-1v`    |
| `*-2`        | 8px  | `fr-*-2v`    |
| `*-3`        | 16px | `fr-*-4v`    |
| `*-4`        | 24px | `fr-*-6v`    |
| `*-5`        | 48px | `fr-*-12v`   |
| `mx-auto`    | auto | `fr-mx-auto` |