### PR TITLE
🐛 Restitution d'une Evaluation evapro avec un score_total supperieur à 167

### DIFF
--- a/app/models/evaluations/diagnostic_pro/bilan_consolide_calculator.rb
+++ b/app/models/evaluations/diagnostic_pro/bilan_consolide_calculator.rb
@@ -23,9 +23,8 @@ module Evaluations
       end
 
       def palier
-        PALIER_PAR_SCORE.each do |interval, niveau|
-          return niveau if interval.cover?(score_total)
-        end
+        _interval, niveau = PALIER_PAR_SCORE.find { |interval, _| interval.cover?(score_total) }
+        niveau || "D"
       end
 
       def score_total

--- a/app/models/evaluations/diagnostic_pro/bilan_consolide_calculator.rb
+++ b/app/models/evaluations/diagnostic_pro/bilan_consolide_calculator.rb
@@ -66,7 +66,7 @@ module Evaluations
         synthese = diag_risques_entreprise&.partie&.synthese
         return if synthese.blank?
 
-        synthese["pourcentage_risque"] || synthese[:pourcentage_risque]
+        synthese["pourcentage_risque"]
       end
 
       def evenements_reponses_risques

--- a/app/models/evaluations/diagnostic_pro/bilan_consolide_calculator.rb
+++ b/app/models/evaluations/diagnostic_pro/bilan_consolide_calculator.rb
@@ -11,10 +11,10 @@ module Evaluations
       }.freeze
 
       MALUS_PAR_POURCENTAGE_RISQUE = {
-        (0..10) => 0,
-        (11..25) => 1,
-        (26..50) => 2,
-        (51..75) => 3
+        10 => 0,
+        25 => 1,
+        50 => 2,
+        75 => 3
       }.freeze
 
       def initialize(diag_risques_entreprise:, evaluation_impact_general:)
@@ -59,11 +59,7 @@ module Evaluations
         pourcentage = pourcentage_risque
         return 0 if pourcentage.nil?
 
-        MALUS_PAR_POURCENTAGE_RISQUE.each do |interval, valeur|
-          return valeur if interval.cover?(pourcentage)
-        end
-
-        0
+        MALUS_PAR_POURCENTAGE_RISQUE[pourcentage]
       end
 
       def pourcentage_risque

--- a/app/models/restitution/diag_risques_entreprise.rb
+++ b/app/models/restitution/diag_risques_entreprise.rb
@@ -2,7 +2,7 @@ module Restitution
   class DiagRisquesEntreprise < Base
     def synthese
       {
-        pourcentage_risque: calcule_pourcentage_risque
+        "pourcentage_risque" => calcule_pourcentage_risque
       }
     end
 
@@ -11,7 +11,7 @@ module Restitution
     end
 
     def palier
-      case synthese[:pourcentage_risque]
+      case synthese["pourcentage_risque"]
       when 0..10
         "A"
       when 11..25

--- a/app/models/restitution/evaluation_impact_general.rb
+++ b/app/models/restitution/evaluation_impact_general.rb
@@ -46,7 +46,7 @@ pourcentage_risque)
     private
 
     def pourcentage_risque
-      @pourcentage_risque ||= restitution_diag_risques_entreprise.synthese[:pourcentage_risque]
+      @pourcentage_risque ||= restitution_diag_risques_entreprise.synthese["pourcentage_risque"]
     end
 
     def restitution_diag_risques_entreprise

--- a/app/models/syntheses_evapro_pour_index.rb
+++ b/app/models/syntheses_evapro_pour_index.rb
@@ -79,12 +79,12 @@ class SynthesesEvaproPourIndex
 
   def extrait_pourcentage_risque(partie)
     synthese = partie.synthese || {}
-    synthese["pourcentage_risque"] || synthese[:pourcentage_risque]
+    synthese["pourcentage_risque"]
   end
 
   def extrait_score_cout(partie)
     synthese = partie.synthese || {}
-    (synthese["score_cout"] || synthese[:score_cout])&.to_s
+    synthese["score_cout"]&.to_s
   end
 
   def extrait_synthese_impact(partie)

--- a/app/views/admin/evaluations/evapro/_bilan_evapro.erb
+++ b/app/views/admin/evaluations/evapro/_bilan_evapro.erb
@@ -1,9 +1,8 @@
 <div id="evaluation-bilan-evapro">
   <% if palier_bilan.present? %>
-    <% palier = palier_bilan %>
     <h2 class="evaluation__titre"><%= t(:titre, scope: [  :admin, :evaluations, :bilan_evapro  ]) %></h2>
     <div class="evaluation-bilan-evapro__contenu">
-      <%= render(BilanEvaProComponent.new(palier: palier)) %>
+      <%= render(BilanEvaProComponent.new(palier: palier_bilan)) %>
       <p class="evaluation-bilan-evapro__explication"><%= t(:explication, scope: [  :admin, :evaluations, :bilan_evapro  ]) %></p>
 
       <% if opco %>

--- a/spec/models/evaluations/diagnostic_pro/bilan_consolide_calculator_spec.rb
+++ b/spec/models/evaluations/diagnostic_pro/bilan_consolide_calculator_spec.rb
@@ -124,6 +124,19 @@ evenements: risque_events)
       expect(calculator.palier).to eq("D")
     end
 
+    it "retourne D pour un score total supérieur à 167" do
+      calculator = build_calculator(
+        score_risque: 33,
+        pourcentage_risque: 75,
+        score_cout: 51,
+        score_strategie: 35,
+        score_numerique: 40
+      )
+
+      expect(calculator.score_total).to eq(168)
+      expect(calculator.palier).to eq("D")
+    end
+
     it "met a jour le palier quand les scores d'impact augmentent" do
       baseline = build_calculator(
         score_risque: 33,

--- a/spec/models/evaluations/diagnostic_pro/bilan_consolide_calculator_spec.rb
+++ b/spec/models/evaluations/diagnostic_pro/bilan_consolide_calculator_spec.rb
@@ -160,6 +160,14 @@ evenements: risque_events)
       expect(with_impacts.palier).to eq("D")
     end
 
+    it "couvre tous les paliers de pourcentage_risque dans MALUS_PAR_POURCENTAGE_RISQUE" do
+      paliers = Restitution::Entreprises::PourcentageRisque::POURCENTAGE_RISQUE_PAR_SEUIL.keys
+      paliers.each do |pourcentage|
+        expect(described_class::MALUS_PAR_POURCENTAGE_RISQUE).to have_key(pourcentage),
+          "pas de malus défini pour pourcentage_risque=#{pourcentage}"
+      end
+    end
+
     it "conserve le malus existant quand le risque atteint 75%" do
       calculator = build_calculator(
         score_risque: 33,

--- a/spec/models/restitution/diag_risques_entreprise_spec.rb
+++ b/spec/models/restitution/diag_risques_entreprise_spec.rb
@@ -11,7 +11,7 @@ describe Restitution::DiagRisquesEntreprise do
     end
 
     it 'calculates pourcentage_risque and returns it in the synthese hash' do
-      expect(diag_risques_entreprise.synthese[:pourcentage_risque]).to eq(expected_risk_percentage)
+      expect(diag_risques_entreprise.synthese["pourcentage_risque"]).to eq(expected_risk_percentage)
     end
   end
 end


### PR DESCRIPTION
On a un problème avec les eval dont : score_risque + score_cout_final + score_strategie_final + score_numerique_final > 167
En particulier, on a un cas en prod à 238
Quand on cherche à trouver la lettre pour ce score, on utilise les paliers suivants
```
PALIER_PAR_SCORE = {
        (0..41) => "A",
        (42..83) => "B",
        (84..126) => "C",
        (127..167) => "D"
      }.freeze
```
Pourquoi le palier “D” s’arrête à 167 ? Est-ce que 238 est une valeur aberrante ou c’est le palier qui est insuffisamment large ?(modifié)

Cette PR met un D dans ce cas. Pour corriger l'erreur et permettre d'analyser la restitution qui plante