### PR TITLE
🐛 Restaure l'accés au campagne evapro en lecture

### DIFF
--- a/app/models/ability_utilisateur.rb
+++ b/app/models/ability_utilisateur.rb
@@ -5,9 +5,8 @@ class AbilityUtilisateur
   def initialize(compte)
     @compte = compte
 
-    droits_superadmin compte
+    droit_superadmin compte
     droit_campagne compte
-    droit_admin_campagne(compte) if compte.admin?
     droit_evaluation compte
     droit_beneficiaire compte
     droit_evenement compte
@@ -18,19 +17,26 @@ class AbilityUtilisateur
     droits_cmr if compte.charge_mission_regionale?
   end
 
+  def droit_campagne(compte)
+    if compte.utilisateur_evapro?
+      droit_campagne_evapro compte
+    else
+      droit_campagne_eva compte
+      droit_admin_campagne_eva(compte) if compte.admin?
+    end
+  end
+
   def can_update_active_pour_campagne?(campagne)
     @compte.au_moins_admin? || campagne.compte_id == @compte.id
   end
 
   private
 
-  def droits_superadmin(compte)
+  def droit_superadmin(compte)
     can :manage, :all if compte.superadmin?
   end
 
-  def droit_campagne(compte)
-    return if compte.utilisateur_evapro?
-
+  def droit_campagne_eva(compte)
     cannot :destroy, Campagne
     can(:destroy, Campagne) { |c| Evaluation.where(campagne: c).empty? }
     can %i[read update autoriser_compte revoquer_compte play destroy], Campagne,
@@ -43,11 +49,13 @@ compte_id: compte.id
     can %i[read], Campagne, campagnes_publique_de_la_structure(compte)
   end
 
-  def droit_admin_campagne(compte)
-    return if compte.utilisateur_evapro?
-
+  def droit_admin_campagne_eva(compte)
     can %i[read update autoriser_compte revoquer_compte play destroy], Campagne,
       campagnes_de_la_structure(compte)
+  end
+
+  def droit_campagne_evapro(compte)
+    can %i[read play], Campagne, compte_id: compte.id
   end
 
   def droit_evaluation(compte)

--- a/spec/integrations/ability_spec.rb
+++ b/spec/integrations/ability_spec.rb
@@ -556,14 +556,14 @@ describe Ability do
   context 'Compte utilisateur entreprise (EvaPro)' do
     let(:structure_entreprise) { create :structure_locale, :eva_pro }
     let(:compte) { create :compte_admin, structure: structure_entreprise }
-    let!(:campagne_entreprise) { create :campagne, :avec_parcours_evapro, compte: compte }
+    let!(:campagne_evapro) { create :campagne, :avec_parcours_evapro, compte: compte }
     let!(:evaluation_evapro) do
-      EvaluationEvapro.create!(campagne: campagne_entreprise,
+      EvaluationEvapro.create!(campagne: campagne_evapro,
                                 beneficiaire: create(:beneficiaire),
                                 debutee_le: 1.hour.ago)
     end
     let!(:evaluation_eva) do
-      create :evaluation, campagne: campagne_entreprise, beneficiaire: create(:beneficiaire)
+      create :evaluation, campagne: campagne_evapro, beneficiaire: create(:beneficiaire)
     end
 
     it 'a accès en lecture et en suppression aux EvaluationEvapro de sa structure' do
@@ -578,8 +578,20 @@ describe Ability do
       expect(subject).not_to be_able_to(:read, Beneficiaire)
     end
 
-    it "n'a pas accès en lecture au modèle Campagne" do
-      expect(subject).not_to be_able_to(:read, Campagne)
+    it "a accès en lecture et en lancement (play) à sa propre campagne" do
+      expect(subject).to be_able_to(%i[read play], campagne_evapro)
+    end
+
+    it "n'a pas accès en modification, suppression, autorisation ou duplication à sa campagne" do
+      expect(subject).not_to be_able_to(
+        %i[update destroy autoriser_compte revoquer_compte duplique],
+        campagne_evapro
+      )
+    end
+
+    it "n'a pas accès en lecture aux campagnes d'une autre structure" do
+      autre_campagne = create :campagne, :avec_parcours_evapro
+      expect(subject).not_to be_able_to(:read, autre_campagne)
     end
   end
 


### PR DESCRIPTION
Sinon elles n'apparaissent pas sur le tableau de bord.