### PR TITLE
🐛 Corrige la génération de PDF cassée par puppeteer-ruby 0.53.0

### DIFF
--- a/app/models/pdf/generator.rb
+++ b/app/models/pdf/generator.rb
@@ -29,7 +29,8 @@ module Pdf
           timeout: 60_000
         )
       else
-        page.set_content(html_content, wait_until: "networkidle2")
+        page.set_content(html_content, wait_until: "load")
+        page.wait_for_network_idle(concurrency: 2)
       end
       pause_pdf if Pdf::Browser.debug_mode?
       page


### PR DESCRIPTION
set_content ne supporte plus wait_until: networkidle2 depuis la mise à jour des dépendances ruby ; on compose désormais set_content (wait_until: load) avec wait_for_network_idle comme recommandé par la gem.