### PR TITLE
🔇 Ignore aussi le chemin racine /wp dans les erreurs de route Rollbar

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -40,10 +40,10 @@ Rollbar.configure do |config|
   # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
 
   # Ignore les 404 générées par des bots qui scannent des chemins WordPress/PHP
-  # ou ASP.NET/IIS inexistants sur notre appli (ex. /wp-includes/php-compat,
+  # ou ASP.NET/IIS inexistants sur notre appli (ex. /wp, /wp-includes/php-compat,
   # /xmlrpc.php, /Default.aspx, /owa/). Les autres RoutingError (vraies
   # erreurs de route dans l'appli) continuent d'être remontées normalement.
-  bot_scan_path_pattern = %r{wp-(admin|includes|content|login|json)|xmlrpc\.php|\.php$|/wordpress|\.asp[x]?$|/owa|/ecp|/autodiscover}i
+  bot_scan_path_pattern = %r{\A[^"]*"/wp["/]|wp-(admin|includes|content|login|json)|xmlrpc\.php|\.php$|/wordpress|\.asp[x]?$|/owa|/ecp|/autodiscover}i
   config.exception_level_filters.merge!(
     'ActionController::RoutingError' => lambda do |e|
       'ignore' if e.message =~ bot_scan_path_pattern


### PR DESCRIPTION
Complète le filtre existant pour ignorer les scans de bots ciblant directement /wp, en plus des variantes /wp-* déjà couvertes.