### PR TITLE
Corrige l'import des variantes de questions

### DIFF
--- a/app/assets/stylesheets/admin/composants/_flash_messages.scss
+++ b/app/assets/stylesheets/admin/composants/_flash_messages.scss
@@ -18,6 +18,7 @@
 
   font-weight: normal;
   text-shadow: none;
+  white-space: pre-wrap;
 }
 
 body.logged_in {

--- a/app/models/import_export/import_xls.rb
+++ b/app/models/import_export/import_xls.rb
@@ -60,7 +60,8 @@ module ImportExport
     def message_erreur_validation(exception, index)
       I18n.t("import_export.import_xls.erreurs.validation",
              numero: index,
-             message: exception.record.errors.full_messages.to_sentence)
+             message: exception.record.errors.full_messages.to_sentence,
+             identifiant: exception.record.try(:nom_technique))
     end
   end
 end

--- a/app/models/import_export/questions/import.rb
+++ b/app/models/import_export/questions/import.rb
@@ -7,11 +7,19 @@ module ImportExport
         @headers = headers_attendus
       end
 
+      MAX_ERREURS_AFFICHEES = 5
+
       def import_from_xls(file)
         recupere_data(file)
         valide_headers
         errors = importe_ligne(@data)
-        raise Import::Error, errors.join("\n") if errors.any?
+        if errors.any?
+          message = errors.first(MAX_ERREURS_AFFICHEES).join("\n")
+          if errors.count > MAX_ERREURS_AFFICHEES
+            message += "\n... et #{errors.count - MAX_ERREURS_AFFICHEES} autres erreurs"
+          end
+          raise Import::Error, message
+        end
       end
 
       private

--- a/app/models/import_export/questions/import.rb
+++ b/app/models/import_export/questions/import.rb
@@ -72,7 +72,10 @@ module ImportExport
 
       def cree_reponse_generique(question_id:, intitule:, nom_technique:, type_choix:,
                                  position_client: nil)
-        choix = Choix.where(nom_technique: nom_technique).first_or_initialize
+        choix = Choix.where(
+          nom_technique: nom_technique,
+          question_id: question_id
+        ).first_or_initialize
         choix.assign_attributes(intitule: intitule, question_id: question_id,
                                 type_choix: type_choix, position_client: position_client)
         choix.save!

--- a/config/locales/models/choix.yml
+++ b/config/locales/models/choix.yml
@@ -28,4 +28,3 @@ fr:
         delete_model: Supprimer
         new_model: Créer un choix
         edit_model: Modifier
-        delete_model: Supprimer

--- a/config/locales/models/import_export/import_xls.yml
+++ b/config/locales/models/import_export/import_xls.yml
@@ -3,6 +3,6 @@ fr:
     import_xls:
       erreurs:
         telechargement_impossible: "Impossible de télécharger le fichier à l'URL %{url}"
-        validation: "Erreur de validation à la ligne %{numero} : %{message}"
+        validation: "Erreur de validation à la ligne %{numero} %{identifiant} : %{message}"
         mauvais_format: |
           Le fichier n'est pas au bon format. Il doit contenir les colonnes dans l'ordre suivant : %{headers}

--- a/spec/models/import_export/questions/import/question_qcm_spec.rb
+++ b/spec/models/import_export/questions/import/question_qcm_spec.rb
@@ -33,6 +33,18 @@ describe ImportExport::Questions::Import::QuestionQcm do
     expect(choix2.illustration.attached?).to be true
   end
 
+  it "ne vole pas les choix d'une autre question lors de la création" do
+    autre_question = create(:question_qcm)
+    choix_existant = create(:choix, :bon, question_id: autre_question.id,
+                                         nom_technique: 'Choix1', intitule: 'Choix1')
+
+    service.import_from_xls(file)
+    question = Question.where.not(id: autre_question.id).first
+
+    expect(choix_existant.reload.question_id).to eq(autre_question.id)
+    expect(question.choix.find_by(nom_technique: 'Choix1')).to be_present
+  end
+
   it 'supprime les choix absents du fichier importé' do
     service.import_from_xls(file)
     question = Question.first

--- a/spec/models/import_export/questions/import_spec.rb
+++ b/spec/models/import_export/questions/import_spec.rb
@@ -70,6 +70,18 @@ describe ImportExport::Questions::Import do
     end
   end
 
+  describe '#message_erreur_validation' do
+    it "utilise une chaîne vide comme identifiant si le record n'a pas de nom_technique" do
+      transcription = Transcription.new
+      transcription.errors.add(:base, 'une erreur')
+      exception = ActiveRecord::RecordInvalid.new(transcription)
+
+      message = service.send(:message_erreur_validation, exception, 0)
+
+      expect(message).to include('Erreur de validation à la ligne 0  :')
+    end
+  end
+
   describe 'avec de nombreuses erreurs de validation' do
     let(:file) { instance_double(ActionDispatch::Http::UploadedFile) }
     let(:nb_erreurs) { ImportExport::Questions::Import::MAX_ERREURS_AFFICHEES + 5 }

--- a/spec/models/import_export/questions/import_spec.rb
+++ b/spec/models/import_export/questions/import_spec.rb
@@ -69,4 +69,25 @@ describe ImportExport::Questions::Import do
       end.to raise_error(ImportExport::Questions::Import::Error, message)
     end
   end
+
+  describe 'avec de nombreuses erreurs de validation' do
+    let(:file) { instance_double(ActionDispatch::Http::UploadedFile) }
+    let(:nb_erreurs) { ImportExport::Questions::Import::MAX_ERREURS_AFFICHEES + 5 }
+
+    before do
+      allow(service).to receive(:recupere_data)
+      allow(service).to receive(:valide_headers)
+      allow(service).to receive(:importe_ligne)
+        .and_return(Array.new(nb_erreurs) { |i| "Erreur à la ligne #{i}" })
+    end
+
+    it "limite le nombre de messages d'erreur pour éviter le dépassement du cookie de session" do
+      expect { service.import_from_xls(file) }
+        .to raise_error(ImportExport::Questions::Import::Error) do |error|
+          nombre_de_ligne = ImportExport::Questions::Import::MAX_ERREURS_AFFICHEES + 1
+          expect(error.message.lines.count).to eq nombre_de_ligne
+          expect(error.message).to include('autres erreurs')
+        end
+    end
+  end
 end


### PR DESCRIPTION
On ne pouvait pas importer un fichier avec des réponses ayant le même id_technique qu'une question déjà existante.

Cette PR corrige aussi l'erreur rollbar 
https://app.rollbar.com/a/eva-betagouv/fix/item/eva-serveur/344

CookieOverflow 🤢

Maintenant on limite l'affichage des erreurs aux 5 premières erreurs pour ne pas dépasser la capacité du Cookie.