### PR TITLE
✨ Donne les URL officielles pour les compétences transversales

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,7 +6,6 @@ HOTE_SERVEUR=localhost:3000
 URL_CLIENT=http://localhost:7700/jeu
 URL_EVA_ENTREPRISES=http://localhost:5173
 URL_SITE_VITRINE=https://eva.anlci.gouv.fr
-URL_COMPETENCES=https://eva.anlci.gouv.fr/competences
 LIEN_INSCRIPTION_PRESENTATION=https://eva.anlci.gouv.fr/formation-et-presentation/
 METABASE_SITE_URL=http://metabase.eva.anlci.gouv.fr
 METABASE_SECRET_KEY=<SECRET_METABASE>

--- a/app/components/evaluation/competence_transversale_component.rb
+++ b/app/components/evaluation/competence_transversale_component.rb
@@ -8,7 +8,7 @@ class Evaluation
     end
 
     def url_competence
-      "#{ENV['URL_COMPETENCES']}/#{@competence}/"
+      "#{ENV['URL_SITE_VITRINE']}/#{::Competence::COMPETENCES_TRANSVERSALES[@competence]}/"
     end
   end
 end

--- a/app/models/competence.rb
+++ b/app/models/competence.rb
@@ -29,13 +29,14 @@ module Competence
   ORGANISATION_METHODE = :organisation_methode
   VIGILANCE_CONTROLE = :vigilance_controle
 
-  COMPETENCES_TRANSVERSALES = [
-    RAPIDITE,
-    COMPARAISON_TRI,
-    ATTENTION_CONCENTRATION,
-    ORGANISATION_METHODE,
-    VIGILANCE_CONTROLE
-  ].freeze
+  # Liste des competences transversales restituées et leur page sur le site vitrine
+  COMPETENCES_TRANSVERSALES = {
+    RAPIDITE => "vitesse-dexecution",
+    COMPARAISON_TRI => "comparaison-et-tri",
+    ATTENTION_CONCENTRATION => "attention-et-concentration",
+    ORGANISATION_METHODE => "organisation-et-methode",
+    VIGILANCE_CONTROLE => "vigilance-et-controle"
+  }.freeze
 
   VOCABULAIRE = :vocabulaire
 end

--- a/spec/components/evaluation/competence_transversale_component_spec.rb
+++ b/spec/components/evaluation/competence_transversale_component_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Evaluation::CompetenceTransversaleComponent, type: :component do
+  subject(:component) do
+    described_class.new(competence: :rapidite, interpretation: 5)
+  end
+
+  describe '#url_competence' do
+    before { allow(ENV).to receive(:[]).and_call_original }
+
+    it "construit l'url à partir de URL_SITE_VITRINE et du nom de page de la compétence" do
+      allow(ENV).to receive(:[]).with('URL_SITE_VITRINE').and_return('https://site-vitrine.fr')
+
+      expect(component.url_competence).to eq('https://site-vitrine.fr/vitesse-dexecution/')
+    end
+  end
+end


### PR DESCRIPTION
* Ne passe plus par les redirections Wordpress
* Raccourcit l'affichage sur le PDF des restitutions
* Supprime la variable d'env `URL_COMPETENCES`

<img width="652" height="1016" alt="Capture d’écran 2026-05-28 à 14 55 50" src="https://github.com/user-attachments/assets/02bf97f7-676d-422c-a2ec-536ee40f1bd3" />
