### PR TITLE
Opacité des ProScore et documentation des restitution des risques

### DIFF
--- a/app/assets/stylesheets/admin/composants/_eva_pro_score.scss
+++ b/app/assets/stylesheets/admin/composants/_eva_pro_score.scss
@@ -14,6 +14,7 @@
   justify-content: center;
   align-items: center;
   background: var(--eva-pro-score-item-bg);
+  opacity: 0.6;
 
   &__lettre {
     @include corps-de-texte-xs-regular;
@@ -44,6 +45,7 @@
     height: 1.75rem;
     border-radius: var(--Radius-SM, 4px);
     border: 2px solid var(--dark-decisions-border-border-action-high-grey, #FFF);
+    opacity: 1;
 
     .eva-pro-score-item__lettre {
       @include corps-de-texte-md-bold;

--- a/app/views/admin/ui_kit/mesure_chiffre_cle.html.erb
+++ b/app/views/admin/ui_kit/mesure_chiffre_cle.html.erb
@@ -48,8 +48,9 @@
 
   <h2>Tous les risques</h2>
 
+  Le composant d'affichage des risques change de couleur en fonction du pourcentage quand il passe un seuil. Cet échan ne dit rien sur la façon de calculer le taux de risque :
   <% scope = [ :admin, :evaluations, :mesure_des_risques ] %>
-  <% Evaluations::DiagnosticPro::RisquesPresenter::SEUILS_PALIERS_RISQUE.each do |pourcentage, palier_label| %>
+  <% [ 10, 11, 25, 26, 50, 51, 75, 100 ].each do |pourcentage| %>
     <% presenter = Evaluations::DiagnosticPro::RisquesPresenter.new(pourcentage_risque: pourcentage) %>
     <div class="fr-mb-5w">
       <h3>Palier <%= presenter.palier %></h3>

--- a/spec/models/evaluations/diagnostic_pro/risques_presenter_spec.rb
+++ b/spec/models/evaluations/diagnostic_pro/risques_presenter_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Evaluations::DiagnosticPro::RisquesPresenter do
+  describe "#palier" do
+    it "retourne le palier A quand le pourcentage est très bas" do
+      presenter = described_class.new(pourcentage_risque: 10)
+      expect(presenter.palier).to eq("A")
+    end
+
+    it "retourne le palier C quand le pourcentage est égale à 50" do
+      presenter = described_class.new(pourcentage_risque: 50)
+      expect(presenter.palier).to eq("C")
+    end
+
+    it "retourne le palier D quand le pourcentage est supérieur 50" do
+      presenter = described_class.new(pourcentage_risque: 51)
+      expect(presenter.palier).to eq("D")
+    end
+
+    it "retourne le palier D quand le pourcentage est supérieur 75" do
+      presenter = described_class.new(pourcentage_risque: 76)
+      expect(presenter.palier).to eq("D")
+    end
+  end
+end

--- a/spec/models/evaluations/diagnostic_pro_spec.rb
+++ b/spec/models/evaluations/diagnostic_pro_spec.rb
@@ -104,13 +104,4 @@ evaluation: double(complete?: false))
       end
     end
   end
-
-  describe Evaluations::DiagnosticPro::RisquesPresenter do
-    describe "#palier" do
-      it "retourne le palier A quand le pourcentage est très bas" do
-        presenter = described_class.new(pourcentage_risque: 10)
-        expect(presenter.palier).to eq("A")
-      end
-    end
-  end
 end


### PR DESCRIPTION
<img width="845" height="429" alt="Capture d’écran 2026-06-11 à 20 34 19" src="https://github.com/user-attachments/assets/2873a7c2-084a-4c13-ad5b-d97aa03eb40c" />

Le composant d'affichage des risques change de couleur en fonction du pourcentage quand il passe un seuil. Cet échan ne dit rien sur la façon de calculer le taux de risque :
<img width="312" height="640" alt="Capture d’écran 2026-06-11 à 20 35 47" src="https://github.com/user-attachments/assets/b7826aa6-ac0a-436f-b24c-3ee53c2275fd" />
