### PR TITLE
🐛 Ajoute le data-fr-opened manquant

### DIFF
--- a/app/views/inscription/structures/_modal_confirmation_creation_structure.html.erb
+++ b/app/views/inscription/structures/_modal_confirmation_creation_structure.html.erb
@@ -24,6 +24,7 @@
       "#",
       type: :secondary,
       tag: :button,
+      "data-fr-opened": "false",
       "aria-controls": id_modal
     ) do %>
       <%= t(".annuler") %>


### PR DESCRIPTION
Dans la doc du dsfr: https://betagouv.github.io/dsfr-view-components/components/modal/

la strucutre de la modal n'etait pas bien faite, il manquait le data-fr-opened