### PR TITLE
💄 Ajoute une marge pour que le titre d'une structure ne s'affiche pas sur le dessin de bienvenue.

### DIFF
--- a/app/assets/stylesheets/admin/composants/_panel.scss
+++ b/app/assets/stylesheets/admin/composants/_panel.scss
@@ -56,6 +56,7 @@ body.logged_out #content_wrapper #active_admin_content {
 
 .panel {
   &.panel-introduction {
+    margin-top: 2rem;
     padding: 1rem 1.5rem;
     display: flex;
     line-height: 1.2;


### PR DESCRIPTION
# avant

<img width="1900" height="730" alt="image" src="https://github.com/user-attachments/assets/c9a58c1d-848e-412c-978a-494d458133b5" />

# après
<img width="1338" height="497" alt="Capture d’écran 2026-07-29 à 16 22 28" src="https://github.com/user-attachments/assets/20911cdc-250f-4c36-8f81-7a333207bdcc" />
