### PR TITLE
💄 refonte DSFR du parcours reset password

### DIFF
--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -32,6 +32,7 @@
 //= require invitation_modal
 //= require modal_dashboard_dsfr
 //= require nouveau_compte
+//= require reset_password
 
 //= require chartkick
 //= require Chart.bundle

--- a/app/assets/javascripts/reset_password.js
+++ b/app/assets/javascripts/reset_password.js
@@ -1,0 +1,64 @@
+document.addEventListener("DOMContentLoaded", function() {
+  setupResetPasswordEditForm();
+  setupResetPasswordEmailForms();
+});
+
+function setupResetPasswordEmailForms() {
+  ["reset-password-request-submit", "reset-password-invalid-submit"].forEach(function(buttonId) {
+    var submitButton = document.getElementById(buttonId);
+    var emailInput = document.getElementById("compte_email");
+
+    if (!submitButton || !emailInput) {
+      return;
+    }
+
+    function emailRempli() {
+      return emailInput.value.trim().length > 0;
+    }
+
+    function updateSubmitState() {
+      var enable = emailRempli();
+
+      submitButton.disabled = !enable;
+      submitButton.classList.toggle("disabled", !enable);
+    }
+
+    emailInput.addEventListener("input", updateSubmitState);
+    emailInput.addEventListener("change", updateSubmitState);
+
+    if (submitButton.dataset.initialDisabled) {
+      submitButton.disabled = true;
+    }
+
+    updateSubmitState();
+  });
+}
+
+function setupResetPasswordEditForm() {
+  var submitButton = document.getElementById("reset-password-submit");
+  var passwordInput = document.getElementById("compte_password");
+  var passwordConfirmationInput = document.getElementById("compte_password_confirmation");
+
+  if (!submitButton || !passwordInput || !passwordConfirmationInput) {
+    return;
+  }
+
+  function updateSubmitState() {
+    var passwordPresent = passwordInput.value.trim().length > 0;
+    var confirmationPresent = passwordConfirmationInput.value.trim().length > 0;
+    var passwordsMatch = passwordInput.value === passwordConfirmationInput.value;
+    var enableButton = passwordPresent && confirmationPresent && passwordsMatch;
+
+    submitButton.disabled = !enableButton;
+    submitButton.classList.toggle("disabled", !enableButton);
+  }
+
+  passwordInput.addEventListener("input", updateSubmitState);
+  passwordConfirmationInput.addEventListener("input", updateSubmitState);
+
+  if (submitButton.dataset.initialDisabled) {
+    submitButton.disabled = true;
+  }
+
+  updateSubmitState();
+}

--- a/app/assets/stylesheets/admin/pages/inscription/_informations_compte.scss
+++ b/app/assets/stylesheets/admin/pages/inscription/_informations_compte.scss
@@ -54,3 +54,42 @@
   color: #000;
   margin-left: 0.25rem;
 }
+
+.page-reset-password {
+  @include onboarding-form-reset;
+
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: stretch;
+  gap: $dsfr-spacing-7w;
+}
+
+// Alerte alignée sur la même largeur que la carte (colonne onboarding)
+.page-informations-compte .page-reset-password__alert-band {
+  width: 100%;
+  align-self: stretch;
+
+  .fr-alert,
+  .page-reset-password__alert {
+    width: 100%;
+    box-sizing: border-box;
+  }
+}
+
+.page-reset-password__champs-obligatoires {
+  @include corps-de-texte-xs-regular;
+
+  margin: 0 0 $dsfr-spacing-3w;
+}
+
+.page-reset-password__lien-accueil {
+  margin-top: $dsfr-spacing-3w;
+}
+
+.page-reset-password .informations-compte-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  width: 100%;
+}

--- a/app/controllers/eva/devise/passwords_controller.rb
+++ b/app/controllers/eva/devise/passwords_controller.rb
@@ -1,31 +1,27 @@
 module Eva
   module Devise
     class PasswordsController < ActiveAdmin::Devise::PasswordsController
+      layout "inscription_v2"
+
       # rubocop:disable Rails/LexicallyScopedActionFilter
-      before_action :validate_reset_password_token, only: :edit
-      before_action :trouve_regles_mot_de_passe, only: :edit
+      before_action :assign_reset_password_context, only: %i[new edit create]
+      before_action :redirect_si_token_invalide, only: :edit
       # rubocop:enable Rails/LexicallyScopedActionFilter
 
       private
 
-      def trouve_regles_mot_de_passe
-        @regles_mot_de_passe = compte&.anlci? ? "regles_mot_de_passe_anlci" : "regles_mot_de_passe"
+      def assign_reset_password_context
+        @reset_password = ResetPassword::PageContext.new(
+          action_name: action_name,
+          token_invalide: params[:token_invalide],
+          reset_password_token: params[:reset_password_token],
+          resource_class: resource_class
+        )
       end
 
-      def validate_reset_password_token
-        return if compte&.reset_password_period_valid?
-
-        flash[:error] = t("active_admin.devise.passwords.edit.token_invalide")
-        redirect_to new_compte_password_path(token_invalide: true)
-      end
-
-      def compte
-        @compte ||= resource_class
-                    .find_by(reset_password_token: ::Devise.token_generator.digest(
-                      resource_class,
-                      :reset_password_token,
-                      params[:reset_password_token]
-                    ))
+      def redirect_si_token_invalide
+        path = @reset_password.redirect_path_si_token_invalide
+        redirect_to path if path
       end
     end
   end

--- a/app/services/reset_password/page_context.rb
+++ b/app/services/reset_password/page_context.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module ResetPassword
+  class PageContext
+    include Rails.application.routes.url_helpers
+
+    def initialize(action_name:, token_invalide:, reset_password_token:, resource_class: Compte)
+      @action_name = action_name
+      @token_invalide = ActiveModel::Type::Boolean.new.cast(token_invalide)
+      @reset_password_token = reset_password_token
+      @resource_class = resource_class
+    end
+
+    def state
+      return :invalid_link if @token_invalide
+      return :change_password if @action_name == "edit"
+
+      :request_email
+    end
+
+    def request_email?
+      state == :request_email
+    end
+
+    def change_password?
+      state == :change_password
+    end
+
+    def invalid_link?
+      state == :invalid_link
+    end
+
+    def compte
+      @compte ||= find_compte_by_token
+    end
+
+    def token_valide?
+      change_password? && compte.present? && compte.reset_password_period_valid?
+    end
+
+    def redirect_path_si_token_invalide
+      return if token_valide? || !change_password?
+
+      new_compte_password_path(token_invalide: true)
+    end
+
+    def regles_mot_de_passe_cle
+      compte&.anlci? ? :regles_mot_de_passe_anlci : :regles_mot_de_passe
+    end
+
+    def hint_mot_de_passe
+      cle = compte&.anlci? ? :hint_password_anlci : :hint_password
+      I18n.t(cle, scope: "active_admin.devise.passwords.edit")
+    end
+
+    def i18n_scope
+      invalid_link? ? "invalid_link" : "request_email"
+    end
+
+    def page_title
+      case state
+      when :invalid_link
+        I18n.t("active_admin.devise.reset_password.invalid_link.title")
+      when :change_password
+        I18n.t("active_admin.devise.change_password.title")
+      else
+        I18n.t("active_admin.devise.reset_password.request_email.title")
+      end
+    end
+
+    def email_submit_button_id
+      invalid_link? ? "reset-password-invalid-submit" : "reset-password-request-submit"
+    end
+
+    def wrapper_modifier_class
+      case state
+      when :invalid_link then "page-reset-password--invalid-link"
+      when :request_email then "page-reset-password--request-email"
+      else "page-reset-password--change-password"
+      end
+    end
+
+    def t_email(key)
+      I18n.t(key, scope: "active_admin.devise.reset_password.#{i18n_scope}")
+    end
+
+    private
+
+    def find_compte_by_token
+      return if @reset_password_token.blank?
+
+      @resource_class.find_by(
+        reset_password_token: Devise.token_generator.digest(
+          @resource_class,
+          :reset_password_token,
+          @reset_password_token
+        )
+      )
+    end
+  end
+end

--- a/app/views/active_admin/devise/passwords/edit.html.erb
+++ b/app/views/active_admin/devise/passwords/edit.html.erb
@@ -1,27 +1,74 @@
-<div id="active_admin_content">
-  <% content_for :titre do %>
-    <%= t("active_admin.devise.change_password.title") -%>
-  <% end %>
-  <div id="login" class="panel">
-    <%= link_to t("active_admin.devise.login.lien_retour"),
-                new_compte_session_path,
-                class: "lien-retour",
-                aria: { label: t("active_admin.devise.login.description_lien_retour") } %>
-    <div class='mot-de-passe-instruction'>
-      <p class='mot-de-passe-instruction--consigne'><%= t(".consigne") %></p>
-      <p><%= t(@regles_mot_de_passe, scope: "creation_compte", longueur_mot_de_passe: Devise.password_length.first)%></p>
+<% content_for :title, @reset_password.page_title %>
+<% content_for :classes_conteneur do "conteneur-elargi conteneur-invisible" end %>
+
+<div class="page-reset-password <%= @reset_password.wrapper_modifier_class %>">
+  <div class="page-informations-compte">
+    <div class="page-reset-password__alert-band">
+      <%= dsfr_alert(type: :info, title: t("active_admin.devise.passwords.edit.alert_titre"), html_attributes: { class: "fr-mb-0v page-reset-password__alert" }) do %>
+        <%= t("active_admin.devise.passwords.edit.alert_description") %>
+      <% end %>
     </div>
-    <%= render partial: "active_admin/devise/shared/messages_erreurs_generales", resource: resource, locals: { champs_affiches: [ :password, :password_confirmation ] } %>
-    <%= active_admin_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
-      f.inputs do
-        f.input :reset_password_token, as: :hidden, input_html: { value: resource.reset_password_token }
-        f.input :password
-        f.input :password_confirmation, required: true, wrapper_html: { class: "libelle-long" }
-      end
-      f.actions do
-        f.action :submit, label: t("active_admin.devise.passwords.edit.submit")
-      end
-    end
-    %>
+
+    <%= render CarteV2Component.new(
+      titre: t("active_admin.devise.passwords.edit.titre_carte"),
+      sous_titre: nil
+    ) do %>
+      <p class="carte-v2__sous-titre"><%= t(@reset_password.regles_mot_de_passe_cle, scope: "creation_compte", longueur_mot_de_passe: Devise.password_length.first) %></p>
+      <p class="page-reset-password__champs-obligatoires"><%= t("active_admin.devise.passwords.edit.champs_obligatoires") %></p>
+
+      <%= semantic_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, id: "reset-password-edit-form" }) do |f| %>
+        <%= f.semantic_errors *champs_non_affiches(f.object.errors.messages.keys, [ :password, :password_confirmation ]) %>
+        <%= f.inputs do %>
+          <div class="fr-grid-row fr-grid-row--gutters">
+            <%= f.hidden_field :reset_password_token, value: resource.reset_password_token %>
+            <div class="fr-col-12">
+              <%= render InputComponent.new(
+                id: "#{resource_name}_password",
+                label: t("active_admin.devise.password.title"),
+                hint: @reset_password.hint_mot_de_passe,
+                form: f,
+                method: :password,
+                type: "password",
+                required: true,
+                autocomplete: "new-password"
+              ) %>
+            </div>
+            <div class="fr-col-12">
+              <%= render InputComponent.new(
+                id: "#{resource_name}_password_confirmation",
+                label: t("active_admin.devise.password_confirmation.title"),
+                form: f,
+                method: :password_confirmation,
+                type: "password",
+                required: true,
+                autocomplete: "new-password"
+              ) %>
+            </div>
+            <div class="fr-col-12">
+              <div class="informations-compte-actions">
+                <%= render BoutonDsfrComponent.new(
+                  new_compte_session_path,
+                  type: :secondary,
+                  tag: :a,
+                  class: "page-reset-password__bouton-annuler"
+                ) do %>
+                  <%= t("active_admin.devise.passwords.edit.annuler") %>
+                <% end %>
+                <%= render BoutonDsfrComponent.new(
+                  t("active_admin.devise.passwords.edit.submit"),
+                  type: :primary,
+                  tag: :submit,
+                  id: "reset-password-submit",
+                  class: "page-reset-password__bouton-principal",
+                  data: { initial_disabled: true }
+                ) do %>
+                  <%= t("active_admin.devise.passwords.edit.submit") %>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/active_admin/devise/passwords/new.html.erb
+++ b/app/views/active_admin/devise/passwords/new.html.erb
@@ -1,26 +1,77 @@
-<div id="active_admin_content">
-  <% content_for :titre do %>
-    <%= t("active_admin.devise.reset_password.title") -%>
-  <% end %>
-  <div id="login" class="panel">
-    <%= link_to t("active_admin.devise.login.lien_retour"),
-                new_compte_session_path,
-                class: "lien-retour",
-                aria: { label: t("active_admin.devise.login.description_lien_retour") } %>
-    <%= render partial: "active_admin/devise/shared/messages_erreurs_generales", resource: resource, locals: { champs_affiches: [ :email ] } %>
-    <%= active_admin_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-      if params[:token_invalide]
-        para para t("active_admin.devise.reset_password.token_invalide")
-        br
-        para t("active_admin.devise.reset_password.saisir_a_nouveau")
-        br
-      end
-      f.inputs do
-        f.input :email
-      end
-      f.actions do
-        f.action :submit, label: t("active_admin.devise.reset_password.submit"), button_html: { value: t("active_admin.devise.reset_password.submit") }
-      end
-    end %>
+<% content_for :title, @reset_password.page_title %>
+<% content_for :classes_conteneur do "conteneur-elargi conteneur-invisible" end %>
+
+<div class="page-reset-password <%= @reset_password.wrapper_modifier_class %>">
+  <div class="page-informations-compte">
+    <% if @reset_password.invalid_link? %>
+      <div class="page-reset-password__alert-band">
+        <%= dsfr_alert(type: :error, title: t("active_admin.devise.reset_password.invalid_link.alert_titre"), html_attributes: { class: "fr-mb-0v page-reset-password__alert" }) do %>
+          <%= t("active_admin.devise.reset_password.invalid_link.alert_description") %>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% if @reset_password.request_email? %>
+      <%= render TexteIntroComponent.new(
+        titre: @reset_password.t_email(:titre_intro),
+        texte: @reset_password.t_email(:sous_titre_intro)
+      ) %>
+    <% end %>
+
+    <%= render CarteV2Component.new(
+      titre: @reset_password.t_email(:titre_carte),
+      sous_titre: @reset_password.t_email(:sous_titre_carte)
+    ) do %>
+      <%= semantic_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, id: "reset-password-email-form" }) do |f| %>
+        <%= f.semantic_errors *champs_non_affiches(f.object.errors.messages.keys, [ :email ]) %>
+        <%= f.inputs do %>
+          <div class="fr-grid-row fr-grid-row--gutters">
+            <div class="fr-col-12">
+              <%= render InputComponent.new(
+                id: "#{resource_name}_email",
+                label: @reset_password.t_email(:email_label),
+                hint: @reset_password.t_email(:hint_email),
+                form: f,
+                method: :email,
+                type: "email",
+                required: true,
+                autocomplete: "email"
+              ) %>
+            </div>
+            <div class="fr-col-12">
+              <div class="informations-compte-actions">
+                <%= render BoutonDsfrComponent.new(
+                  new_compte_session_path,
+                  type: :secondary,
+                  tag: :a,
+                  class: "page-reset-password__bouton-annuler"
+                ) do %>
+                  <%= @reset_password.t_email(:annuler) %>
+                <% end %>
+                <%= render BoutonDsfrComponent.new(
+                  @reset_password.t_email(:submit),
+                  type: :primary,
+                  tag: :submit,
+                  id: @reset_password.email_submit_button_id,
+                  class: "page-reset-password__bouton-principal",
+                  disabled: true,
+                  data: { initial_disabled: true }
+                ) do %>
+                  <%= @reset_password.t_email(:submit) %>
+                <% end %>
+              </div>
+            </div>
+            <% if @reset_password.invalid_link? %>
+              <div class="fr-col-12">
+                <%= link_to t("active_admin.devise.reset_password.invalid_link.lien_accueil"),
+                            new_compte_session_path,
+                            class: "page-reset-password__lien-accueil fr-link",
+                            aria: { label: t("active_admin.devise.reset_password.invalid_link.lien_accueil_description") } %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/config/locales/activeadmin.yml
+++ b/config/locales/activeadmin.yml
@@ -17,6 +17,8 @@ fr:
         title: Identifiant
       password:
         title: Mot de passe
+      password_confirmation:
+        title: Confirmation du mot de passe
       links:
         forgot_your_password: "Mot de passe oublié ?"
       sessions:
@@ -70,13 +72,40 @@ fr:
       passwords:
         edit:
           consigne: Saisissez et confirmez votre nouveau mot de passe ci-dessous.
+          alert_titre: Changez votre mot de passe
+          alert_description: Vous avez fait une demande de changement de mot de passe.
+          titre_carte: Saisissez et confirmez votre nouveau mot de passe
+          champs_obligatoires: Les champs notés * sont obligatoires.
+          hint_password: Votre mot de passe doit comporter au moins 8 caractères.
+          hint_password_anlci: Au moins 12 caractères, une majuscule, une minuscule, un chiffre et un symbole.
           token_invalide: Votre lien de réinitialisation n’est pas valide.
-          submit: Valider mon nouveau mot de passe
+          annuler: Annuler
+          submit: Valider mon mot de passe
       change_password:
         title: Changez votre mot de passe
       reset_password:
-        token_invalide: "Veuillez vérifier de nouveau l’email reçu."
-        saisir_a_nouveau: Si vous souhaitez recevoir de nouveau cet email, merci de saisir votre adresse ci-dessous.
+        request_email:
+          title: Vous avez oublié votre mot de passe ?
+          titre_intro: Vous avez oublié votre mot de passe ?
+          sous_titre_intro: Si vous avez oublié votre mot de passe, votre compte n’est pas perdu.
+          titre_carte: Réinitialiser son mot de passe
+          sous_titre_carte: En inscrivant l’adresse e-mail de votre compte Eva, vous recevrez un e-mail afin de réinitialiser votre mot de passe.
+          email_label: Adresse e-mail
+          hint_email: "Format attendu : nom@domaine.fr"
+          annuler: Annuler
+          submit: "Envoyer l'e-mail"
+        invalid_link:
+          title: Veuillez vérifier de nouveau l’email reçu
+          alert_titre: Votre lien de réinitialisation n’est pas valide
+          alert_description: Vous avez sûrement déjà utilisé ce lien. Si ce n’est pas le cas, contactez un référent de votre structure ou le support.
+          titre_carte: Veuillez vérifier de nouveau l’email reçu
+          sous_titre_carte: Si vous souhaitez recevoir de nouveau cet email, merci de saisir votre adresse ci-dessous.
+          email_label: Adresse e-mail professionnelle
+          hint_email: "Format attendu : nom@domaine.fr"
+          annuler: Annuler
+          submit: "Envoyer l'e-mail"
+          lien_accueil: ← Aller à l’accueil pour se connecter
+          lien_accueil_description: Aller à l’accueil pour se connecter
     export:
       limite_atteinte: "L'export est limité à %{limite} lignes, les lignes supplémentaires n'ont pas été exportées. Vous pouvez utiliser les filtres pour réduire le nombre de lignes que vous voulez exporter"
     menu_connexion:

--- a/spec/features/admin/reset_mot_de_passe_spec.rb
+++ b/spec/features/admin/reset_mot_de_passe_spec.rb
@@ -10,34 +10,93 @@ describe 'Reset mot de passe', type: :feature do
     it { expect(page.has_css?('#error_explanation')).to be false }
   end
 
+  describe 'mot de passe oublié (sans lien)' do
+    let(:i18n_request_email) { 'active_admin.devise.reset_password.request_email' }
+
+    it 'affiche la demande d’e-mail avec bouton désactivé tant que l’e-mail est vide' do
+      visit new_compte_password_path
+
+      expect(page).to have_content(I18n.t(:title, scope: i18n_request_email))
+      expect(page).to have_content(I18n.t(:titre_carte, scope: i18n_request_email))
+      expect(page).to have_css('.texte-intro')
+      expect(page).to have_css('.carte-v2')
+      expect(page).to have_field(I18n.t(:email_label, scope: i18n_request_email))
+      expect(page).not_to have_css('.fr-alert--info')
+      expect(page).not_to have_css('.fr-alert--error')
+      expect(page).to have_button(I18n.t(:submit, scope: i18n_request_email), disabled: true)
+    end
+  end
+
   describe 'page modification du mot de passe' do
-    let(:compte) { create :compte }
-
-    context 'avec un token valide' do
-      before do
-        raw_token, hashed_token = Devise.token_generator.generate(Compte, :reset_password_token)
-        compte.update(reset_password_token: hashed_token, reset_password_sent_at: Time.now.utc)
-        visit edit_compte_password_path(compte, reset_password_token: raw_token)
-
-        click_on 'Valider mon nouveau mot de passe'
-      end
-
-      it { expect(page.has_css?('#error_explanation')).to be false }
+    let(:compte) do
+      create(:compte, password: 'AncienMotDePasse12$', password_confirmation: 'AncienMotDePasse12$')
+    end
+    let(:i18n_passwords_edit) { 'active_admin.devise.passwords.edit' }
+    let(:raw_token) do
+      raw_token, hashed_token = Devise.token_generator.generate(Compte, :reset_password_token)
+      compte.update(reset_password_token: hashed_token, reset_password_sent_at: Time.zone.now.utc)
+      raw_token
     end
 
-    context 'avec un token invalide' do
+    context 'avec un token valide (première ouverture du lien)' do
+      it 'affiche l’alerte info et le formulaire de nouveau mot de passe' do
+        visit edit_compte_password_path(compte, reset_password_token: raw_token)
+
+        expect(page).to have_content(I18n.t('active_admin.devise.change_password.title'))
+        expect(page).to have_css('.fr-alert--info')
+        expect(page).to have_content(I18n.t(:alert_titre, scope: i18n_passwords_edit))
+        expect(page).to have_content(I18n.t(:alert_description, scope: i18n_passwords_edit))
+        expect(page).to have_css('.carte-v2')
+        expect(page).not_to have_css('.texte-intro')
+        expect(page).to have_field(I18n.t('active_admin.devise.password.title'))
+        expect(page).to have_field(I18n.t('active_admin.devise.password_confirmation.title'))
+        expect(page).to have_content(I18n.t(:champs_obligatoires, scope: i18n_passwords_edit))
+        expect(page).to have_button(I18n.t(:submit, scope: i18n_passwords_edit))
+      end
+
+      it 'affiche une erreur quand les mots de passe ne correspondent pas' do
+        visit edit_compte_password_path(compte, reset_password_token: raw_token)
+
+        fill_in I18n.t('active_admin.devise.password.title'), with: 'azerty123'
+        fill_in I18n.t('active_admin.devise.password_confirmation.title'), with: 'different123'
+        click_on I18n.t(:submit, scope: i18n_passwords_edit)
+
+        expect(page).to have_content('ne concorde pas avec')
+      end
+
+      it 'ne change pas le mot de passe quand il ne respecte pas les règles' do
+        visit edit_compte_password_path(compte, reset_password_token: raw_token)
+
+        fill_in I18n.t('active_admin.devise.password.title'), with: '1234567'
+        fill_in I18n.t('active_admin.devise.password_confirmation.title'), with: '1234567'
+        click_on I18n.t(:submit, scope: i18n_passwords_edit)
+
+        expect(compte.reload.valid_password?('1234567')).to be false
+      end
+    end
+
+    context 'avec un token invalide (deuxième ouverture du lien)' do
+      let(:i18n_invalid_link) { 'active_admin.devise.reset_password.invalid_link' }
+
       before do
         visit edit_compte_password_path(compte, reset_password_token: 'invalide')
       end
 
-      it do
-        texte = I18n.t('active_admin.devise.reset_password.saisir_a_nouveau')
-        expect(page).to have_content(texte)
+      it 'affiche une alerte erreur et le formulaire de renvoi d’e-mail' do
+        expect(page).to have_css('.fr-alert--error')
+        expect(page).to have_content(I18n.t(:alert_titre, scope: i18n_invalid_link))
+        expect(page).to have_content(I18n.t(:alert_description, scope: i18n_invalid_link))
+        expect(page).to have_css('.carte-v2')
+        expect(page).not_to have_css('.texte-intro')
+        expect(page).to have_field(I18n.t(:email_label, scope: i18n_invalid_link))
+        expect(page).to have_button(I18n.t(:submit, scope: i18n_invalid_link), disabled: true)
       end
 
-      it do
-        texte = I18n.t('active_admin.devise.passwords.edit.token_invalide')
-        expect(page).to have_content(texte)
+      it 'permet de naviguer vers la connexion' do
+        expect(page).to have_link(
+          I18n.t(:lien_accueil, scope: i18n_invalid_link),
+          href: new_compte_session_path
+        )
       end
     end
   end

--- a/spec/requests/eva/devise/passwords_spec.rb
+++ b/spec/requests/eva/devise/passwords_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Eva::Devise::PasswordsController#create", type: :request do
+  describe "POST /admin/password" do
+    context "avec un email inconnu" do
+      it "réaffiche le formulaire avec l'erreur d'email introuvable" do
+        post compte_password_path, params: { compte: { email: "inconnu@example.com" } }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("n’a pas été trouvé(e)")
+        expect(response.body).not_to include("<ul class=\"errors\">")
+      end
+    end
+
+    context "avec un email d'un compte existant" do
+      let!(:compte) { create(:compte) }
+
+      it "envoie les instructions de réinitialisation" do
+        expect do
+          post compte_password_path, params: { compte: { email: compte.email } }
+        end.to change { ActionMailer::Base.deliveries.size }.by(1)
+
+        expect(response).to redirect_to(new_compte_session_path)
+      end
+    end
+  end
+end

--- a/spec/services/reset_password/page_context_spec.rb
+++ b/spec/services/reset_password/page_context_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ResetPassword::PageContext do
+  subject(:context) do
+    described_class.new(
+      action_name: action_name,
+      token_invalide: token_invalide,
+      reset_password_token: reset_password_token,
+      resource_class: Compte
+    )
+  end
+
+  let(:action_name) { "new" }
+  let(:token_invalide) { false }
+  let(:reset_password_token) { nil }
+
+  describe "#state" do
+    it "est request_email sur new sans token_invalide" do
+      expect(context.state).to eq(:request_email)
+    end
+
+    context "sur edit avec token valide" do
+      let(:action_name) { "edit" }
+      let(:compte) { create(:compte) }
+      let(:raw_token) do
+        raw, hashed = Devise.token_generator.generate(Compte, :reset_password_token)
+        compte.update!(reset_password_token: hashed, reset_password_sent_at: Time.zone.now.utc)
+        raw
+      end
+      let(:reset_password_token) { raw_token }
+
+      it "est change_password" do
+        expect(context.state).to eq(:change_password)
+      end
+    end
+
+    context "avec token_invalide" do
+      let(:token_invalide) { true }
+
+      it "est invalid_link" do
+        expect(context.state).to eq(:invalid_link)
+      end
+    end
+  end
+
+  describe "#token_valide?" do
+    let(:action_name) { "edit" }
+    let(:compte) { create(:compte) }
+
+    context "avec un token valide" do
+      let(:raw_token) do
+        raw, hashed = Devise.token_generator.generate(Compte, :reset_password_token)
+        compte.update!(reset_password_token: hashed, reset_password_sent_at: Time.zone.now.utc)
+        raw
+      end
+      let(:reset_password_token) { raw_token }
+
+      it { expect(context.token_valide?).to be true }
+    end
+
+    context "avec un token inconnu" do
+      let(:reset_password_token) { "invalide" }
+
+      it { expect(context.token_valide?).to be false }
+    end
+  end
+
+  describe "#redirect_path_si_token_invalide" do
+    let(:action_name) { "edit" }
+    let(:reset_password_token) { "invalide" }
+
+    it "renvoie le chemin de renvoi email" do
+      chemin_attendu = Rails.application.routes.url_helpers
+        .new_compte_password_path(token_invalide: true)
+      expect(context.redirect_path_si_token_invalide).to eq(chemin_attendu)
+    end
+  end
+
+  describe "#regles_mot_de_passe_cle et #hint_mot_de_passe" do
+    let(:action_name) { "edit" }
+    let(:i18n_passwords_edit) { "active_admin.devise.passwords.edit" }
+    let(:compte) { create(:compte, role: :superadmin) }
+    let(:raw_token) do
+      raw, hashed = Devise.token_generator.generate(Compte, :reset_password_token)
+      compte.update!(reset_password_token: hashed, reset_password_sent_at: Time.zone.now.utc)
+      raw
+    end
+    let(:reset_password_token) { raw_token }
+
+    it "utilise les règles ANLCI pour un compte ANLCI" do
+      expect(context.regles_mot_de_passe_cle).to eq(:regles_mot_de_passe_anlci)
+      expect(context.hint_mot_de_passe).to eq(
+        I18n.t(:hint_password_anlci, scope: i18n_passwords_edit)
+      )
+    end
+  end
+
+  describe "#regles_mot_de_passe_cle pour un conseiller" do
+    let(:action_name) { "edit" }
+    let(:i18n_passwords_edit) { "active_admin.devise.passwords.edit" }
+    let(:compte) { create(:compte_conseiller, :structure_avec_admin) }
+    let(:raw_token) do
+      raw, hashed = Devise.token_generator.generate(Compte, :reset_password_token)
+      compte.update!(reset_password_token: hashed, reset_password_sent_at: Time.zone.now.utc)
+      raw
+    end
+    let(:reset_password_token) { raw_token }
+
+    it "utilise les règles standard" do
+      expect(context.regles_mot_de_passe_cle).to eq(:regles_mot_de_passe)
+      expect(context.hint_mot_de_passe).to eq(I18n.t(:hint_password, scope: i18n_passwords_edit))
+    end
+  end
+end


### PR DESCRIPTION
Uniformise les écrans mot de passe oublié, changement de mot de passe et lien invalide sur le layout onboarding v2, avec alertes et contenus par état. Extrait la logique d’écran dans ResetPassword::PageContext pour alléger le contrôleur Devise.