### PR TITLE
🐛 Corrige le calcul de score_strategie et supprime tes exemples de statégies de contournement

### DIFF
--- a/app/models/restitution/entreprises/impact/score_par_impact.rb
+++ b/app/models/restitution/entreprises/impact/score_par_impact.rb
@@ -2,48 +2,47 @@ module Restitution
   module Entreprises
     module Impact
       class ScoreParImpact
-        # Si cumul des scores >= 39, alors très fort
-        SEUILS_POUR_COUT = {
-          39 => :tres_fort,
-          26 => :fort,
-          13 => :moyen,
-          0 => :faible
+        SEUILS = {
+          score_cout: {
+            39 => :tres_fort,
+            26 => :fort,
+            13 => :moyen,
+            0 => :faible
+          },
+          score_strategies: {
+            27 => :tres_fort,
+            18 => :fort,
+            9 => :moyen,
+            0 => :faible
+          },
+          score_numerique: {
+            30 => :tres_fort,
+            20 => :fort,
+            10 => :moyen,
+            0 => :faible
+          }
         }.freeze
 
         def calcule_score_cout(evenements, pourcentage_risque)
-          calcule(evenements, "score_cout", SEUILS_POUR_COUT, pourcentage_risque)
+          calcule(evenements, :score_cout, pourcentage_risque)
         end
-
-        SEUILS_POUR_STRATEGIE = {
-          27 => :tres_fort,
-          18 => :fort,
-          9 => :moyen,
-          0 => :faible
-        }.freeze
 
         def calcule_score_strategie(evenements, pourcentage_risque)
-          calcule(evenements, "score_numerique", SEUILS_POUR_STRATEGIE, pourcentage_risque)
+          calcule(evenements, :score_strategies, pourcentage_risque)
         end
-
-        SEUILS_POUR_NUMERIQUE = {
-          30 => :tres_fort,
-          20 => :fort,
-          10 => :moyen,
-          0 => :faible
-        }.freeze
 
         def calcule_score_numerique(evenements, pourcentage_risque)
-          calcule(evenements, "score_numerique", SEUILS_POUR_NUMERIQUE, pourcentage_risque)
+          calcule(evenements, :score_numerique, pourcentage_risque)
         end
 
-        def calcule(evenements, type_score, seuils, pourcentage_risque)
+        def calcule(evenements, type_score, pourcentage_risque)
           evenements_reponse = MetriquesHelper.filtre_evenements_reponses(evenements)
           return if evenements_reponse.blank?
 
-          total = evenements_reponse&.sum { |e| e.donnees[type_score] || 0 }
+          total = evenements_reponse.sum { |e| e.donnees[type_score.to_s] || 0 }
           total += calcule_malus(pourcentage_risque)
 
-          seuils.each do |seuil, interpretation|
+          SEUILS[type_score].each do |seuil, interpretation|
             return interpretation if total >= seuil
           end
         end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -438,16 +438,12 @@ fr:
               texte:
                 A: |
                   Les mécanismes d'adaptation existent à peine ou passent inaperçus.
-                  Ex. « Ça se passe bien, je n'ai pas de souci particulier. »
                 B: |
-                  Certaines situations « à risque » sont contournées de façon occasionnelle.  
-                  Ex. « Ce n'est pas urgent, je verrai ça plus tard… De toutes façons ce n'est pas vraiment de ma responsabilité. »
+                  Certaines situations « à risque » sont contournées de façon occasionnelle.
                 C: |
                   Les contournements et parades deviennent habituels, l'écrit est évité, l'oral est privilégié.
-                  Ex. « J'aime mieux en parler directement, c'est plus simple. Les mails ce n'est pas mon truc. »
                 D: |
                   L'entourage est sollicité systématiquement pour les tâches impliquant de l'écrit.
-                  Ex. « J'en ai parlé à mon collègue, il s'en occupe. Moi je gère autre chose. »
           score_numerique:
             question: "Où en est votre structure dans une logique de transition et reconversion ?"
             titre_graphique: "Compétences numériques de base"

--- a/spec/models/restitution/entreprises/impact/score_par_impact_spec.rb
+++ b/spec/models/restitution/entreprises/impact/score_par_impact_spec.rb
@@ -121,4 +121,34 @@ describe Restitution::Entreprises::Impact::ScoreParImpact do
       end
     end
   end
+
+  describe '#calcule_score_strategie' do
+    let(:pourcentage_risque) { 10 }
+    let(:evenements) do
+      [
+        build(:evenement_demarrage),
+        build(:evenement_reponse, donnees: { question: 'q1', score_strategies: 9 })
+      ]
+    end
+
+    it 'retourne moyen quand score_strategies vaut 9' do
+      resultat = described_class.new.calcule_score_strategie(evenements, pourcentage_risque)
+      expect(resultat).to eq(:moyen)
+    end
+  end
+
+  describe '#calcule_score_numerique' do
+    let(:pourcentage_risque) { 10 }
+    let(:evenements) do
+      [
+        build(:evenement_demarrage),
+        build(:evenement_reponse, donnees: { question: 'q1', score_numerique: 10 })
+      ]
+    end
+
+    it 'retourne moyen quand score_numerique vaut 10' do
+      resultat = described_class.new.calcule_score_numerique(evenements, pourcentage_risque)
+      expect(resultat).to eq(:moyen)
+    end
+  end
 end


### PR DESCRIPTION
* Le score_strategie se basait sur les données pour score_numerique
* Les exemples ne tiennent pas sur la page