### PR TITLE
✨ Divise le travail de redimentionnement des images en un job par question

### DIFF
--- a/app/jobs/redimensionne_illustration_job.rb
+++ b/app/jobs/redimensionne_illustration_job.rb
@@ -1,0 +1,7 @@
+class RedimensionneIllustrationJob < ApplicationJob
+  queue_as :default
+
+  def perform(question)
+    question.illustration.variant(:defaut).processed
+  end
+end

--- a/app/jobs/redimensionne_illustrations_job.rb
+++ b/app/jobs/redimensionne_illustrations_job.rb
@@ -5,7 +5,7 @@ class RedimensionneIllustrationsJob < ApplicationJob
     Question.find_each do |question|
       next unless question.illustration.attached?
 
-      question.illustration.variant(:defaut).processed
+      RedimensionneIllustrationJob.perform_later(question)
     end
   end
 end


### PR DESCRIPTION
Faire tourner toutes les images dans un seul job dépasse la capacité mémoire du worker.