### PR TITLE
✨ Évite le scolling horizontal sur la table compte et tri les structures

### DIFF
--- a/app/admin/annonce_generales.rb
+++ b/app/admin/annonce_generales.rb
@@ -10,7 +10,7 @@ ActiveAdmin.register AnnonceGenerale do
   filter :created_at
 
   index dsfr_table: proc { true } do
-    column :texte do |ag|
+    column :texte, class: "col-lien-voir" do |ag|
       link_to ag.texte, admin_annonce_generale_path(ag)
     end
     column :afficher

--- a/app/admin/campagnes.rb
+++ b/app/admin/campagnes.rb
@@ -102,7 +102,7 @@ ActiveAdmin.register Campagne do
     link_to(I18n.t("active_admin.campagnes.blank_slate_link"), new_resource_path)
   }, dsfr_table: proc { true },
     class: "fr-table--multiline" do
-      column :libelle do |campagne|
+      column :libelle, class: "col-lien-voir" do |campagne|
         div class: "contenu-libelle" do
           div do
             div link_to(campagne.libelle, admin_campagne_path(campagne))

--- a/app/admin/comptes.rb
+++ b/app/admin/comptes.rb
@@ -15,6 +15,11 @@ ActiveAdmin.register Compte do
 
   config.sort_order = "created_at_desc"
 
+  order_by(:prenom_nom) do |clause|
+    table = clause.active_admin_config.resource_table_name
+    "#{table}.prenom #{clause.order}, #{table}.nom #{clause.order}"
+  end
+
   filter :email
   filter :nom, filters: [ :contains_unaccent, :eq ]
   filter :prenom, filters: [ :contains_unaccent, :eq ]

--- a/app/admin/opcos.rb
+++ b/app/admin/opcos.rb
@@ -10,7 +10,7 @@ ActiveAdmin.register Opco do
   filter :financeur
 
   index dsfr_table: proc { true } do
-    column :nom do |opco|
+    column :nom, class: "col-lien-voir" do |opco|
       libelle = opco.nom
       if opco.logo.attached?
         logo = image_tag(cdn_for(opco.logo.variant(:defaut)),

--- a/app/admin/parcours_type.rb
+++ b/app/admin/parcours_type.rb
@@ -12,7 +12,7 @@ ActiveAdmin.register ParcoursType do
   form partial: "form"
 
   index dsfr_table: proc { true } do
-    column :libelle do |pt|
+    column :libelle, class: "col-lien-voir" do |pt|
       link_to pt.libelle, admin_parcours_type_path(pt)
     end
     column :actif

--- a/app/admin/questionnaires.rb
+++ b/app/admin/questionnaires.rb
@@ -57,7 +57,7 @@ ActiveAdmin.register Questionnaire do
   end
 
   index dsfr_table: proc { true } do
-    column :libelle do |q|
+    column :libelle, class: "col-lien-voir" do |q|
       link_to q.libelle, admin_questionnaire_path(q)
     end
     column :nom_technique

--- a/app/admin/questions_clic_dans_image.rb
+++ b/app/admin/questions_clic_dans_image.rb
@@ -17,7 +17,7 @@ ActiveAdmin.register QuestionClicDansImage do
   form partial: "form"
 
   index dsfr_table: proc { true } do
-    column :libelle do |q|
+    column :libelle, class: "col-lien-voir" do |q|
       link_to q.libelle, admin_question_clic_dans_image_path(q)
     end
     column :intitule do |question|

--- a/app/admin/questions_clic_dans_texte.rb
+++ b/app/admin/questions_clic_dans_texte.rb
@@ -24,7 +24,7 @@ ActiveAdmin.register QuestionClicDansTexte do
   form partial: "form"
 
   index dsfr_table: proc { true } do
-    column :libelle do |q|
+    column :libelle, class: "col-lien-voir" do |q|
       link_to q.libelle, admin_question_clic_dans_texte_path(q)
     end
     column :categorie

--- a/app/admin/questions_glisser_deposer.rb
+++ b/app/admin/questions_glisser_deposer.rb
@@ -25,7 +25,7 @@ ActiveAdmin.register QuestionGlisserDeposer do
   end
 
   index dsfr_table: proc { true } do
-    column :libelle do |q|
+    column :libelle, class: "col-lien-voir" do |q|
       link_to q.libelle, admin_question_glisser_deposer_path(q)
     end
     column :intitule do |question|

--- a/app/admin/questions_qcm.rb
+++ b/app/admin/questions_qcm.rb
@@ -25,7 +25,7 @@ ActiveAdmin.register QuestionQcm do
   end
 
   index dsfr_table: proc { true } do
-    column :libelle do |q|
+    column :libelle, class: "col-lien-voir" do |q|
       link_to q.libelle, admin_question_qcm_path(q)
     end
     column :categorie

--- a/app/admin/questions_saisie.rb
+++ b/app/admin/questions_saisie.rb
@@ -26,7 +26,7 @@ ActiveAdmin.register QuestionSaisie do
   form partial: "form"
 
   index dsfr_table: proc { true } do
-    column :libelle do |q|
+    column :libelle, class: "col-lien-voir" do |q|
       link_to q.libelle, admin_question_saisie_path(q)
     end
     column :categorie

--- a/app/admin/questions_sous_consigne.rb
+++ b/app/admin/questions_sous_consigne.rb
@@ -19,7 +19,7 @@ ActiveAdmin.register QuestionSousConsigne do
   form partial: "form"
 
   index dsfr_table: proc { true } do
-    column :libelle do |q|
+    column :libelle, class: "col-lien-voir" do |q|
       link_to q.libelle, admin_question_sous_consigne_path(q)
     end
     column :intitule do |question|

--- a/app/admin/situations.rb
+++ b/app/admin/situations.rb
@@ -25,7 +25,7 @@ ActiveAdmin.register Situation do
   end
 
   index dsfr_table: proc { true } do
-    column :illustration do |situation|
+    column :illustration, class: "col-lien-voir" do |situation|
       illustration = situation_illustration(situation)
       link_to illustration, admin_situation_path(situation) if illustration.present?
     end

--- a/app/admin/source_aides.rb
+++ b/app/admin/source_aides.rb
@@ -6,7 +6,7 @@ ActiveAdmin.register SourceAide do
   filter :description
 
   index dsfr_table: proc { true } do
-    column :titre do |sa|
+    column :titre, class: "col-lien-voir" do |sa|
       link_to sa.titre, admin_source_aide_path(sa)
     end
     column(:categorie) do |a|

--- a/app/admin/structures_administratives.rb
+++ b/app/admin/structures_administratives.rb
@@ -6,7 +6,7 @@ ActiveAdmin.register StructureAdministrative do
   filter :created_at
 
   index dsfr_table: proc { true } do
-    column :nom do |sa|
+    column :nom, class: "col-lien-voir" do |sa|
       link_to sa.nom, admin_structure_administrative_path(sa)
     end
     column :siret do |structure|

--- a/app/admin/structures_administratives.rb
+++ b/app/admin/structures_administratives.rb
@@ -1,4 +1,6 @@
 ActiveAdmin.register StructureAdministrative do
+  config.sort_order = "created_at_desc"
+
   permit_params :nom, :parent_id, :siret
 
   filter :nom, filters: [ :contains_unaccent, :eq ]

--- a/app/admin/structures_locales.rb
+++ b/app/admin/structures_locales.rb
@@ -34,7 +34,7 @@ ActiveAdmin.register StructureLocale do
   sidebar :aide_filtres, only: :index, if: -> { params[:stats] }
 
   index dsfr_table: proc { true }, class: "fr-table--multiline" do
-    column :nom do |sl|
+    column :nom, class: "col-lien-voir" do |sl|
       link_to sl.nom, admin_structure_locale_path(sl)
     end
     column(:type_structure) do |structure|

--- a/app/admin/structures_locales.rb
+++ b/app/admin/structures_locales.rb
@@ -1,6 +1,8 @@
 ActiveAdmin.register StructureLocale do
   actions :all
 
+  config.sort_order = "created_at_desc"
+
   permit_params :nom, :type_structure, :code_postal, :parent_id, :siret,
                 :autorisation_creation_campagne, :usage, :email_contact, :telephone
 

--- a/app/admin/structures_opcos.rb
+++ b/app/admin/structures_opcos.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register StructureOpco do
   filter :created_at
 
   index dsfr_table: proc { true } do
-    column :nom do |structure|
+    column :nom, class: "col-lien-voir" do |structure|
       link_to structure.nom, admin_structure_opco_path(structure)
     end
     column :siret do |structure|

--- a/app/admin/structures_opcos.rb
+++ b/app/admin/structures_opcos.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register StructureOpco do
-  # La position dans le menu est gérée par NavigationComponent
+  config.sort_order = "created_at_desc"
 
   permit_params :nom, :siret, :opco_id
 

--- a/app/assets/stylesheets/admin/composants/_active_admin_tableau_dsfr.scss
+++ b/app/assets/stylesheets/admin/composants/_active_admin_tableau_dsfr.scss
@@ -26,12 +26,6 @@
   border-bottom: 1px solid $grey-625;
 }
 
-.dsfr-table-active-admin table.index_table tbody tr td:first-child {
-  font-weight: 600;
-  border-left: none;
-  padding: $dsfr-spacing-1w $dsfr-spacing-2w;
-}
-
 .dsfr-table-active-admin table.index_table tbody tr td:last-child {
   border-right: none;
   padding: $dsfr-spacing-1w $dsfr-spacing-2w;

--- a/app/assets/stylesheets/admin/composants/_tables.scss
+++ b/app/assets/stylesheets/admin/composants/_tables.scss
@@ -22,17 +22,21 @@ table.index_table {
       background: none;
       padding-top: 0;
       padding-bottom: .5rem;
+
       &:first-child {
         padding-left: 1.375rem;
       }
+
       &:last-child {
         border-right: 0;
         width: 1px;
       }
+
       &.sorted-asc,
       &.sorted-desc {
         background: none;
       }
+
       a,
       a:link,
       a:visited {
@@ -40,13 +44,15 @@ table.index_table {
       }
     }
   }
+
   tbody {
     tr {
       border-radius: 0.5rem;
 
       @include ombre;
 
-      &.even, &.odd {
+      &.even,
+      &.odd {
         td {
           background-color: $grey-1000;
         }
@@ -58,29 +64,23 @@ table.index_table {
         vertical-align: middle;
         border-top: 1px solid $eva_bluegrey;
         border-bottom: 1px solid $eva_bluegrey;
-        color: $couleur-texte;
         background-color: $grey-1000;
-        &:first-child {
-          font-weight: 600;
-          padding-left: 1.375rem;
-          border-left: 1px solid $eva_bluegrey;
-          border-top-left-radius: 0.5rem;
-          border-bottom-left-radius: 0.5rem;
+
+        &.col-lien-voir {
           a {
+            font-weight: 600;
             background-image: none;
           }
         }
-        &:last-child {
-          border-right: 1px solid $eva_bluegrey;
-          border-top-right-radius: 0.5rem;
-          border-bottom-right-radius: 0.5rem;
-        }
+
         a {
           color: $eva_main_blue;
         }
+
         &.col-actions {
           @include menu-actions;
         }
+
         &.col-illustration {
           line-height: 0;
         }
@@ -113,6 +113,7 @@ table.index_table {
     background-image: none;
   }
 }
+
 .pagination_information {
   color: $couleur-texte;
 }

--- a/app/views/admin/beneficiaires/_index.html.arb
+++ b/app/views/admin/beneficiaires/_index.html.arb
@@ -1,6 +1,6 @@
 context.instance_eval do
   selectable_column if can?(:fusionner, Beneficiaire)
-  column :nom do |beneficiaire|
+  column :nom, class: "col-lien-voir" do |beneficiaire|
     render partial: "nom_beneficiaire", locals: { beneficiaire: beneficiaire }
   end
   column :code_beneficiaire

--- a/app/views/admin/comptes/_index.html.arb
+++ b/app/views/admin/comptes/_index.html.arb
@@ -1,9 +1,7 @@
 context.instance_eval do
-  column :prenom do |compte|
-    link_to compte.prenom, admin_compte_path(compte)
+  column :nom, class: "col-lien-voir", sortable: "prenom_nom" do |compte|
+    render partial: "nom", locals: { compte: compte }
   end
-  column :nom
-  column :email
   column :telephone
   column :statut_validation do |compte|
     traduis_acces(compte.statut_validation, compte.role)

--- a/app/views/admin/comptes/_nom.html.erb
+++ b/app/views/admin/comptes/_nom.html.erb
@@ -1,0 +1,3 @@
+<%= link_to compte.display_name, admin_compte_path(compte) %>
+<br>
+<%= compte.email %>

--- a/app/views/admin/evaluations_eva/_index.html.arb
+++ b/app/views/admin/evaluations_eva/_index.html.arb
@@ -1,5 +1,5 @@
 context.instance_eval do
-  column :beneficiaire, class: "evaluation__col-beneficiaire" do |evaluation|
+  column :beneficiaire, class: "evaluation__col-beneficiaire col-lien-voir" do |evaluation|
     render partial: "admin/evaluations_eva/beneficiaire", locals: { evaluation: evaluation }
   end
 

--- a/app/views/admin/evaluations_evapro/_index.html.arb
+++ b/app/views/admin/evaluations_evapro/_index.html.arb
@@ -7,7 +7,7 @@ caption do
 end
 
 context.instance_eval do
-  column t(".colonne_par"), sortable: "beneficiaires.nom" do |evaluation|
+  column t(".colonne_par"), sortable: "beneficiaires.nom", class: "col-lien-voir" do |evaluation|
     link_to(evaluation.beneficiaire&.nom, admin_evaluation_evapro_path(evaluation))
   end
   column t(".colonne_date"), sortable: :created_at do |evaluation|


### PR DESCRIPTION
J'ai regroupé, prénom, nom et email dans la première colonne.

J'ai au passage trié les structures par date de création par défaut

<img width="915" height="314" alt="Capture d’écran 2026-09-02 à 17 02 35" src="https://github.com/user-attachments/assets/906f8f9e-3b06-4c97-af25-fd2d2cd75799" />
