### PR TITLE
🐛 Répare Plausible, en ajoutant les services tarteaucitron

### DIFF
--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -236,6 +236,7 @@ ActiveAdmin.setup do |config|
   #
   # To load a javascript file:
   config.register_javascript '/tarteaucitron/tarteaucitron.js'
+  config.register_javascript '/tarteaucitron/tarteaucitron.services.js'
   config.register_javascript 'tarteaucitron-init.js'
   config.register_javascript 'hotjar.js'
   config.register_javascript 'plausible.js'


### PR DESCRIPTION
<img width="1116" height="537" alt="Capture d’écran 2026-05-15 à 17 23 14" src="https://github.com/user-attachments/assets/749a54a6-a573-48d1-8693-e85350ce79c0" />
<img width="920" height="141" alt="Capture d’écran 2026-05-15 à 17 24 05" src="https://github.com/user-attachments/assets/7760ab5c-3b3e-4324-9a2b-7d93721e0c9a" />

Depuis la version 1.32.0 de tarteaucitron, les services ont été séparés dans tarteaucitron.services.js, qui n'était pas chargé dans active_admin.rb. Le fichier tarteaucitron.js seul ne contient plus les définitions de services.