### PR TITLE
🐛 Sérialise avec un mutex l'accès au Chrome headless partagé pour les exports PDF

### DIFF
--- a/app/models/pdf/browser.rb
+++ b/app/models/pdf/browser.rb
@@ -7,6 +7,10 @@ module Pdf
 
     def self.instance
       @browser ||= Puppeteer.launch(**puppeteer_options)
+      @mutex ||= Mutex.new
+      @mutex.synchronize do
+        yield @browser
+      end
     end
 
     def self.puppeteer_options

--- a/app/models/pdf/generator.rb
+++ b/app/models/pdf/generator.rb
@@ -1,13 +1,14 @@
 module Pdf
   class Generator
     def generate(html_content, filename: "document-#{SecureRandom.uuid}")
-      browser = Pdf::Browser.instance
+      page = nil
+      Pdf::Browser.instance do |browser|
+        page = prepare_page(browser, html_content)
 
-      page = prepare_page(browser, html_content)
-
-      page.pdf(**pdf_options(filename: filename))
-      page.close
-      file_path(filename)
+        page.pdf(**pdf_options(filename: filename))
+        page.close
+        file_path(filename)
+      end
     rescue => e
       Rails.logger.error("Chromium crash: #{e.message}")
       Rollbar.error(e)


### PR DESCRIPTION
Deux threads Puma pouvaient appeler Target.createTarget en même temps sur le même Pdf::Browser.instance, provoquant des Puppeteer::Browser::MissingTargetError en production (295 occurrences sur 2 semaines côté Rollbar) sous charge mémoire/CPU.

https://app.rollbar.com/a/eva-betagouv/fix/item/eva-serveur/385