### PR TITLE
🐛 Corrige l'apparition de bénéficiaires en double quand on filtre par structure

### DIFF
--- a/app/admin/beneficiaire.rb
+++ b/app/admin/beneficiaire.rb
@@ -89,7 +89,7 @@ ActiveAdmin.register Beneficiaire do
     end
 
     def scoped_collection
-      end_of_association_chain
+      end_of_association_chain.distinct
     end
 
     def restitutions_positionnement

--- a/spec/controllers/admin/beneficiaires_controller_spec.rb
+++ b/spec/controllers/admin/beneficiaires_controller_spec.rb
@@ -29,4 +29,30 @@ describe Admin::BeneficiairesController, type: :controller do
       expect(beneficiaire_json["code_beneficiaire"]).to eq("ABC123")
     end
   end
+
+  describe "filtre par structure" do
+    let(:structure) { create :structure_locale }
+    let!(:compte) { create :compte_admin, structure: structure }
+    let!(:autre_campagne) { create :campagne, compte: compte }
+    let!(:campagne) { create :campagne, compte: compte }
+    let!(:beneficiaire) { create :beneficiaire }
+    let!(:evaluation) { create :evaluation, campagne: campagne, beneficiaire: beneficiaire }
+    let!(:autre_evaluation) do
+      create :evaluation, campagne: autre_campagne, beneficiaire: beneficiaire
+    end
+
+    before { sign_in compte }
+
+    it "ne retourne pas le bénéficiaire en double quand il a plusieurs évaluations par structure" do
+      get :index, format: :json,
+        params: { q: { evaluations_campagne_compte_structure_id_eq: structure.id } }
+
+      expect(response).to be_successful
+
+      resultat = response.parsed_body
+      occurrences = resultat.select { |b| b["id"] == beneficiaire.id }
+
+      expect(occurrences.size).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
Ça corrige aussi quand on filtre par campagne.

## avant
<img width="1261" height="846" alt="Capture d’écran 2026-08-03 à 11 36 13" src="https://github.com/user-attachments/assets/5f11f568-96bb-4c06-be95-6939c1ebb58d" />

## après
<img width="1270" height="850" alt="Capture d’écran 2026-08-03 à 11 35 57" src="https://github.com/user-attachments/assets/5af97908-04ef-451b-8ffb-057b20fd6ad6" />
