### PR TITLE
💄 Remet le fil d'ariane partout, sauf le tableau de bord evapro

### DIFF
--- a/app/assets/stylesheets/admin/_adaptation_dsfr.scss
+++ b/app/assets/stylesheets/admin/_adaptation_dsfr.scss
@@ -47,6 +47,7 @@ a.pas-souligne {
 }
 
 body.logged_in {
+
   &::before,
   &::after {
     display: none !important;
@@ -66,24 +67,6 @@ body.logged_in.evapro_admin {
   .header {
     max-width: none;
     margin: 0;
-  }
-
-  #title_bar {
-    display: none;
-  }
-
-  #title_bar,
-  #active_admin_content {
-    max-width: 75rem;
-    margin: 0 auto;
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-  }
-  
-  // EvaPro admin: ajustements des marges entre le Header et le Footer pour les vues non custo
-  #active_admin_content.with_sidebar {
-    margin-top: 2rem !important;
-    margin-bottom: 3.5rem !important;
   }
 }
 
@@ -186,7 +169,7 @@ body.logged_in.evapro_admin {
   // (invitation structure, vérification comptes en attente, etc.). Sans ça, le
   // `pointer-events: none` sur `.fr-modal > .fr-container` bloque boutons et formulaires.
   // Exclure le menu burger header : son `.fr-container` doit rester géré à part.
-  .fr-modal.fr-modal--opened:not(.fr-header__menu) > .fr-container {
+  .fr-modal.fr-modal--opened:not(.fr-header__menu)>.fr-container {
     pointer-events: auto;
   }
 }
@@ -217,13 +200,6 @@ body.logged_out #wrapper .fr-modal__content ul li,
   line-height: 1.5rem;
 }
 
-// Boutons DSFR dans les modales (hors body.evapro_admin / body.logged_in)
-.fr-modal.evapro_admin .fr-btn {
-  @include grand-bouton;
-
-  border-radius: 0;
-}
-
 button.fr-link--close {
   border-radius: 0;
   background: transparent;
@@ -237,19 +213,11 @@ button.fr-link--close {
     @include focus;
   }
 }
+
 button.fr-link--close:not(.disabled):hover {
   @include light-decisions-background-transparent-hover;
 
   background-image: none;
-}
-
-.fr-modal.evapro_admin .fr-btn--secondary,
-.fr-modal.evapro_admin .fr-btn--tertiary {
-  color: var(--text-action-high-blue-france);
-}
-
-.fr-modal.evapro_admin .fr-btn--tertiary:hover {
-  background: var(--background-raised-grey-hover);
 }
 
 body.evapro_admin a:not(.fr-btn),
@@ -269,18 +237,19 @@ body.evapro_admin .fr-btn:not(.fr-btn--secondary, .fr-btn--tertiary, .fr-btn--me
 
 .fr-btn--sm,
 .bouton-annuler {
-  align-self: flex-start; 
+  align-self: flex-start;
   min-height: 2rem;
   line-height: normal !important;
-};
+}
 
 .fr-btn--md {
-  align-self: flex-start; 
+  align-self: flex-start;
   min-height: 2.5rem;
   line-height: normal !important;
 }
 
 .fr-btn {
+
   &:-moz-focusring,
   &:focus-visible {
     @include focus;
@@ -343,10 +312,7 @@ input[type="submit"].fr-btn:not(.disabled):hover,
 input[type="button"].fr-btn:not(.disabled):hover,
 form button.fr-btn:not(.disabled):hover,
 form input[type="submit"].fr-btn:not(.disabled):hover,
-form input[type="button"].fr-btn:not(.disabled):hover,
-// Boutons avec attribut form= (hors du formulaire, ex. modale invitation)
-.fr-modal.evapro_admin button.fr-btn:not(.disabled):hover,
-.fr-modal.evapro_admin input[type="submit"].fr-btn:not(.disabled):hover {
+form input[type="button"].fr-btn:not(.disabled):hover {
 
   &.fr-btn--primary,
   &:not(.fr-btn--secondary, .fr-btn--tertiary, .fr-btn--close) {
@@ -576,7 +542,7 @@ a.fr-btn.fr-btn--tertiary:active {
   box-shadow: inset 0 0 0 1px $grey-900;
 }
 
-.fr-btn--primary.bouton--actif{
+.fr-btn--primary.bouton--actif {
   background: $blue-france-sun-113-active;
 
   &:hover {

--- a/app/assets/stylesheets/admin/composants/_scopes.scss
+++ b/app/assets/stylesheets/admin/composants/_scopes.scss
@@ -1,11 +1,12 @@
 @mixin reset-ul() {
+
   ul,
   ul li,
   ul ul li {
-     margin:0;
-     padding: 0;
-     text-indent: 0;
-     list-style-type: none;
+    margin: 0;
+    padding: 0;
+    text-indent: 0;
+    list-style-type: none;
   }
 }
 
@@ -13,7 +14,7 @@
   display: flex;
   justify-content: space-between;
   gap: 1rem;
-  margin-bottom: 0.5rem;
+  margin-bottom: $dsfr-spacing-2w;
 }
 
 .scopes {
@@ -43,6 +44,7 @@
 
   .scope:first-child {
     display: flex;
+
     &::before {
       content: '';
       display: inline-block;

--- a/app/assets/stylesheets/admin/layout/_breadcrumb.scss
+++ b/app/assets/stylesheets/admin/layout/_breadcrumb.scss
@@ -5,6 +5,8 @@
   background-image: none;
   box-shadow: none;
   background-color: unset;
+  margin: $dsfr-spacing-4w auto 0;
+  max-width: $container;
 
   #titlebar_left {
     display: block;
@@ -30,7 +32,8 @@
     .breadcrumb {
       margin-bottom: 0.5rem;
 
-      a, .breadcrumb_sep {
+      a,
+      .breadcrumb_sep {
         color: $couleur-texte;
       }
 

--- a/app/assets/stylesheets/admin/layout/_content.scss
+++ b/app/assets/stylesheets/admin/layout/_content.scss
@@ -2,6 +2,7 @@ body.logged_in {
   #wrapper {
     position: relative;
   }
+
   &::before,
   &::after {
     content: '';
@@ -11,27 +12,20 @@ body.logged_in {
     position: absolute;
     left: 0;
   }
+
   &::before {
     top: 0;
     background-color: $eva_main_blue;
   }
+
   &::after {
     top: 64px;
     background-color: $eva_bluegrey;
   }
 
-  #title_bar, #active_admin_content {
-    max-width: $container;
-    margin: 0 auto;
-  }
-
-  // Eva admin: ajustements des marges entre le Header et le Footer
-  #title_bar {
-    margin-top: 2rem;
-  }
-
   #active_admin_content {
-    margin-bottom: 3.5rem;
+    max-width: $container;
+    margin: 0 auto 3.5rem;
   }
 }
 

--- a/app/assets/stylesheets/admin/layout/_main_structure.scss
+++ b/app/assets/stylesheets/admin/layout/_main_structure.scss
@@ -20,14 +20,3 @@ body.logged_in {
     }
   }
 }
-
-// Layout spécifique Evapro : exclut le dashboard EvaPro.
-body.logged_in.evapro_admin:not(.admin_dashboard) #active_admin_content #main_content_wrapper #main_content,
-body.logged_in.evapro_admin.admin_evaluations #active_admin_content #main_content_wrapper #main_content {
-  display: flex;
-  padding: $dsfr-spacing-4w 0 $dsfr-spacing-7w 0;
-  flex-direction: column;
-  align-items: stretch;
-  gap: $dsfr-spacing-8w;
-  flex: 1 0 0;
-}

--- a/app/assets/stylesheets/admin/pages/_evapro.scss
+++ b/app/assets/stylesheets/admin/pages/_evapro.scss
@@ -12,6 +12,7 @@
 
   .evaluation-evapro__titre {
     margin-bottom: 0;
+    margin-top: $dsfr-spacing-3w;
     color: var(--text-title-grey);
 
     @include titre-h2;

--- a/app/assets/stylesheets/admin/pages/dashboard/_dashboard.scss
+++ b/app/assets/stylesheets/admin/pages/dashboard/_dashboard.scss
@@ -4,6 +4,10 @@
 
   @import "../../../bootstrap_grid";
 
+  &.evapro_admin #title_bar {
+    display: none;
+  }
+
   .section-evaluations,
   .section-actualites {
     margin-bottom: 2.5rem;

--- a/app/assets/stylesheets/admin/pages/dashboard/_modal_dashboard_dsfr.scss
+++ b/app/assets/stylesheets/admin/pages/dashboard/_modal_dashboard_dsfr.scss
@@ -1,11 +1,11 @@
-.fr-modal-dashboard-evapro.fr-modal.fr-modal--opened {
+.fr-modal-ancien-style-eva.fr-modal.fr-modal--opened {
   display: flex !important;
   visibility: inherit !important;
   opacity: 1 !important;
   background-color: rgba(255, 255, 255, 0.9);
 }
 
-.fr-modal-dashboard-evapro {
+.fr-modal-ancien-style-eva {
   .fr-modal__header {
     display: none;
   }
@@ -49,7 +49,7 @@
   }
 
 
-  .fr-modal-dashboard-evapro__actions {
+  .fr-modal-ancien-style-eva__actions {
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-end;

--- a/app/views/admin/beneficiaires/_modal_fusion.html.erb
+++ b/app/views/admin/beneficiaires/_modal_fusion.html.erb
@@ -5,7 +5,7 @@
   title: t(".titre").html_safe,
   html_attributes: {
     id: id_modal,
-    class: "fr-modal-fusion evapro_admin",
+    class: "fr-modal-fusion",
     data: { fusion_batch_action: batch_action_admin_beneficiaires_path }
   }
 ) do |component| %>

--- a/app/views/admin/comptes/_modal_verification.html.erb
+++ b/app/views/admin/comptes/_modal_verification.html.erb
@@ -1,10 +1,4 @@
-
-<%
-  usage_evapro = current_compte.structure&.evapro?
-  modal_classes = "fr-modal-verification"
-  modal_classes += " evapro_admin" if usage_evapro
-%>
-<%= dsfr_modal(title: t(".titre").html_safe, html_attributes: { id: "fr-modal-#{compte.id}", class: modal_classes }) do %>
+<%= dsfr_modal(title: t(".titre").html_safe, html_attributes: { id: "fr-modal-#{compte.id}", class: "fr-modal-verification" }) do %>
   <div class="contenu-modale">
     <div class="contenu">
       <%= form_with url: verifier_admin_compte_path(compte), method: :patch, local: true do |f| %>

--- a/app/views/admin/dashboard/_modal_confirmation_cgu.html.erb
+++ b/app/views/admin/dashboard/_modal_confirmation_cgu.html.erb
@@ -13,7 +13,7 @@
   opened: true,
   html_attributes: {
     id: id_modal,
-    class: "fr-modal-confirmation-cgu fr-modal-dashboard-evapro evapro_admin",
+    class: "fr-modal-confirmation-cgu fr-modal-ancien-style-eva",
     "data-fr-concealing-backdrop": "false"
   }
 ) do %>
@@ -22,7 +22,7 @@
       <%= render partial: "admin/comptes/demande_acceptation_cgu_creation_compte",
         locals: { scope: "admin.dashboard.modal_confirmation_cgu" } %>
     </div>
-    <div class="fr-modal-dashboard-evapro__actions">
+    <div class="fr-modal-ancien-style-eva__actions">
       <%= render BoutonDsfrComponent.new(
         accepter_cgu_admin_compte_path(current_compte),
         type: :primary,

--- a/app/views/admin/dashboard/_modal_validation_comptes_en_attente.html.erb
+++ b/app/views/admin/dashboard/_modal_validation_comptes_en_attente.html.erb
@@ -14,7 +14,7 @@
   opened: true,
   html_attributes: {
     id: id_modal,
-    class: "fr-modal-validation-comptes fr-modal-dashboard-evapro evapro_admin",
+    class: "fr-modal-validation-comptes fr-modal-ancien-style-eva",
     "data-fr-concealing-backdrop": "true"
   }
 ) do |component| %>
@@ -22,7 +22,7 @@
     <div class="message">
       <%= md t(".info_comptes_en_attente") %>
     </div>
-    <div class="fr-modal-dashboard-evapro__actions">
+    <div class="fr-modal-ancien-style-eva__actions">
       <%= render BoutonDsfrComponent.new(
         "#",
         type: :secondary,

--- a/app/views/admin/evaluations_evapro/_index.html.arb
+++ b/app/views/admin/evaluations_evapro/_index.html.arb
@@ -1,7 +1,6 @@
 vue = self
 
 caption do
-  text_node t(".titre")
   div class: "fr-table__caption__desc" do
     t(".texte")
   end

--- a/app/views/admin/ui_kit/boutons_dsfr.html.erb
+++ b/app/views/admin/ui_kit/boutons_dsfr.html.erb
@@ -1,4 +1,4 @@
-<div class="container evapro_admin">
+<div class="container">
   <h1 class="fr-h1 fr-mt-6w">Démo BoutonDsfrComponent</h1>
   <h2 class="fr-h2 fr-mt-6w">Tag a (défaut)</h2>
   <h3 class="fr-h3 fr-mt-4w">Primaire</h3>

--- a/app/views/inscription/structures/_modal_confirmation_creation_structure.html.erb
+++ b/app/views/inscription/structures/_modal_confirmation_creation_structure.html.erb
@@ -2,12 +2,12 @@
 
 <%= dsfr_modal(
   title: t(".titre"),
-  html_attributes: { id: id_modal, class: "evapro_admin" }
+  html_attributes: { id: id_modal }
 ) do |component| %>
   <div>
     <%= md t(".message") %>
   </div>
-  
+
   <% component.with_button do %>
     <%= render BoutonDsfrComponent.new(
       t(".creer_structure"),

--- a/config/locales/models/evaluation_evapro.yml
+++ b/config/locales/models/evaluation_evapro.yml
@@ -1,4 +1,9 @@
 fr:
+  activerecord:
+    models:
+      evaluation_evapro:
+        one: Évaluation
+        other: Évaluations
   active_admin:
     resources:
       evaluation_evapro:

--- a/config/locales/views/evaluations_evapro.yml
+++ b/config/locales/views/evaluations_evapro.yml
@@ -2,7 +2,6 @@ fr:
   admin:
     evaluations_evapro:
       index:
-        titre: "Évaluations"
         texte: "Cette page présente toutes les évaluations réalisées au sein de votre structure, qu'elles soient terminées ou en cours."
         colonne_par: Par
         colonne_date: Date


### PR DESCRIPTION
Par souci d'homogénéité entre les deux univers eva et evapro et une meilleure conformité activeadmin.
Sur le plan de l'accessibilité, cette PR répare aussi la structure de titre de des pages des évaluations.

<img width="1279" height="556" alt="Capture d’écran 2026-08-03 à 18 41 53" src="https://github.com/user-attachments/assets/193751fc-aa26-4664-8268-c8d7ac560253" />
<img width="1287" height="678" alt="Capture d’écran 2026-08-03 à 18 42 00" src="https://github.com/user-attachments/assets/3a236a67-3110-4697-af1f-e29c114fa6e0" />
<img width="1269" height="665" alt="Capture d’écran 2026-08-03 à 18 42 04" src="https://github.com/user-attachments/assets/c10da17b-8582-47f1-b936-68dc70e61d3a" />
<img width="1310" height="661" alt="Capture d’écran 2026-08-03 à 18 42 16" src="https://github.com/user-attachments/assets/f6bb8de1-e561-4ba2-b95c-2285b441f8a3" />
<img width="1264" height="615" alt="Capture d’écran 2026-08-03 à 18 42 21" src="https://github.com/user-attachments/assets/cedd28b0-0484-4cf5-9a4a-257519e7c793" />
<img width="1309" height="584" alt="Capture d’écran 2026-08-03 à 18 42 30" src="https://github.com/user-attachments/assets/566ff4d6-24ba-4aed-b150-beff5913f561" />
