### PR TITLE
🐛 Restitution contrôle : l'événement abandon n'est pas toujours en dernier

### DIFF
--- a/app/models/restitution/base/evenements_helper.rb
+++ b/app/models/restitution/base/evenements_helper.rb
@@ -29,7 +29,7 @@ module Restitution
       end
 
       def abandon?
-        dernier_evenement.nom == EVENEMENT[:ABANDON]
+        @evenements.any? { |evenement| evenement.nom == EVENEMENT[:ABANDON] }
       end
 
       def termine?

--- a/spec/factories/evenement.rb
+++ b/spec/factories/evenement.rb
@@ -48,6 +48,10 @@ FactoryBot.define do
       nom { 'abandon' }
     end
 
+    factory :evenement_piece_apparition do
+      nom { 'pieceApparition' }
+    end
+
     factory :evenement_piece_bien_placee do
       nom { 'pieceBienPlacee' }
     end

--- a/spec/models/restitution/base_spec.rb
+++ b/spec/models/restitution/base_spec.rb
@@ -5,19 +5,32 @@ describe Restitution::Base do
   let(:campagne)    { build(:campagne) }
   let(:restitution) { described_class.new(campagne, evenements) }
   let(:evaluation)  { create :evaluation }
-  let(:situation)   { create :situation_inventaire }
+  let(:situation)   { create :situation_controle }
   let!(:partie) { create :partie, evaluation: evaluation, situation: situation }
 
-  context 'lorsque le dernier événement est stop' do
-    let!(:evenements) do
-      [
-        create(:evenement_piece_bien_placee, partie: partie),
-        create(:evenement_piece_mal_placee, partie: partie),
-        create(:evenement_abandon, partie: partie)
-      ]
+  describe "#abandon?" do
+    context "lorsque l'événement est en dernier" do
+      let!(:evenements) do
+        [
+          create(:evenement_piece_bien_placee, partie: partie),
+          create(:evenement_piece_mal_placee, partie: partie),
+          create(:evenement_abandon, partie: partie)
+        ]
+      end
+
+      it { expect(restitution.abandon?).to be(true) }
     end
 
-    it { expect(restitution.abandon?).to be(true) }
+    context "lorsque l'événement n'est pas en dernier" do
+      let!(:evenements) do
+        [
+          create(:evenement_abandon, partie: partie),
+          create(:evenement_piece_apparition, partie: partie)
+        ]
+      end
+
+      it { expect(restitution.abandon?).to be(true) }
+    end
   end
 
   context 'renvoie le nombre de réécoute de la consigne' do


### PR DESCRIPTION
## avant
<img width="1258" height="989" alt="Capture d’écran 2026-08-03 à 12 26 23" src="https://github.com/user-attachments/assets/d1cfd5a8-c1aa-4908-86d9-a892462ab553" />

## après 
<img width="1260" height="989" alt="Capture d’écran 2026-08-03 à 12 26 00" src="https://github.com/user-attachments/assets/a6b7bc04-b98e-4b70-9321-81d48e8ca529" />
