### PR TITLE
🐛 Corrige le crash quand l'utilisateur essayait de définir un mot de passe invalide

### DIFF
--- a/app/assets/stylesheets/admin/pages/inscription/_structure.scss
+++ b/app/assets/stylesheets/admin/pages/inscription/_structure.scss
@@ -62,12 +62,6 @@
     gap: $dsfr-spacing-3w;
   }
 
-  .carte-v2__sous-titre {
-    margin: 0;
-
-    @include corps-de-texte-md-regular;
-  }
-
   .structure-content-wrapper-siret {
     display: flex;
     flex-direction: column;

--- a/app/controllers/eva/devise/passwords_controller.rb
+++ b/app/controllers/eva/devise/passwords_controller.rb
@@ -4,7 +4,7 @@ module Eva
       layout "inscription_v2"
 
       # rubocop:disable Rails/LexicallyScopedActionFilter
-      before_action :assign_reset_password_context, only: %i[new edit create]
+      before_action :assign_reset_password_context, only: %i[new edit create update]
       before_action :redirect_si_token_invalide, only: :edit
       # rubocop:enable Rails/LexicallyScopedActionFilter
 

--- a/app/controllers/eva/devise/passwords_controller.rb
+++ b/app/controllers/eva/devise/passwords_controller.rb
@@ -11,10 +11,12 @@ module Eva
       private
 
       def assign_reset_password_context
+        reset_password_token = params[:reset_password_token] ||
+                               params[resource_name]&.[](:reset_password_token)
         @reset_password = ResetPassword::PageContext.new(
           action_name: action_name,
           token_invalide: params[:token_invalide],
-          reset_password_token: params[:reset_password_token],
+          reset_password_token: reset_password_token,
           resource_class: resource_class
         )
       end

--- a/app/services/reset_password/page_context.rb
+++ b/app/services/reset_password/page_context.rb
@@ -13,7 +13,7 @@ module ResetPassword
 
     def state
       return :invalid_link if @token_invalide
-      return :change_password if @action_name == "edit"
+      return :change_password if %w[edit update].include?(@action_name)
 
       :request_email
     end
@@ -45,8 +45,8 @@ module ResetPassword
     end
 
     def hint_mot_de_passe
-      cle = compte&.anlci? ? :hint_password_anlci : :hint_password
-      I18n.t(cle, scope: "active_admin.devise.passwords.edit")
+      cle = compte&.anlci? ? :regles_mot_de_passe_anlci : :regles_mot_de_passe
+      I18n.t(cle, scope: "creation_compte", longueur_mot_de_passe: Devise.password_length.first)
     end
 
     def i18n_scope

--- a/app/services/reset_password/page_context.rb
+++ b/app/services/reset_password/page_context.rb
@@ -44,10 +44,6 @@ module ResetPassword
       new_compte_password_path(token_invalide: true)
     end
 
-    def regles_mot_de_passe_cle
-      compte&.anlci? ? :regles_mot_de_passe_anlci : :regles_mot_de_passe
-    end
-
     def hint_mot_de_passe
       cle = compte&.anlci? ? :hint_password_anlci : :hint_password
       I18n.t(cle, scope: "active_admin.devise.passwords.edit")

--- a/app/views/active_admin/devise/passwords/edit.html.erb
+++ b/app/views/active_admin/devise/passwords/edit.html.erb
@@ -13,7 +13,6 @@
       titre: t("active_admin.devise.passwords.edit.titre_carte"),
       sous_titre: nil
     ) do %>
-      <p class="carte-v2__sous-titre"><%= t(@reset_password.regles_mot_de_passe_cle, scope: "creation_compte", longueur_mot_de_passe: Devise.password_length.first) %></p>
       <p class="page-reset-password__champs-obligatoires"><%= t("active_admin.devise.passwords.edit.champs_obligatoires") %></p>
 
       <%= semantic_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, id: "reset-password-edit-form" }) do |f| %>

--- a/app/views/inscription/nouveaux_comptes/show.html.erb
+++ b/app/views/inscription/nouveaux_comptes/show.html.erb
@@ -84,7 +84,7 @@
               <%= render InputComponent.new(
                 id: "compte_password",
                 label: t(".label_password"),
-                hint: t(".hint_password"),
+                hint: t("creation_compte.regles_mot_de_passe", longueur_mot_de_passe: Devise.password_length.first),
                 form: compte,
                 method: :password,
                 type: "password",

--- a/config/locales/activeadmin.yml
+++ b/config/locales/activeadmin.yml
@@ -77,8 +77,6 @@ fr:
           alert_description: Vous avez fait une demande de changement de mot de passe.
           titre_carte: Saisissez et confirmez votre nouveau mot de passe
           champs_obligatoires: Les champs notés * sont obligatoires.
-          hint_password: Votre mot de passe doit comporter au moins 8 caractères.
-          hint_password_anlci: Au moins 12 caractères, une majuscule, une minuscule, un chiffre et un symbole.
           token_invalide: Votre lien de réinitialisation n’est pas valide.
           annuler: Annuler
           submit: Valider mon mot de passe

--- a/config/locales/views/nouveaux_comptes.yml
+++ b/config/locales/views/nouveaux_comptes.yml
@@ -15,7 +15,6 @@ fr:
         label_email: Adresse e-mail professionnelle
         hint_email: "Format attendu : nom@domaine.fr"
         label_password: Mot de passe
-        hint_password: Votre mot de passe doit comporter au moins 8 caractères
         label_password_confirmation: Confirmation du mot de passe
         label_cgu_lien: conditions générales d'utilisation d'eva
         label_cgu: "J'accepte les %{cgu_lien}"

--- a/spec/requests/eva/devise/passwords_spec.rb
+++ b/spec/requests/eva/devise/passwords_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe "Eva::Devise::PasswordsController#update", type: :request do
     context "avec un token valide et des mots de passe non conformes" do
       let!(:compte) { create(:compte) }
 
-      it "réaffiche le formulaire sans erreur NoMethodError sur @reset_password" do
+      def soumettre_mot_de_passe_invalide(compte)
         raw_token, _hashed = Devise.token_generator.generate(Compte, :reset_password_token)
+        digest = Devise.token_generator.digest(Compte, :reset_password_token, raw_token)
         compte.update!(
-          reset_password_token: Devise.token_generator.digest(Compte, :reset_password_token, raw_token),
+          reset_password_token: digest,
           reset_password_sent_at: Time.current
         )
-
         put compte_password_path, params: {
           compte: {
             reset_password_token: raw_token,
@@ -21,14 +21,26 @@ RSpec.describe "Eva::Devise::PasswordsController#update", type: :request do
             password_confirmation: "court"
           }
         }
+      end
+
+      it "réaffiche le formulaire sans erreur NoMethodError sur @reset_password" do
+        soumettre_mot_de_passe_invalide(compte)
 
         expect(response).to have_http_status(:ok)
       end
+
+      context "avec un superadmin" do
+        let!(:compte) { create(:compte_superadmin) }
+
+        it "affiche le hint ANLCI" do
+          soumettre_mot_de_passe_invalide(compte)
+
+          expect(response.body).to include("générateur de mot de passe fort")
+        end
+      end
     end
   end
-end
 
-RSpec.describe "Eva::Devise::PasswordsController#create", type: :request do
   describe "POST /admin/password" do
     context "avec un email inconnu" do
       it "réaffiche le formulaire avec l'erreur d'email introuvable" do

--- a/spec/requests/eva/devise/passwords_spec.rb
+++ b/spec/requests/eva/devise/passwords_spec.rb
@@ -2,6 +2,32 @@
 
 require "rails_helper"
 
+RSpec.describe "Eva::Devise::PasswordsController#update", type: :request do
+  describe "PUT /admin/password" do
+    context "avec un token valide et des mots de passe non conformes" do
+      let!(:compte) { create(:compte) }
+
+      it "réaffiche le formulaire sans erreur NoMethodError sur @reset_password" do
+        raw_token, _hashed = Devise.token_generator.generate(Compte, :reset_password_token)
+        compte.update!(
+          reset_password_token: Devise.token_generator.digest(Compte, :reset_password_token, raw_token),
+          reset_password_sent_at: Time.current
+        )
+
+        put compte_password_path, params: {
+          compte: {
+            reset_password_token: raw_token,
+            password: "court",
+            password_confirmation: "court"
+          }
+        }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end
+
 RSpec.describe "Eva::Devise::PasswordsController#create", type: :request do
   describe "POST /admin/password" do
     context "avec un email inconnu" do

--- a/spec/services/reset_password/page_context_spec.rb
+++ b/spec/services/reset_password/page_context_spec.rb
@@ -77,40 +77,4 @@ RSpec.describe ResetPassword::PageContext do
       expect(context.redirect_path_si_token_invalide).to eq(chemin_attendu)
     end
   end
-
-  describe "#regles_mot_de_passe_cle et #hint_mot_de_passe" do
-    let(:action_name) { "edit" }
-    let(:i18n_passwords_edit) { "active_admin.devise.passwords.edit" }
-    let(:compte) { create(:compte, role: :superadmin) }
-    let(:raw_token) do
-      raw, hashed = Devise.token_generator.generate(Compte, :reset_password_token)
-      compte.update!(reset_password_token: hashed, reset_password_sent_at: Time.zone.now.utc)
-      raw
-    end
-    let(:reset_password_token) { raw_token }
-
-    it "utilise les règles ANLCI pour un compte ANLCI" do
-      expect(context.regles_mot_de_passe_cle).to eq(:regles_mot_de_passe_anlci)
-      expect(context.hint_mot_de_passe).to eq(
-        I18n.t(:hint_password_anlci, scope: i18n_passwords_edit)
-      )
-    end
-  end
-
-  describe "#regles_mot_de_passe_cle pour un conseiller" do
-    let(:action_name) { "edit" }
-    let(:i18n_passwords_edit) { "active_admin.devise.passwords.edit" }
-    let(:compte) { create(:compte_conseiller, :structure_avec_admin) }
-    let(:raw_token) do
-      raw, hashed = Devise.token_generator.generate(Compte, :reset_password_token)
-      compte.update!(reset_password_token: hashed, reset_password_sent_at: Time.zone.now.utc)
-      raw
-    end
-    let(:reset_password_token) { raw_token }
-
-    it "utilise les règles standard" do
-      expect(context.regles_mot_de_passe_cle).to eq(:regles_mot_de_passe)
-      expect(context.hint_mot_de_passe).to eq(I18n.t(:hint_password, scope: i18n_passwords_edit))
-    end
-  end
 end


### PR DESCRIPTION

https://app.rollbar.com/a/eva-betagouv/fix/item/eva-serveur/340

Au passage, j'ai supprimé l'affichage de la règle de mot de passe qui était au mauvais endroit, redondant et faux dans certains cas.
<img width="926" height="742" alt="Capture d’écran 2026-06-17 à 13 01 04" src="https://github.com/user-attachments/assets/dca4b658-9496-46e5-9a5d-0a707163303b" />

<img width="917" height="824" alt="Capture d’écran 2026-06-17 à 13 00 35" src="https://github.com/user-attachments/assets/87c9c351-7bd9-423d-a0c6-95c80dda3b31" />

