### PR TITLE
💄 Corrige un retour à la ligne sur le lien vers les metiers dans la restitution

### DIFF
--- a/app/assets/stylesheets/admin/pages/restitution_globale/_base.scss
+++ b/app/assets/stylesheets/admin/pages/restitution_globale/_base.scss
@@ -1,4 +1,5 @@
-.en-tete-page, .pied-page {
+.en-tete-page,
+.pied-page {
   display: none;
 }
 
@@ -9,6 +10,7 @@
   .panel {
     padding: 2rem 0;
     margin-bottom: $dsfr-spacing-12v;
+
     &--avec-references {
       padding-bottom: 0;
     }
@@ -18,7 +20,10 @@
     margin: 0 3rem;
   }
 
-  .header, .title_bar { display: none; }
+  .header,
+  .title_bar {
+    display: none;
+  }
 
   #competence-numerique {
     .panel {
@@ -42,11 +47,13 @@
 
     .clause-non-responsabilite {
       color: $eva_dark_blue_grey;
+
       a {
         color: $eva_dark_blue_grey;
       }
 
       padding-top: 0.125rem;
+
       p {
         margin-top: 0.875rem;
         margin-bottom: 0;
@@ -57,13 +64,14 @@
   .autopositionnement {
     color: $couleur-texte;
 
-    > .row {
+    >.row {
       margin-bottom: 2rem;
     }
 
     .intitule-question {
       display: flex;
       align-items: center;
+
       p {
         margin: 0;
       }
@@ -79,13 +87,33 @@
       height: 2rem;
     }
 
-    .position-1 { left: -1%; }
-    .position-2 { left: 14%; }
-    .position-3 { left: 31%; }
-    .position-4 { left: 48%; }
-    .position-5 { left: 63%; }
-    .position-6 { left: 80%; }
-    .position-7 { left: 97%; }
+    .position-1 {
+      left: -1%;
+    }
+
+    .position-2 {
+      left: 14%;
+    }
+
+    .position-3 {
+      left: 31%;
+    }
+
+    .position-4 {
+      left: 48%;
+    }
+
+    .position-5 {
+      left: 63%;
+    }
+
+    .position-6 {
+      left: 80%;
+    }
+
+    .position-7 {
+      left: 97%;
+    }
 
     .puce {
       position: absolute;
@@ -115,6 +143,7 @@
       font-weight: 600;
       margin-top: .625rem;
       margin-bottom: 1rem;
+
       &:last-child {
         margin-bottom: 0;
       }
@@ -156,9 +185,11 @@
         &-3 {
           width: 100%;
         }
+
         &-2 {
           width: 75%;
         }
+
         &-1 {
           width: 50%;
         }
@@ -169,6 +200,7 @@
       position: absolute;
       top: 0;
       left: -1.7rem;
+
       img {
         width: 3.4rem;
       }
@@ -197,6 +229,7 @@
 
         .image-lien {
           margin-right: .5rem;
+
           img {
             height: 1.5rem;
           }
@@ -248,6 +281,7 @@
 
     &.socle_clea {
       background-color: $success-950;
+
       h3 {
         color: $success-425;
       }
@@ -333,6 +367,7 @@
     position: absolute;
     top: -1.3rem;
     right: -1rem;
+
     img {
       height: 2.6rem;
     }
@@ -361,6 +396,7 @@
     align-items: center;
     border-bottom: 1px solid $grey-200;
     color: $grey-200;
+
     img {
       height: 4rem;
     }
@@ -408,10 +444,21 @@
   /* stylelint-disable-next-line */
   margin: 0 5px;
 
-  &.niveau-indetermine { border: 2px solid $couleur-niveau-indetermine; }
-  &.niveau-1 { background-color: $couleur-niveau-1; }
-  &.niveau-2 { background-color: $couleur-niveau-2; }
-  &.niveau-3 { background-color: $couleur-niveau-3; }
+  &.niveau-indetermine {
+    border: 2px solid $couleur-niveau-indetermine;
+  }
+
+  &.niveau-1 {
+    background-color: $couleur-niveau-1;
+  }
+
+  &.niveau-2 {
+    background-color: $couleur-niveau-2;
+  }
+
+  &.niveau-3 {
+    background-color: $couleur-niveau-3;
+  }
 }
 
 .restitution-p {

--- a/app/assets/stylesheets/admin/pages/restitution_globale/_base.scss
+++ b/app/assets/stylesheets/admin/pages/restitution_globale/_base.scss
@@ -175,7 +175,7 @@
     }
 
     .informations-competence {
-      padding: 1.5rem 0 0 5rem;
+      padding: 1.5rem 0 0 4rem;
     }
 
     .nom-competence {


### PR DESCRIPTION
Diminution de la marge des descriptions des compétences transversales

## Avant
<img width="622" height="669" alt="Capture d’écran 2026-05-27 à 15 17 11" src="https://github.com/user-attachments/assets/835c46b7-4bdf-467b-a60e-4a73030d8e03" />

## Après
<img width="631" height="724" alt="Capture d’écran 2026-05-27 à 15 16 34" src="https://github.com/user-attachments/assets/55f24328-dded-41ae-bdc1-618a649ee7a1" />
